### PR TITLE
Refactor: Decouple storage trait and impl

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod json_utils;
 mod methods;
 mod move_execution;
 mod state_actor;
+mod storage;
 mod types;
 
 #[cfg(test)]
@@ -55,7 +56,7 @@ static JWTSECRET: Lazy<Vec<u8>> = Lazy::new(|| {
 async fn main() {
     // TODO: think about channel size bound
     let (state_channel, rx) = mpsc::channel(1_000);
-    let state = state_actor::StateActor::new(rx);
+    let state = state_actor::StateActor::new_in_memory(rx);
 
     let http_state_channel = state_channel.clone();
     let http_server_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 8545));

--- a/src/methods/forkchoice_updated.rs
+++ b/src/methods/forkchoice_updated.rs
@@ -234,7 +234,7 @@ pub fn example_request() -> serde_json::Value {
 #[tokio::test]
 async fn test_execute_v3() {
     let (state_channel, rx) = tokio::sync::mpsc::channel(10);
-    let state = crate::state_actor::StateActor::new(rx);
+    let state = crate::state_actor::StateActor::new_in_memory(rx);
     let state_handle = state.spawn();
 
     // Set payload id

--- a/src/methods/get_payload.rs
+++ b/src/methods/get_payload.rs
@@ -89,7 +89,7 @@ fn test_parse_params_v3() {
 #[tokio::test]
 async fn test_execute_v3() {
     let (state_channel, rx) = tokio::sync::mpsc::channel(10);
-    let state = crate::state_actor::StateActor::new(rx);
+    let state = crate::state_actor::StateActor::new_in_memory(rx);
     let state_handle = state.spawn();
 
     // Set payload id

--- a/src/methods/new_payload.rs
+++ b/src/methods/new_payload.rs
@@ -266,7 +266,7 @@ fn test_parse_params_v3() {
 #[tokio::test]
 async fn test_execute_v3() {
     let (state_channel, rx) = tokio::sync::mpsc::channel(10);
-    let state = crate::state_actor::StateActor::new(rx);
+    let state = crate::state_actor::StateActor::new_in_memory(rx);
     let state_handle = state.spawn();
 
     // Set payload id

--- a/src/methods/send_raw_transaction.rs
+++ b/src/methods/send_raw_transaction.rs
@@ -59,7 +59,7 @@ async fn inner_execute(
 #[tokio::test]
 async fn test_execute() {
     let (state_channel, rx) = tokio::sync::mpsc::channel(10);
-    let state = crate::state_actor::StateActor::new(rx);
+    let state = crate::state_actor::StateActor::new_in_memory(rx);
     let state_handle = state.spawn();
 
     let request: serde_json::Value = serde_json::from_str(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,28 @@
+use {
+    move_binary_format::errors::PartialVMError,
+    move_core_types::{effects::ChangeSet, resolver::MoveResolver},
+    move_vm_test_utils::InMemoryStorage,
+    std::fmt::Debug,
+};
+
+/// A persistent storage trait.
+///
+/// This trait inherits [`MoveResolver`] that can resolve both resources and modules and extends it
+/// with the [`apply`] operation.
+///
+/// [`apply`]: Self::apply
+pub trait Storage: MoveResolver<Self::Err> {
+    /// The associated error that can occur on storage operations.
+    type Err: Debug;
+
+    /// Applies the `changes` to the underlying storage state.
+    fn apply(&mut self, changes: ChangeSet) -> Result<(), Self::Err>;
+}
+
+impl Storage for InMemoryStorage {
+    type Err = PartialVMError;
+
+    fn apply(&mut self, changes: ChangeSet) -> Result<(), PartialVMError> {
+        InMemoryStorage::apply(self, changes)
+    }
+}


### PR DESCRIPTION
Closes  #11

## About
This PR decouples storage interface and implementation as per linked issue.

## Motivation
`StateActor` is dependent on `InMemoryStorage`. However, this only makes sense for testing. Furthermore, there is no reason for `StateActor` to be dependent on any specific implementation of storage as it only need to pass a storage interface for the transaction execution.

## Goals
The goal is to create an interface for storage that satisfies our purposes and make it compatible with the `InMemoryStorage`, keeping everything working as before.

## Solution
* Create a module `storage` in `op-move` crate.
* Declare `Storage` trait inheriting `MoveResolver` and any necessary methods.
* Implement `Storage` for `InMemoryStorage`.

## Additional context
The `storage` module could be a crate. Splitting the project into a workspace of crates would promote better isolation of bounded contexts, better recompilation and dependency distribution.

Putting this idea aside for now as this module is tiny right now.