### PR TITLE
Feat: Implement custom error types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5246,6 +5246,8 @@ dependencies = [
  "openssl",
  "serde",
  "serde_json",
+ "test-case",
+ "thiserror",
  "tokio",
  "warp",
  "warp-reverse-proxy",
@@ -7243,6 +7245,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+ "test-case-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ once_cell = "1.19"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
+thiserror = "1"
 warp = "0.3"
 warp-reverse-proxy = "1"
 
@@ -44,3 +45,4 @@ alloy = { version = "0.1", features = ["full", "signer-keystore"] }
 dotenvy = "0.15"
 openssl = "0.10"
 move-compiler = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.14.0" }
+test-case = "3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,135 @@
+//! # The error module
+//!
+//! This module is responsible for providing structured error types that are easily processable.
+//! They implement [`Display`] and [`Debug`] traits so that they are representable and printable to
+//! log files.
+//!
+//! It is important that any logic processing the error only uses the structured data. No logic
+//! should be dependent on the particular error message that are reachable by the [`Debug`] or
+//! [`Display`] trait, they serve only an informative purpose and a human-readable representation.   
+
+use {
+    alloy_consensus::TxType,
+    move_binary_format::errors::{PartialVMError, VMError},
+    thiserror::Error,
+};
+
+/// The result type with its error type set to [`Error`].
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Error for operations in [`op-move`].
+///
+/// # Variants
+/// * [`UserError`] is an error caused by an invalid user input.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("{0}")]
+    User(UserError),
+}
+
+impl<T> From<T> for Error
+where
+    UserError: From<T>,
+{
+    fn from(value: T) -> Self {
+        Error::User(UserError::from(value))
+    }
+}
+
+/// The error caused by invalid user input.
+#[derive(Debug, Error)]
+pub enum UserError {
+    #[error("{0}")]
+    Vm(#[from] VMError),
+    #[error("{0}")]
+    PartialVm(#[from] PartialVMError),
+    #[error("{0}")]
+    InvalidSignature(#[from] alloy_primitives::SignatureError),
+    #[error("{0}")]
+    InvalidTransaction(InvalidTransactionCause),
+}
+
+impl<T> From<T> for UserError
+where
+    InvalidTransactionCause: From<T>,
+{
+    fn from(value: T) -> Self {
+        UserError::InvalidTransaction(InvalidTransactionCause::from(value))
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum InvalidTransactionCause {
+    #[error("tx.to must match payload module address")]
+    InvalidDestination,
+    #[error("Signer does not match transaction signature")]
+    InvalidSigner,
+    #[error("{0}")]
+    InvalidPayload(#[from] bcs::Error),
+    #[error("Incorrect number of arguments")]
+    MismatchedArgumentCount,
+    #[error("Failed to deserialize entry function argument")]
+    FailedArgumentDeserialization,
+    #[error("Invalid nested references")]
+    UnsupportedNestedReference,
+    #[error("Blob transactions are not supported")]
+    UnsupportedType,
+    #[error("Unknown transaction type: {0}")]
+    UnknownType(TxType),
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*, move_binary_format::errors::Location, move_core_types::vm_status::StatusCode,
+        test_case::test_case,
+    };
+
+    #[test_case(
+        InvalidTransactionCause::InvalidDestination,
+        "tx.to must match payload module address"
+    )]
+    #[test_case(
+        InvalidTransactionCause::InvalidSigner,
+        "Signer does not match transaction signature"
+    )]
+    #[test_case(
+        InvalidTransactionCause::UnsupportedNestedReference,
+        "Invalid nested references"
+    )]
+    #[test_case(
+        InvalidTransactionCause::MismatchedArgumentCount,
+        "Incorrect number of arguments"
+    )]
+    #[test_case(
+        InvalidTransactionCause::FailedArgumentDeserialization,
+        "Failed to deserialize entry function argument"
+    )]
+    #[test_case(
+        InvalidTransactionCause::UnsupportedType,
+        "Blob transactions are not supported"
+    )]
+    #[test_case(
+        InvalidTransactionCause::UnknownType(TxType::Legacy),
+        "Unknown transaction type: Legacy"
+    )]
+    #[test_case(
+        alloy_primitives::SignatureError::InvalidParity(0),
+        "invalid parity: 0"
+    )]
+    #[test_case(bcs::Error::Eof, "unexpected end of input")]
+    #[test_case(
+        PartialVMError::new(StatusCode::ABORTED),
+        "PartialVMError with status ABORTED"
+    )]
+    #[test_case(
+        PartialVMError::new(StatusCode::ABORTED).finish(Location::Undefined),
+        "VMError with status ABORTED at location UNDEFINED"
+    )]
+    fn test_error_converts_and_displays(actual: impl Into<Error>, expected: impl Into<String>) {
+        let actual = actual.into().to_string();
+        let expected = expected.into();
+
+        assert_eq!(actual, expected);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+pub use error::*;
+
 use self::types::{
     jsonrpc::{JsonRpcError, JsonRpcResponse},
     method_name::MethodName,
@@ -20,6 +22,7 @@ use warp::{Filter, Rejection};
 use warp_reverse_proxy::{extract_request_data_filter, proxy_to_and_forward_response, Headers};
 use warp_reverse_proxy::{Method, QueryParameters};
 
+mod error;
 mod genesis;
 mod json_utils;
 mod methods;
@@ -119,7 +122,9 @@ async fn mirror(
     headers: Headers,
     body: Bytes,
     port: &str,
-) -> Result<warp::reply::Response, Rejection> {
+) -> std::result::Result<warp::reply::Response, Rejection> {
+    use std::result::Result;
+
     let is_zipped = headers
         .get("accept-encoding")
         .map(|x| x.to_str().unwrap().contains("gzip"))
@@ -215,7 +220,7 @@ async fn proxy(
     headers: Headers,
     body: Bytes,
     port: &str,
-) -> Result<Response<Body>, Rejection> {
+) -> std::result::Result<Response<Body>, Rejection> {
     proxy_to_and_forward_response(
         format!("http://0.0.0.0:{}", port),
         "".to_string(),
@@ -256,7 +261,7 @@ async fn handle_request(
 async fn inner_handle_request(
     request: serde_json::Value,
     state_channel: mpsc::Sender<StateMessage>,
-) -> Result<serde_json::Value, JsonRpcError> {
+) -> std::result::Result<serde_json::Value, JsonRpcError> {
     let method: MethodName = match json_utils::get_field(&request, "method") {
         serde_json::Value::String(m) => m.parse()?,
         _ => {


### PR DESCRIPTION
### Description
Closes #14 

### Changes
- Replaces anyhow errors with custom error type

### Testing
```
cargo test
```

### Notes

I'm expecting more of a feedback since this is more of a open-ended issue.

For example: correctly parsed and verified signature that does not equal expected signature - is that a signature error or invalid argument error? In this case I chose argument error, because signature error is only for the case of parsing or verification failure.