### PR TITLE
Feat(transactions): Execution outcome type

### DIFF
--- a/src/state_actor.rs
+++ b/src/state_actor.rs
@@ -204,8 +204,9 @@ impl<S: Storage<Err = PartialVMError>> StateActor<S> {
     fn execute_transactions(&mut self, transactions: &[ExtendedTxEnvelope]) -> ExecutionOutcome {
         // TODO: parallel transaction processing?
         for tx in transactions {
-            if let Err(e) = execute_transaction(tx, &self.storage).and_then(|changes| {
-                self.storage.apply(changes)?;
+            if let Err(e) = execute_transaction(tx, &self.storage).and_then(|outcome| {
+                // TODO: record success or failure from outcome.vm_outcome
+                self.storage.apply(outcome.changes)?;
                 Ok(())
             }) {
                 // TODO: proper error handling

--- a/src/types/transactions.rs
+++ b/src/types/transactions.rs
@@ -2,6 +2,7 @@ use {
     alloy_consensus::TxEnvelope,
     alloy_primitives::{Address, Bytes, B256, U256, U64},
     alloy_rlp::{Buf, Decodable, Encodable, RlpDecodable, RlpEncodable},
+    move_core_types::effects::ChangeSet,
     serde::{Deserialize, Serialize},
 };
 
@@ -68,6 +69,29 @@ impl Decodable for ExtendedTxEnvelope {
                 let tx = TxEnvelope::decode(buf)?;
                 Ok(Self::Canonical(tx))
             }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TransactionExecutionOutcome {
+    pub vm_outcome: Result<(), crate::Error>,
+    pub changes: ChangeSet,
+    // TODO: gas used
+}
+
+impl TransactionExecutionOutcome {
+    pub fn empty_success() -> Self {
+        Self {
+            vm_outcome: Ok(()),
+            changes: ChangeSet::new(),
+        }
+    }
+
+    pub fn new(vm_outcome: Result<(), crate::Error>, changes: ChangeSet) -> Self {
+        Self {
+            vm_outcome,
+            changes,
         }
     }
 }


### PR DESCRIPTION
### Description
Building off of #23 it is now easy to introduce a tx execution outcome type. Note that the execution errors are captured in this type while basic validation errors are an early return from the `execution_transaction` function.

This work is an important pre-requisite for #22 because even if the VM execution fails, it is still important that we increment the nonce to prevent replaying the transaction. In the future we will also want to still change gas even when the VM execution fails. These state updates will still be in the `changes` of the transaction even when the `vm_outcome` is an error.

### Changes

- Introduce `TransactionExecutionOutcome` type

### Testing
Existing tests