### PR TITLE
refactor: Isolate signer checking into a submodule

### DIFF
--- a/moved/src/move_execution.rs
+++ b/moved/src/move_execution.rs
@@ -1,5 +1,8 @@
+mod signers;
+
 use {
     crate::{
+        move_execution::signers::check_signer,
         types::transactions::{ExtendedTxEnvelope, TransactionExecutionOutcome},
         InvalidTransactionCause,
     },
@@ -199,32 +202,6 @@ fn strip_reference(t: &Type) -> crate::Result<&Type> {
     }
 }
 
-// Check that any instances of `MoveValue::Signer` contained within the given `arg`
-// are the `expected_signer`; return an error if not.
-fn check_signer(arg: &MoveValue, expected_signer: &AccountAddress) -> crate::Result<()> {
-    let mut stack = Vec::with_capacity(10);
-    stack.push(arg);
-    while let Some(arg) = stack.pop() {
-        match arg {
-            MoveValue::Signer(given_signer) if given_signer != expected_signer => {
-                Err(InvalidTransactionCause::InvalidSigner)?
-            }
-            MoveValue::Vector(values) => {
-                for v in values {
-                    stack.push(v);
-                }
-            }
-            MoveValue::Struct(s) => {
-                for v in s.fields() {
-                    stack.push(v);
-                }
-            }
-            _ => (),
-        }
-    }
-    Ok(())
-}
-
 fn deploy_module(
     code: Module,
     address: AccountAddress,
@@ -246,10 +223,14 @@ fn evm_address_to_move_address(address: &alloy_primitives::Address) -> AccountAd
 mod tests {
     use {
         super::*,
-        crate::{genesis::init_storage, tests::signer::Signer, types::transactions::DepositedTx},
+        crate::{
+            genesis::init_storage,
+            tests::{signer::Signer, EVM_ADDRESS, PRIVATE_KEY},
+            types::transactions::DepositedTx,
+        },
         alloy::network::TxSignerSync,
         alloy_consensus::{transaction::TxEip1559, SignableTransaction},
-        alloy_primitives::{address, Address, FixedBytes, U256, U64},
+        alloy_primitives::{FixedBytes, U256, U64},
         anyhow::Context,
         move_binary_format::{
             file_format::{
@@ -272,132 +253,6 @@ mod tests {
         move_vm_test_utils::InMemoryStorage,
         std::collections::BTreeSet,
     };
-
-    const EVM_ADDRESS: Address = address!("8fd379246834eac74b8419ffda202cf8051f7a03");
-
-    /// The address corresponding to this private key is 0x8fd379246834eac74B8419FfdA202CF8051F7A03
-    const PRIVATE_KEY: [u8; 32] = [0xaa; 32];
-
-    #[test]
-    fn test_check_signer() {
-        let correct_signer = evm_address_to_move_address(&EVM_ADDRESS);
-        let incorrect_signer =
-            evm_address_to_move_address(&address!("c104f4840573bed437190daf5d2898c2bdf928ac"));
-        type CheckSignerOutcome = Result<(), ()>;
-
-        let test_cases: &[(MoveValue, CheckSignerOutcome)] = &[
-            (MoveValue::Address(incorrect_signer), Ok(())),
-            (MoveValue::Address(correct_signer), Ok(())),
-            (MoveValue::Signer(incorrect_signer), Err(())),
-            (MoveValue::Signer(correct_signer), Ok(())),
-            (MoveValue::Vector(vec![]), Ok(())),
-            (
-                MoveValue::Vector(vec![
-                    MoveValue::Signer(correct_signer),
-                    MoveValue::Signer(correct_signer),
-                ]),
-                Ok(()),
-            ),
-            (
-                MoveValue::Vector(vec![
-                    MoveValue::Signer(correct_signer),
-                    MoveValue::Signer(correct_signer),
-                    MoveValue::Signer(correct_signer),
-                ]),
-                Ok(()),
-            ),
-            (
-                MoveValue::Vector(vec![
-                    MoveValue::Signer(incorrect_signer),
-                    MoveValue::Signer(correct_signer),
-                ]),
-                Err(()),
-            ),
-            (
-                MoveValue::Vector(vec![
-                    MoveValue::Signer(correct_signer),
-                    MoveValue::Signer(incorrect_signer),
-                ]),
-                Err(()),
-            ),
-            (
-                MoveValue::Vector(vec![
-                    MoveValue::Signer(correct_signer),
-                    MoveValue::Signer(correct_signer),
-                    MoveValue::Signer(incorrect_signer),
-                ]),
-                Err(()),
-            ),
-            (
-                MoveValue::Vector(vec![
-                    MoveValue::U32(0),
-                    MoveValue::U32(1),
-                    MoveValue::U32(2),
-                    MoveValue::U32(3),
-                ]),
-                Ok(()),
-            ),
-            (MoveValue::Struct(MoveStruct::new(vec![])), Ok(())),
-            (
-                MoveValue::Struct(MoveStruct::new(vec![
-                    MoveValue::U8(0),
-                    MoveValue::U16(1),
-                    MoveValue::U32(2),
-                    MoveValue::U64(3),
-                    MoveValue::U128(4),
-                    MoveValue::U256(5u64.into()),
-                ])),
-                Ok(()),
-            ),
-            (
-                MoveValue::Struct(MoveStruct::new(vec![
-                    MoveValue::Bool(true),
-                    MoveValue::Bool(false),
-                    MoveValue::Signer(correct_signer),
-                ])),
-                Ok(()),
-            ),
-            (
-                MoveValue::Struct(MoveStruct::new(vec![
-                    MoveValue::Signer(correct_signer),
-                    MoveValue::Vector(vec![MoveValue::Struct(MoveStruct::new(vec![
-                        MoveValue::Vector(vec![
-                            MoveValue::Struct(MoveStruct::new(vec![
-                                MoveValue::Signer(correct_signer),
-                                MoveValue::Address(correct_signer),
-                            ])),
-                            MoveValue::Struct(MoveStruct::new(vec![
-                                MoveValue::Signer(correct_signer),
-                                MoveValue::Address(incorrect_signer),
-                            ])),
-                        ]),
-                    ]))]),
-                ])),
-                Ok(()),
-            ),
-            (
-                MoveValue::Struct(MoveStruct::new(vec![
-                    MoveValue::Signer(correct_signer),
-                    MoveValue::Vector(vec![MoveValue::Struct(MoveStruct::new(vec![
-                        MoveValue::Vector(vec![
-                            MoveValue::Signer(correct_signer),
-                            MoveValue::Signer(incorrect_signer),
-                        ]),
-                    ]))]),
-                ])),
-                Err(()),
-            ),
-        ];
-
-        for (test_case, expected_outcome) in test_cases {
-            let actual_outcome = check_signer(test_case, &correct_signer).map_err(|_| ());
-            assert_eq!(
-                &actual_outcome,
-                expected_outcome,
-                "check_signer test case {test_case:?} failed. Expected={expected_outcome:?} Actual={actual_outcome:?}"
-            );
-        }
-    }
 
     #[test]
     fn test_execute_counter_contract() {

--- a/moved/src/move_execution/signers.rs
+++ b/moved/src/move_execution/signers.rs
@@ -1,0 +1,159 @@
+use {
+    crate::InvalidTransactionCause, move_core_types::account_address::AccountAddress,
+    move_core_types::value::MoveValue,
+};
+
+/// Check that any instances of `MoveValue::Signer` contained within the given `arg`
+/// are the `expected_signer`; return an error if not.
+pub(super) fn check_signer(arg: &MoveValue, expected_signer: &AccountAddress) -> crate::Result<()> {
+    let mut stack = Vec::with_capacity(10);
+    stack.push(arg);
+    while let Some(arg) = stack.pop() {
+        match arg {
+            MoveValue::Signer(given_signer) if given_signer != expected_signer => {
+                Err(InvalidTransactionCause::InvalidSigner)?
+            }
+            MoveValue::Vector(values) => {
+                for v in values {
+                    stack.push(v);
+                }
+            }
+            MoveValue::Struct(s) => {
+                for v in s.fields() {
+                    stack.push(v);
+                }
+            }
+            _ => (),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*, crate::move_execution::evm_address_to_move_address, crate::tests::EVM_ADDRESS,
+        alloy_primitives::address, move_core_types::value::MoveStruct,
+    };
+
+    #[test]
+    fn test_check_signer() {
+        let correct_signer = evm_address_to_move_address(&EVM_ADDRESS);
+        let incorrect_signer =
+            evm_address_to_move_address(&address!("c104f4840573bed437190daf5d2898c2bdf928ac"));
+        type CheckSignerOutcome = Result<(), ()>;
+
+        let test_cases: &[(MoveValue, CheckSignerOutcome)] = &[
+            (MoveValue::Address(incorrect_signer), Ok(())),
+            (MoveValue::Address(correct_signer), Ok(())),
+            (MoveValue::Signer(incorrect_signer), Err(())),
+            (MoveValue::Signer(correct_signer), Ok(())),
+            (MoveValue::Vector(vec![]), Ok(())),
+            (
+                MoveValue::Vector(vec![
+                    MoveValue::Signer(correct_signer),
+                    MoveValue::Signer(correct_signer),
+                ]),
+                Ok(()),
+            ),
+            (
+                MoveValue::Vector(vec![
+                    MoveValue::Signer(correct_signer),
+                    MoveValue::Signer(correct_signer),
+                    MoveValue::Signer(correct_signer),
+                ]),
+                Ok(()),
+            ),
+            (
+                MoveValue::Vector(vec![
+                    MoveValue::Signer(incorrect_signer),
+                    MoveValue::Signer(correct_signer),
+                ]),
+                Err(()),
+            ),
+            (
+                MoveValue::Vector(vec![
+                    MoveValue::Signer(correct_signer),
+                    MoveValue::Signer(incorrect_signer),
+                ]),
+                Err(()),
+            ),
+            (
+                MoveValue::Vector(vec![
+                    MoveValue::Signer(correct_signer),
+                    MoveValue::Signer(correct_signer),
+                    MoveValue::Signer(incorrect_signer),
+                ]),
+                Err(()),
+            ),
+            (
+                MoveValue::Vector(vec![
+                    MoveValue::U32(0),
+                    MoveValue::U32(1),
+                    MoveValue::U32(2),
+                    MoveValue::U32(3),
+                ]),
+                Ok(()),
+            ),
+            (MoveValue::Struct(MoveStruct::new(vec![])), Ok(())),
+            (
+                MoveValue::Struct(MoveStruct::new(vec![
+                    MoveValue::U8(0),
+                    MoveValue::U16(1),
+                    MoveValue::U32(2),
+                    MoveValue::U64(3),
+                    MoveValue::U128(4),
+                    MoveValue::U256(5u64.into()),
+                ])),
+                Ok(()),
+            ),
+            (
+                MoveValue::Struct(MoveStruct::new(vec![
+                    MoveValue::Bool(true),
+                    MoveValue::Bool(false),
+                    MoveValue::Signer(correct_signer),
+                ])),
+                Ok(()),
+            ),
+            (
+                MoveValue::Struct(MoveStruct::new(vec![
+                    MoveValue::Signer(correct_signer),
+                    MoveValue::Vector(vec![MoveValue::Struct(MoveStruct::new(vec![
+                        MoveValue::Vector(vec![
+                            MoveValue::Struct(MoveStruct::new(vec![
+                                MoveValue::Signer(correct_signer),
+                                MoveValue::Address(correct_signer),
+                            ])),
+                            MoveValue::Struct(MoveStruct::new(vec![
+                                MoveValue::Signer(correct_signer),
+                                MoveValue::Address(incorrect_signer),
+                            ])),
+                        ]),
+                    ]))]),
+                ])),
+                Ok(()),
+            ),
+            (
+                MoveValue::Struct(MoveStruct::new(vec![
+                    MoveValue::Signer(correct_signer),
+                    MoveValue::Vector(vec![MoveValue::Struct(MoveStruct::new(vec![
+                        MoveValue::Vector(vec![
+                            MoveValue::Signer(correct_signer),
+                            MoveValue::Signer(incorrect_signer),
+                        ]),
+                    ]))]),
+                ])),
+                Err(()),
+            ),
+        ];
+
+        for (test_case, expected_outcome) in test_cases {
+            let actual_outcome = check_signer(test_case, &correct_signer).map_err(|_| ());
+            assert_eq!(
+                &actual_outcome,
+                expected_outcome,
+                "check_signer test case {test_case:?} failed. Expected={expected_outcome:?} Actual={actual_outcome:?}"
+            );
+        }
+    }
+}

--- a/moved/src/tests/mod.rs
+++ b/moved/src/tests/mod.rs
@@ -2,12 +2,18 @@ mod integration;
 pub mod signer;
 
 use crate::{validate_jwt, Claims};
+use alloy_primitives::{address, Address};
 use aptos_types::transaction::{EntryFunction, TransactionPayload};
 use jsonwebtoken::{EncodingKey, Header};
 use move_core_types::account_address::AccountAddress;
 use move_core_types::ident_str;
 use move_core_types::language_storage::{ModuleId, StructTag, TypeTag};
 use std::time::SystemTime;
+
+pub(crate) const EVM_ADDRESS: Address = address!("8fd379246834eac74b8419ffda202cf8051f7a03");
+
+/// The address corresponding to this private key is 0x8fd379246834eac74B8419FfdA202CF8051F7A03
+pub(crate) const PRIVATE_KEY: [u8; 32] = [0xaa; 32];
 
 #[tokio::test]
 async fn test_authorized_request() -> anyhow::Result<()> {


### PR DESCRIPTION
### Description
The `move_execution` module is getting large and contains multiple responsibilities. This PR addresses that.

### Changes
<!-- Key changes -->
- Move signer checking into a submodule
- Update usages

### Testing
```
cargo test
```
