### PR TITLE
ci: Explicitly set `nightly` toolchain for `format` action to enable unstable options

### DIFF
--- a/.github/workflows/format_check.yaml
+++ b/.github/workflows/format_check.yaml
@@ -20,4 +20,4 @@ jobs:
           default: true
           toolchain: nightly
       - name: format
-        run: cargo fmt -- --check
+        run: cargo +nightly fmt -- --check


### PR DESCRIPTION
Even when the default toolchain is set to nightly, the unstable options (which we use for imports) are not used.

That's why the cargo fmt call needs to have the toolchain set explicitly.