### PR TITLE
feat: Implement conversion to ethereum address

### DIFF
--- a/moved/src/move_execution/deposited.rs
+++ b/moved/src/move_execution/deposited.rs
@@ -4,6 +4,7 @@ use {
         move_execution::{
             create_move_vm, create_vm_session, eth_token,
             gas::{new_gas_meter, total_gas_used},
+            LogsBloom,
         },
         primitives::ToMoveAddress,
         types::transactions::{DepositedTx, TransactionExecutionOutcome},
@@ -46,8 +47,14 @@ pub(super) fn execute_deposited_transaction(
         "tokens were minted"
     );
 
-    let changes = session.finish()?;
+    let (changes, mut extensions) = session.finish_with_extensions()?;
     let gas_used = total_gas_used(&gas_meter, genesis_config);
+    let logs_bloom = extensions.logs_bloom();
 
-    Ok(TransactionExecutionOutcome::new(Ok(()), changes, gas_used))
+    Ok(TransactionExecutionOutcome::new(
+        Ok(()),
+        changes,
+        gas_used,
+        logs_bloom,
+    ))
 }

--- a/moved/src/move_execution/tests.rs
+++ b/moved/src/move_execution/tests.rs
@@ -33,7 +33,7 @@ use {
     },
     move_vm_runtime::module_traversal::{TraversalContext, TraversalStorage},
     move_vm_types::gas::UnmeteredGasMeter,
-    std::{collections::BTreeSet, u64},
+    std::collections::BTreeSet,
 };
 
 #[test]

--- a/moved/src/primitives.rs
+++ b/moved/src/primitives.rs
@@ -3,7 +3,6 @@ use {
     move_core_types::account_address::AccountAddress,
 };
 
-#[allow(dead_code)] // TODO: use this
 pub(crate) trait ToEthAddress {
     fn to_eth_address(&self) -> alloy_primitives::Address;
 }
@@ -41,7 +40,10 @@ impl ToH256 for HashValue {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, alloy::hex, alloy_primitives::address};
+    use {
+        super::*,
+        alloy_primitives::{address, hex},
+    };
 
     #[test]
     fn conversion_from_hash_value_to_h256_and_back_produces_identical_value() {

--- a/moved/src/storage.rs
+++ b/moved/src/storage.rs
@@ -25,7 +25,7 @@ use {
 /// * [`state_root`]: Returns current state root.
 /// * [`apply`]: Applies changes produced by a transaction on the state trie.
 /// * [`apply_with_tables`]: Same as [`apply`] but includes changes to tables from
-/// [`move_table_extension`].
+///   [`move_table_extension`].
 ///
 /// [`resolver`]: Self::resolver
 /// [`state_root`]: Self::state_root

--- a/moved/src/types/transactions.rs
+++ b/moved/src/types/transactions.rs
@@ -1,10 +1,11 @@
 use {
-    crate::{Error, InvalidTransactionCause, UserError},
+    crate::{primitives::ToEthAddress, Error, InvalidTransactionCause, UserError},
     alloy_consensus::{Signed, Transaction, TxEip1559, TxEip2930, TxEnvelope, TxLegacy},
     alloy_eips::eip2930::AccessList,
-    alloy_primitives::{Address, Bytes, TxKind, B256, U256, U64},
+    alloy_primitives::{Address, Bloom, Bytes, Keccak256, Log, LogData, TxKind, B256, U256, U64},
     alloy_rlp::{Buf, Decodable, Encodable, RlpDecodable, RlpEncodable},
-    move_core_types::effects::ChangeSet,
+    aptos_types::contract_event::ContractEvent,
+    move_core_types::{effects::ChangeSet, language_storage::TypeTag},
     serde::{Deserialize, Serialize},
 };
 
@@ -80,14 +81,22 @@ pub struct TransactionExecutionOutcome {
     pub vm_outcome: Result<(), UserError>,
     pub changes: ChangeSet,
     pub gas_used: u64,
+    /// The bloom filter created from all emitted Move events converted to Ethereum logs.
+    pub logs_bloom: Bloom,
 }
 
 impl TransactionExecutionOutcome {
-    pub fn new(vm_outcome: Result<(), UserError>, changes: ChangeSet, gas_used: u64) -> Self {
+    pub fn new(
+        vm_outcome: Result<(), UserError>,
+        changes: ChangeSet,
+        gas_used: u64,
+        logs_bloom: Bloom,
+    ) -> Self {
         Self {
             vm_outcome,
             changes,
             gas_used,
+            logs_bloom,
         }
     }
 }
@@ -196,22 +205,92 @@ impl TryFrom<Signed<TxLegacy>> for NormalizedEthTransaction {
     }
 }
 
-#[test]
-fn test_extended_tx_envelope_rlp() {
-    use std::str::FromStr;
+pub(crate) trait ToLog {
+    fn to_log(&self) -> Log<LogData>;
+}
 
-    // Deposited Transaction
-    rlp_roundtrip(&Bytes::from_str("0x7ef8f8a0672dfee56b1754d9fb99b11dae8eab6dfb7246470f6f7354d7acab837eab12b294deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e2000000558000c5fc50000000000000004000000006672f4bd000000000000020e00000000000000000000000000000000000000000000000000000000000000070000000000000000000000000000000000000000000000000000000000000001bc6d63f57e9fd865ae9a204a4db7fe1cff654377442541b06d020ddab88c2eeb000000000000000000000000e25583099ba105d9ec0a67f5ae86d90e50036425").unwrap());
+impl ToLog for ContractEvent {
+    fn to_log(&self) -> Log<LogData> {
+        let (type_tag, event_data) = match self {
+            ContractEvent::V1(event) => (event.type_tag(), event.event_data()),
+            ContractEvent::V2(event) => (event.type_tag(), event.event_data()),
+        };
 
-    // Canonical Transaction
-    rlp_roundtrip(&Bytes::from_str("0x02f86f82a45580808346a8928252089465d08a056c17ae13370565b04cf77d2afa1cb9fa8806f05b59d3b2000080c080a0dd50efde9a4d2f01f5248e1a983165c8cfa5f193b07b4b094f4078ad4717c1e4a017db1be1e8751b09e033bcffca982d0fe4919ff6b8594654e06647dee9292750").unwrap())
+        let address = match type_tag {
+            TypeTag::Struct(struct_tag) => struct_tag.address,
+            _ => unreachable!("This would break move event extension invariant"),
+        };
+
+        let address = address.to_eth_address();
+
+        let mut hasher = Keccak256::new();
+        let type_string = type_tag.to_canonical_string();
+        hasher.update(type_string.as_bytes());
+        let type_hash = hasher.finalize();
+
+        let topics = vec![type_hash];
+
+        let data = event_data.to_vec();
+        let data = data.into();
+
+        Log::new_unchecked(address, topics, data)
+    }
 }
 
 #[cfg(test)]
-fn rlp_roundtrip(encoded: &[u8]) {
-    let mut re_encoded = Vec::with_capacity(encoded.len());
-    let mut slice = encoded;
-    let tx = ExtendedTxEnvelope::decode(&mut slice).unwrap();
-    tx.encode(&mut re_encoded);
-    assert_eq!(re_encoded, encoded);
+mod tests {
+    use {
+        super::*,
+        alloy_primitives::{address, hex, keccak256},
+        alloy_rlp::{Decodable, Encodable},
+        aptos_types::contract_event::{ContractEvent, ContractEventV2},
+        move_core_types::{
+            identifier::Identifier,
+            language_storage::{StructTag, TypeTag},
+        },
+    };
+
+    #[test]
+    fn test_move_event_converts_to_eth_log_successfully() {
+        let data = vec![0u8, 1, 2, 3];
+        let type_tag = TypeTag::Struct(Box::new(StructTag {
+            address: hex!("0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff")
+                .into(),
+            module: Identifier::new("moved").unwrap(),
+            name: Identifier::new("test").unwrap(),
+            type_args: vec![],
+        }));
+        let event = ContractEvent::V2(ContractEventV2::new(type_tag, data));
+
+        let actual_log = event.to_log();
+        let expected_log = Log::new_unchecked(
+            address!("6666777788889999aaaabbbbccccddddeeeeffff"),
+            vec![keccak256(
+                "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff::moved::test",
+            )],
+            Bytes::from([0u8, 1, 2, 3]),
+        );
+
+        assert_eq!(actual_log, expected_log);
+    }
+
+    #[test]
+    fn test_extended_tx_envelope_rlp() {
+        use std::str::FromStr;
+
+        // Deposited Transaction
+        rlp_roundtrip(&Bytes::from_str("0x7ef8f8a0672dfee56b1754d9fb99b11dae8eab6dfb7246470f6f7354d7acab837eab12b294deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e2000000558000c5fc50000000000000004000000006672f4bd000000000000020e00000000000000000000000000000000000000000000000000000000000000070000000000000000000000000000000000000000000000000000000000000001bc6d63f57e9fd865ae9a204a4db7fe1cff654377442541b06d020ddab88c2eeb000000000000000000000000e25583099ba105d9ec0a67f5ae86d90e50036425").unwrap());
+
+        // Canonical Transaction
+        rlp_roundtrip(&Bytes::from_str("0x02f86f82a45580808346a8928252089465d08a056c17ae13370565b04cf77d2afa1cb9fa8806f05b59d3b2000080c080a0dd50efde9a4d2f01f5248e1a983165c8cfa5f193b07b4b094f4078ad4717c1e4a017db1be1e8751b09e033bcffca982d0fe4919ff6b8594654e06647dee9292750").unwrap())
+    }
+
+    #[cfg(test)]
+    fn rlp_roundtrip(encoded: &[u8]) {
+        let mut re_encoded = Vec::with_capacity(encoded.len());
+        let mut slice = encoded;
+        let tx = ExtendedTxEnvelope::decode(&mut slice).unwrap();
+        tx.encode(&mut re_encoded);
+        assert_eq!(re_encoded, encoded);
+    }
 }


### PR DESCRIPTION
After working on #95, I decided to take some parts of that PR and implement them separately as a smaller, more focused and complete, easier to review PRs with test coverage.

This one follows-up on #96

The conversion is a feature required by move events to log conversion.

## Changes
Implements a conversion from move to eth address as an extension trait it in the `primitives` module.

* Declares trait for conversion to eth address
* Implements the trait for move address using the existing function
* Adds test coverage