### PR TITLE
refactor: Declare primitive types in `primitives` module

### DIFF
--- a/moved/src/genesis/config.rs
+++ b/moved/src/genesis/config.rs
@@ -1,8 +1,8 @@
 use {
+    crate::primitives::B256,
     alloy_primitives::hex,
     aptos_gas_schedule::{InitialGasSchedule, VMGasParameters},
     aptos_vm_types::storage::StorageGasParameters,
-    ethers_core::types::H256,
 };
 
 pub const CHAIN_ID: u64 = 404;
@@ -17,7 +17,7 @@ pub struct GasCosts {
 #[derive(Debug, Clone)]
 pub struct GenesisConfig {
     pub chain_id: u64,
-    pub initial_state_root: H256,
+    pub initial_state_root: B256,
     pub gas_costs: GasCosts,
 }
 
@@ -35,7 +35,7 @@ impl Default for GenesisConfig {
     fn default() -> Self {
         Self {
             chain_id: CHAIN_ID,
-            initial_state_root: H256::from(hex!(
+            initial_state_root: B256::from(hex!(
                 "2503e9898a861f2753c4bd406d6454acba57f101096fa13ab01c5d7d585fcbf4"
             )),
             gas_costs: GasCosts::default(),

--- a/moved/src/lib.rs
+++ b/moved/src/lib.rs
@@ -3,6 +3,7 @@ pub use error::*;
 use {
     self::{
         genesis::config::GenesisConfig,
+        primitives::{B256, U64},
         types::{
             jsonrpc::{JsonRpcError, JsonRpcResponse},
             method_name::MethodName,
@@ -12,7 +13,6 @@ use {
     },
     crate::state_actor::StatePayloadId,
     clap::Parser,
-    ethers_core::types::{H256, U64},
     flate2::read::GzDecoder,
     jsonwebtoken::{DecodingKey, Validation},
     once_cell::sync::Lazy,
@@ -192,7 +192,7 @@ async fn mirror(
         &maybe_execution_payload,
         "blockNumber",
     ));
-    let block_hash: Result<Option<H256>, _> =
+    let block_hash: Result<Option<B256>, _> =
         serde_json::from_value(json_utils::get_field(&maybe_execution_payload, "blockHash"));
     if let (Ok(Some(block_height)), Ok(Some(block_hash))) = (block_height, block_hash) {
         let msg = StateMessage::NewBlock {

--- a/moved/src/methods/forkchoice_updated.rs
+++ b/moved/src/methods/forkchoice_updated.rs
@@ -16,7 +16,7 @@ use {
 #[cfg(test)]
 use {
     crate::genesis::config::GenesisConfig,
-    ethers_core::types::{Bytes, H160, H256, U64},
+    crate::primitives::{Address, Bytes, B256, U64},
     std::str::FromStr,
 };
 
@@ -128,36 +128,36 @@ fn test_parse_params_v3() {
 
     let expected_params = (
         ForkchoiceStateV1 {
-            head_block_hash: H256::from_str(
+            head_block_hash: B256::from_str(
                 "0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d",
             )
             .unwrap(),
-            safe_block_hash: H256::from_str(
+            safe_block_hash: B256::from_str(
                 "0xc9488c812782fac769416f918718107ca8f44f98fd2fe7dbcc12b9f5afa276dd",
             )
             .unwrap(),
-            finalized_block_hash: H256::from_str(
+            finalized_block_hash: B256::from_str(
                 "0x2c7cb7e2f79c2fa31f2b4280e96c34f7de981c6ccf5d0e998b51f5dc798fa53d",
             )
             .unwrap(),
         },
         Some(PayloadAttributesV3 {
-            timestamp: U64::from_str_radix("0x6660737b", 16).unwrap(),
-            prev_randao: H256::from_str(
+            timestamp: U64::from_str_radix("6660737b", 16).unwrap(),
+            prev_randao: B256::from_str(
                 "0xbde07f5d381bb84700433fe6c0ae077aa40eaad3a5de7abd298f0e3e27e6e4c9",
             )
             .unwrap(),
-            suggested_fee_recipient: H160::from_str("0x4200000000000000000000000000000000000011")
+            suggested_fee_recipient: Address::from_str("0x4200000000000000000000000000000000000011")
                 .unwrap(),
             withdrawals: Vec::new(),
-            parent_beacon_block_root: H256::from_str(
+            parent_beacon_block_root: B256::from_str(
                 "0x2bd857e239f7e5b5e6415608c76b90600d51fa0f7f0bbbc04e2d6861b3186f1c",
             )
             .unwrap(),
             transactions: vec![
                 Bytes::from_str("0x7ef8f8a0de86bef815fc910df65a9459ccb2b9a35fa8596dfcfed1ff01bbf28891d86d5e94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e2000000558000c5fc50000000000000000000000006660735b00000000000001a9000000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000017ae3f74f0134521a7d62a387ac75a5153bcd1aab1c7e003e9b9e15a5d8846363000000000000000000000000e25583099ba105d9ec0a67f5ae86d90e50036425").unwrap()
             ],
-            gas_limit: U64::from_str_radix("0x1c9c380", 16).unwrap(),
+            gas_limit: U64::from_str_radix("1c9c380", 16).unwrap(),
         }),
     );
 
@@ -183,15 +183,15 @@ fn test_parse_params_v3() {
 
     let expected_params = (
         ForkchoiceStateV1 {
-            head_block_hash: H256::from_str(
+            head_block_hash: B256::from_str(
                 "0xb412d0583c92bd00d1987291ba05a894af7483ff9b6e33891a47cf125f400ce2",
             )
             .unwrap(),
-            safe_block_hash: H256::from_str(
+            safe_block_hash: B256::from_str(
                 "0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d",
             )
             .unwrap(),
-            finalized_block_hash: H256::from_str(
+            finalized_block_hash: B256::from_str(
                 "0x2c7cb7e2f79c2fa31f2b4280e96c34f7de981c6ccf5d0e998b51f5dc798fa53d",
             )
             .unwrap(),

--- a/moved/src/methods/get_payload.rs
+++ b/moved/src/methods/get_payload.rs
@@ -12,8 +12,11 @@ use {
 
 #[cfg(test)]
 use {
-    crate::{genesis::config::GenesisConfig, methods::forkchoice_updated},
-    ethers_core::types::H256,
+    crate::{
+        genesis::config::GenesisConfig,
+        methods::forkchoice_updated,
+        primitives::{B256, U64},
+    },
     std::str::FromStr,
 };
 
@@ -100,11 +103,11 @@ async fn test_execute_v3() {
 
     // Set known block height
     let head_hash =
-        H256::from_str("0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d")
+        B256::from_str("0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d")
             .unwrap();
     let msg = StateMessage::NewBlock {
         block_hash: head_hash,
-        block_height: 1_194u64.into(),
+        block_height: U64::from(1_194u64),
     };
     state_channel.send(msg).await.unwrap();
 

--- a/moved/src/methods/send_raw_transaction.rs
+++ b/moved/src/methods/send_raw_transaction.rs
@@ -1,11 +1,11 @@
 use {
     crate::{
         json_utils::{self, access_state_error},
+        primitives::{Bytes, B256},
         types::{jsonrpc::JsonRpcError, state::StateMessage},
     },
     alloy_consensus::transaction::TxEnvelope,
     alloy_rlp::Decodable,
-    ethers_core::types::{Bytes, H256},
     tokio::sync::mpsc,
 };
 
@@ -50,7 +50,7 @@ fn parse_params(request: serde_json::Value) -> Result<TxEnvelope, JsonRpcError> 
 async fn inner_execute(
     tx: TxEnvelope,
     state_channel: mpsc::Sender<StateMessage>,
-) -> Result<H256, JsonRpcError> {
+) -> Result<B256, JsonRpcError> {
     let tx_hash = tx.tx_hash().0.into();
 
     let msg = StateMessage::AddTransaction { tx };

--- a/moved/src/move_execution/canonical.rs
+++ b/moved/src/move_execution/canonical.rs
@@ -8,7 +8,7 @@ use {
             nonces::check_nonce,
             LogsBloom,
         },
-        primitives::ToMoveAddress,
+        primitives::{ToMoveAddress, B256},
         types::{
             session_id::SessionId,
             transactions::{NormalizedEthTransaction, TransactionExecutionOutcome},
@@ -21,7 +21,6 @@ use {
     aptos_gas_meter::AptosGasMeter,
     aptos_table_natives::TableResolver,
     aptos_types::transaction::{EntryFunction, Module},
-    ethers_core::types::H256,
     move_binary_format::errors::PartialVMError,
     move_core_types::resolver::MoveResolver,
     move_vm_runtime::module_traversal::{TraversalContext, TraversalStorage},
@@ -29,7 +28,7 @@ use {
 
 pub(super) fn execute_canonical_transaction(
     tx: &TxEnvelope,
-    tx_hash: &H256,
+    tx_hash: &B256,
     state: &(impl MoveResolver<PartialVMError> + TableResolver),
     genesis_config: &GenesisConfig,
 ) -> crate::Result<TransactionExecutionOutcome> {

--- a/moved/src/move_execution/deposited.rs
+++ b/moved/src/move_execution/deposited.rs
@@ -6,14 +6,13 @@ use {
             gas::{new_gas_meter, total_gas_used},
             LogsBloom,
         },
-        primitives::ToMoveAddress,
+        primitives::{ToMoveAddress, B256},
         types::{
             session_id::SessionId,
             transactions::{DepositedTx, TransactionExecutionOutcome},
         },
     },
     aptos_table_natives::TableResolver,
-    ethers_core::types::H256,
     move_binary_format::errors::PartialVMError,
     move_core_types::resolver::MoveResolver,
     move_vm_runtime::module_traversal::{TraversalContext, TraversalStorage},
@@ -21,7 +20,7 @@ use {
 
 pub(super) fn execute_deposited_transaction(
     tx: &DepositedTx,
-    tx_hash: &H256,
+    tx_hash: &B256,
     state: &(impl MoveResolver<PartialVMError> + TableResolver),
     genesis_config: &GenesisConfig,
 ) -> crate::Result<TransactionExecutionOutcome> {

--- a/moved/src/move_execution/mod.rs
+++ b/moved/src/move_execution/mod.rs
@@ -1,6 +1,7 @@
 use {
     crate::{
         genesis::config::GenesisConfig,
+        primitives::B256,
         types::{
             session_id::SessionId,
             transactions::{ExtendedTxEnvelope, ToLog, TransactionExecutionOutcome},
@@ -17,7 +18,6 @@ use {
     aptos_vm::natives::aptos_natives,
     canonical::execute_canonical_transaction,
     deposited::execute_deposited_transaction,
-    ethers_core::types::H256,
     move_binary_format::errors::PartialVMError,
     move_core_types::resolver::MoveResolver,
     move_vm_runtime::{
@@ -84,7 +84,7 @@ where
 
 pub fn execute_transaction(
     tx: &ExtendedTxEnvelope,
-    tx_hash: &H256,
+    tx_hash: &B256,
     state: &(impl MoveResolver<PartialVMError> + TableResolver),
     genesis_config: &GenesisConfig,
 ) -> crate::Result<TransactionExecutionOutcome> {

--- a/moved/src/move_execution/tests.rs
+++ b/moved/src/move_execution/tests.rs
@@ -2,14 +2,14 @@ use {
     super::*,
     crate::{
         genesis::{config::CHAIN_ID, init_storage},
-        primitives::ToMoveAddress,
+        primitives::{ToMoveAddress, B256, U256, U64},
         storage::{InMemoryState, State},
         tests::{signer::Signer, EVM_ADDRESS, PRIVATE_KEY},
         types::transactions::DepositedTx,
     },
     alloy::network::TxSignerSync,
     alloy_consensus::{transaction::TxEip1559, SignableTransaction, TxEnvelope},
-    alloy_primitives::{keccak256, FixedBytes, TxKind, U256, U64},
+    alloy_primitives::{keccak256, FixedBytes, TxKind},
     alloy_rlp::Encodable,
     anyhow::Context,
     aptos_types::transaction::EntryFunction,
@@ -397,7 +397,7 @@ fn test_deposit_tx() {
         let capacity = tx.length();
         let mut bytes = Vec::with_capacity(capacity);
         tx.encode(&mut bytes);
-        H256(keccak256(bytes).0)
+        B256::new(keccak256(bytes).0)
     };
 
     execute_transaction(&tx, &tx_hash, state.resolver(), &genesis_config)
@@ -468,7 +468,7 @@ fn test_transaction_chain_id() {
     };
     let signature = signer.inner.sign_transaction_sync(&mut tx).unwrap();
     let signed_tx = TxEnvelope::Eip1559(tx.into_signed(signature));
-    let tx_hash = H256(signed_tx.tx_hash().0);
+    let tx_hash = B256::new(signed_tx.tx_hash().0);
     let signed_tx = ExtendedTxEnvelope::Canonical(signed_tx);
 
     let err =
@@ -505,7 +505,7 @@ fn test_out_of_gas() {
     };
     let signature = signer.inner.sign_transaction_sync(&mut tx).unwrap();
     let signed_tx = TxEnvelope::Eip1559(tx.into_signed(signature));
-    let tx_hash = H256(signed_tx.tx_hash().0);
+    let tx_hash = B256::new(signed_tx.tx_hash().0);
     let signed_tx = ExtendedTxEnvelope::Canonical(signed_tx);
 
     let err =
@@ -791,7 +791,7 @@ fn create_transaction(
     signer: &mut Signer,
     to: TxKind,
     input: Vec<u8>,
-) -> (H256, ExtendedTxEnvelope) {
+) -> (B256, ExtendedTxEnvelope) {
     let mut tx = TxEip1559 {
         chain_id: CHAIN_ID,
         nonce: signer.nonce,
@@ -806,7 +806,7 @@ fn create_transaction(
     signer.nonce += 1;
     let signature = signer.inner.sign_transaction_sync(&mut tx).unwrap();
     let signed_tx = TxEnvelope::Eip1559(tx.into_signed(signature));
-    let tx_hash = H256(signed_tx.tx_hash().0);
+    let tx_hash = B256::new(signed_tx.tx_hash().0);
     (tx_hash, ExtendedTxEnvelope::Canonical(signed_tx))
 }
 

--- a/moved/src/primitives.rs
+++ b/moved/src/primitives.rs
@@ -1,7 +1,6 @@
-use {
-    aptos_crypto::HashValue, ethers_core::types::H256,
-    move_core_types::account_address::AccountAddress,
-};
+pub(crate) use alloy_primitives::{aliases::B2048, Address, Bytes, B256, U256, U64};
+
+use {aptos_crypto::HashValue, move_core_types::account_address::AccountAddress};
 
 pub(crate) trait ToEthAddress {
     fn to_eth_address(&self) -> alloy_primitives::Address;
@@ -28,13 +27,13 @@ impl<T: AsRef<[u8; 20]>> ToMoveAddress for T {
     }
 }
 
-pub(crate) trait ToH256 {
-    fn to_h256(self) -> H256;
+pub(crate) trait ToB256 {
+    fn to_h256(self) -> B256;
 }
 
-impl ToH256 for HashValue {
-    fn to_h256(self) -> H256 {
-        H256::from_slice(self.as_slice())
+impl ToB256 for HashValue {
+    fn to_h256(self) -> B256 {
+        B256::from_slice(self.as_slice())
     }
 }
 
@@ -50,7 +49,7 @@ mod tests {
         let bytes = hex!("123456789abcdef000000feedb1123535271351623521abcefdabdfc0000001f");
         let value = HashValue::from_slice(bytes).unwrap();
         let converted = value.to_h256();
-        let actual_value = HashValue::from_slice(converted.as_fixed_bytes()).unwrap();
+        let actual_value = HashValue::from_slice(converted.as_slice()).unwrap();
         let expected_value = value;
 
         assert_eq!(actual_value, expected_value);
@@ -61,7 +60,7 @@ mod tests {
         let bytes = hex!("123456789abcdef000000feedb1123535271351623521abcefdabdfc0000001f");
         let value = HashValue::from_slice(bytes).unwrap();
         let converted = value.to_h256();
-        let actual_bytes = converted.as_fixed_bytes();
+        let actual_bytes = converted.as_slice();
         let expected_bytes = &bytes;
 
         assert_eq!(actual_bytes, expected_bytes);

--- a/moved/src/storage.rs
+++ b/moved/src/storage.rs
@@ -1,5 +1,8 @@
 use {
-    crate::{iter::GroupIterator, primitives::ToH256},
+    crate::{
+        iter::GroupIterator,
+        primitives::{ToB256, B256},
+    },
     aptos_crypto::{hash::CryptoHash, HashValue},
     aptos_jellyfish_merkle::{
         mock_tree_store::MockTreeStore, node_type::Node, JellyfishMerkleTree, TreeReader,
@@ -10,7 +13,6 @@ use {
         state_store::{state_key::StateKey, state_value::StateValue},
         transaction::Version,
     },
-    ethers_core::types::H256,
     move_binary_format::errors::PartialVMError,
     move_core_types::{effects::ChangeSet, resolver::MoveResolver},
     move_table_extension::{TableChangeSet, TableResolver},
@@ -50,7 +52,7 @@ pub trait State {
     fn resolver(&self) -> &(impl MoveResolver<Self::Err> + TableResolver);
 
     /// Retrieves the current state root.
-    fn state_root(&self) -> H256;
+    fn state_root(&self) -> B256;
 }
 
 pub struct InMemoryState {
@@ -98,10 +100,10 @@ impl State for InMemoryState {
         &self.resolver
     }
 
-    fn state_root(&self) -> H256 {
+    fn state_root(&self) -> B256 {
         self.tree()
             .get_root_hash(self.version)
-            .map(ToH256::to_h256)
+            .map(ToB256::to_h256)
             .unwrap()
     }
 }
@@ -112,7 +114,7 @@ impl InMemoryState {
         self.version
     }
 
-    fn insert_change_set_into_merkle_trie(&mut self, change_set: &ChangeSet) -> H256 {
+    fn insert_change_set_into_merkle_trie(&mut self, change_set: &ChangeSet) -> B256 {
         let version = self.next_version();
         let values = change_set.to_tree_values();
         let values_per_shard = values

--- a/moved/src/types/engine_api.rs
+++ b/moved/src/types/engine_api.rs
@@ -2,8 +2,11 @@
 //! for specification of types.
 
 use {
-    crate::state_actor::NewPayloadIdInput,
-    ethers_core::types::{Bytes, Withdrawal, H160, H256, U256, U64},
+    crate::{
+        primitives::{Address, Bytes, B2048, B256, U256, U64},
+        state_actor::NewPayloadIdInput,
+    },
+    alloy_eips::eip4895::Withdrawal,
     serde::{Deserialize, Serialize},
     std::str::FromStr,
 };
@@ -11,19 +14,19 @@ use {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ExecutionPayloadV1 {
-    pub parent_hash: H256,
-    pub fee_recipient: H160,
-    pub state_root: H256,
-    pub receipts_root: H256,
+    pub parent_hash: B256,
+    pub fee_recipient: Address,
+    pub state_root: B256,
+    pub receipts_root: B256,
     pub logs_bloom: Bytes,
-    pub prev_randao: H256,
+    pub prev_randao: B256,
     pub block_number: U64,
     pub gas_limit: U64,
     pub gas_used: U64,
     pub timestamp: U64,
     pub extra_data: Bytes,
     pub base_fee_per_gas: U256,
-    pub block_hash: H256,
+    pub block_hash: B256,
     pub transactions: Vec<Bytes>,
 }
 
@@ -32,26 +35,26 @@ pub struct ExecutionPayloadV1 {
 pub struct WithdrawalV1 {
     pub index: U64,
     pub validator_index: U64,
-    pub address: H160,
+    pub address: Address,
     pub amount: U64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ExecutionPayloadV2 {
-    pub parent_hash: H256,
-    pub fee_recipient: H160,
-    pub state_root: H256,
-    pub receipts_root: H256,
+    pub parent_hash: B256,
+    pub fee_recipient: Address,
+    pub state_root: B256,
+    pub receipts_root: B256,
     pub logs_bloom: Bytes,
-    pub prev_randao: H256,
+    pub prev_randao: B256,
     pub block_number: U64,
     pub gas_limit: U64,
     pub gas_used: U64,
     pub timestamp: U64,
     pub extra_data: Bytes,
     pub base_fee_per_gas: U256,
-    pub block_hash: H256,
+    pub block_hash: B256,
     pub transactions: Vec<Bytes>,
     pub withdrawals: Vec<WithdrawalV1>,
 }
@@ -59,19 +62,19 @@ pub struct ExecutionPayloadV2 {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ExecutionPayloadV3 {
-    pub parent_hash: H256,
-    pub fee_recipient: H160,
-    pub state_root: H256,
-    pub receipts_root: H256,
-    pub logs_bloom: Bytes,
-    pub prev_randao: H256,
+    pub parent_hash: B256,
+    pub fee_recipient: Address,
+    pub state_root: B256,
+    pub receipts_root: B256,
+    pub logs_bloom: B2048,
+    pub prev_randao: B256,
     pub block_number: U64,
     pub gas_limit: U64,
     pub gas_used: U64,
     pub timestamp: U64,
     pub extra_data: Bytes,
     pub base_fee_per_gas: U256,
-    pub block_hash: H256,
+    pub block_hash: B256,
     pub transactions: Vec<Bytes>,
     pub withdrawals: Vec<WithdrawalV1>,
     pub blob_gas_used: U64,
@@ -81,25 +84,25 @@ pub struct ExecutionPayloadV3 {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ForkchoiceStateV1 {
-    pub head_block_hash: H256,
-    pub safe_block_hash: H256,
-    pub finalized_block_hash: H256,
+    pub head_block_hash: B256,
+    pub safe_block_hash: B256,
+    pub finalized_block_hash: B256,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PayloadAttributesV1 {
     pub timestamp: U64,
-    pub prev_randao: H256,
-    pub suggested_fee_recipient: H160,
+    pub prev_randao: B256,
+    pub suggested_fee_recipient: Address,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PayloadAttributesV2 {
     pub timestamp: U64,
-    pub prev_randao: H256,
-    pub suggested_fee_recipient: H160,
+    pub prev_randao: B256,
+    pub suggested_fee_recipient: Address,
     pub withdrawals: Vec<WithdrawalV1>,
 }
 
@@ -107,16 +110,16 @@ pub struct PayloadAttributesV2 {
 #[serde(rename_all = "camelCase")]
 pub struct PayloadAttributesV3 {
     pub timestamp: U64,
-    pub prev_randao: H256,
-    pub suggested_fee_recipient: H160,
+    pub prev_randao: B256,
+    pub suggested_fee_recipient: Address,
     pub withdrawals: Vec<WithdrawalV1>,
-    pub parent_beacon_block_root: H256,
+    pub parent_beacon_block_root: B256,
     pub transactions: Vec<Bytes>,
     pub gas_limit: U64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(from = "U64", into = "String")]
+#[serde(into = "String")]
 pub struct PayloadId(pub U64);
 
 impl FromStr for PayloadId {
@@ -127,15 +130,15 @@ impl FromStr for PayloadId {
     }
 }
 
-impl<U: Into<U64>> From<U> for PayloadId {
+impl<U: Into<u64>> From<U> for PayloadId {
     fn from(value: U) -> Self {
-        Self(value.into())
+        Self(U64::from_limbs([value.into()]))
     }
 }
 
 impl From<PayloadId> for String {
     fn from(value: PayloadId) -> Self {
-        let inner: u64 = value.0 .0[0];
+        let inner: u64 = value.0.into_limbs()[0];
         format!("{inner:#018x}")
     }
 }
@@ -144,7 +147,7 @@ impl From<PayloadId> for String {
 #[serde(rename_all = "camelCase")]
 pub struct PayloadStatusV1 {
     pub status: Status,
-    pub latest_valid_hash: Option<H256>,
+    pub latest_valid_hash: Option<B256>,
     #[serde(default)]
     pub validation_error: Option<String>,
 }
@@ -180,7 +183,7 @@ pub struct GetPayloadResponseV3 {
     pub block_value: U256,
     pub blobs_bundle: BlobsBundleV1,
     pub should_override_builder: bool,
-    pub parent_beacon_block_root: H256,
+    pub parent_beacon_block_root: B256,
 }
 
 trait ToWithdrawal {
@@ -190,23 +193,23 @@ trait ToWithdrawal {
 impl ToWithdrawal for WithdrawalV1 {
     fn to_withdrawal(&self) -> Withdrawal {
         Withdrawal {
-            index: self.index,
-            validator_index: self.validator_index,
+            index: self.index.into_limbs()[0],
+            validator_index: self.validator_index.into_limbs()[0],
             address: self.address,
-            amount: U256::from(self.amount.as_u64()),
+            amount: self.amount.into_limbs()[0],
         }
     }
 }
 
 pub(crate) trait ToPayloadIdInput<'a> {
-    fn to_payload_id_input(&'a self, head: &'a H256) -> NewPayloadIdInput<'a>;
+    fn to_payload_id_input(&'a self, head: &'a B256) -> NewPayloadIdInput<'a>;
 }
 
 impl<'a> ToPayloadIdInput<'a> for &'a PayloadAttributesV3 {
-    fn to_payload_id_input(&'a self, head: &'a H256) -> NewPayloadIdInput<'a> {
+    fn to_payload_id_input(&'a self, head: &'a B256) -> NewPayloadIdInput<'a> {
         NewPayloadIdInput::new_v3(
             head,
-            self.timestamp.as_u64(),
+            self.timestamp.into_limbs()[0],
             &self.prev_randao,
             &self.suggested_fee_recipient,
         )

--- a/moved/src/types/session_id.rs
+++ b/moved/src/types/session_id.rs
@@ -2,13 +2,12 @@ use {
     super::transactions::DepositedTx,
     crate::{
         genesis::config::{GenesisConfig, CHAIN_ID},
-        primitives::ToMoveAddress,
+        primitives::{ToMoveAddress, B256},
         types::transactions::NormalizedEthTransaction,
     },
     alloy_primitives::U256,
     aptos_types::transaction::EntryFunction,
     aptos_vm::move_vm_ext::UserTransactionContext,
-    ethers_core::types::H256,
 };
 
 /// This struct represents a unique identifier for the current session of the MoveVM.
@@ -27,7 +26,7 @@ impl SessionId {
     pub fn new_from_canonical(
         tx: &NormalizedEthTransaction,
         maybe_entry_fn: Option<&EntryFunction>,
-        tx_hash: &H256,
+        tx_hash: &B256,
         genesis_config: &GenesisConfig,
     ) -> Self {
         let chain_id = u8_chain_id(genesis_config);
@@ -53,7 +52,7 @@ impl SessionId {
 
     pub fn new_from_deposited(
         tx: &DepositedTx,
-        tx_hash: &H256,
+        tx_hash: &B256,
         genesis_config: &GenesisConfig,
     ) -> Self {
         let chain_id = u8_chain_id(genesis_config);

--- a/moved/src/types/state.rs
+++ b/moved/src/types/state.rs
@@ -5,16 +5,18 @@
 
 use {
     super::engine_api::GetPayloadResponseV3,
-    crate::types::engine_api::{PayloadAttributesV3, PayloadId},
+    crate::{
+        primitives::{B2048, B256, U64},
+        types::engine_api::{PayloadAttributesV3, PayloadId},
+    },
     alloy_consensus::transaction::TxEnvelope,
-    ethers_core::types::{Bytes, H256, U64},
     tokio::sync::oneshot,
 };
 
 #[derive(Debug)]
 pub enum StateMessage {
     UpdateHead {
-        block_hash: H256,
+        block_hash: B256,
     },
     StartBlockBuild {
         payload_attributes: PayloadAttributesV3,
@@ -25,7 +27,7 @@ pub enum StateMessage {
         response_channel: oneshot::Sender<Option<GetPayloadResponseV3>>,
     },
     GetPayloadByBlockHash {
-        block_hash: H256,
+        block_hash: B256,
         response_channel: oneshot::Sender<Option<GetPayloadResponseV3>>,
     },
     AddTransaction {
@@ -34,15 +36,15 @@ pub enum StateMessage {
     // Tells the state to remember a new block hash/height correspondence.
     // TODO: should be able to remove in the future
     NewBlock {
-        block_hash: H256,
+        block_hash: B256,
         block_height: U64,
     },
 }
 
 #[derive(Debug)]
 pub struct ExecutionOutcome {
-    pub receipts_root: H256,
-    pub state_root: H256,
-    pub logs_bloom: Bytes,
+    pub receipts_root: B256,
+    pub state_root: B256,
+    pub logs_bloom: B2048,
     pub gas_used: U64,
 }


### PR DESCRIPTION
This PR is about clearing up some confusion about primitive types as we're using both `ethers` and `alloy` to source them from.

## Motivation
Whilst defining the block structure, I noticed that there is a mix of types from `ethers` and `alloy` being used, making it difficult to work with and requiring conversions on places where no conversion is supposed to happen.

When writing new code it is also not clear whether to use primitives from `ethers` or `alloy`.

## Solution

This PR makes the primitive types available under `primitives` module of the `moved` crate. This primarily has a few effects in that it:
* Centralizes the primitive type declarations.
* Makes the type declarations local (sort of).
* Hides the fact which concrete library is used under the hood.
* Uses only one implementation of the primitives.

This has the following consequences:
* Reduces the need for conversion between identical primitives from different libraries.
* Clears any doubt as to which library to use to import the primitives from.

## Summary
- Resolves mismatch between `alloy` and `ethers`
- Makes the types available under a single and local alias
- Does not expose the concrete library from which the types are sourced
- Allows for simple replaceability
