### PR TITLE
feat: Store created blocks on new payload

### DIFF
--- a/moved/src/block/in_memory.rs
+++ b/moved/src/block/in_memory.rs
@@ -1,0 +1,18 @@
+use crate::block::{root::BlockRepository, BlockWithHash};
+
+#[derive(Debug)]
+pub struct InMemoryBlockRepository {
+    blocks: Vec<BlockWithHash>,
+}
+
+impl InMemoryBlockRepository {
+    pub fn new() -> Self {
+        Self { blocks: Vec::new() }
+    }
+}
+
+impl BlockRepository for InMemoryBlockRepository {
+    fn add(&mut self, block: BlockWithHash) {
+        self.blocks.push(block);
+    }
+}

--- a/moved/src/block/mod.rs
+++ b/moved/src/block/mod.rs
@@ -5,9 +5,11 @@
 //! * Declares a collection of blocks in the node.
 
 mod hash;
+mod in_memory;
 mod root;
 
 pub use {
     hash::{BlockHash, MovedBlockHash},
-    root::{Block, BlockWithHash, Header},
+    in_memory::InMemoryBlockRepository,
+    root::{Block, BlockRepository, BlockWithHash, Header},
 };

--- a/moved/src/block/root.rs
+++ b/moved/src/block/root.rs
@@ -5,7 +5,12 @@ use {
     },
     alloy_primitives::hex,
     alloy_rlp::RlpEncodable,
+    std::fmt::Debug,
 };
+
+pub trait BlockRepository: Debug {
+    fn add(&mut self, block: BlockWithHash);
+}
 
 #[derive(Debug, Clone)]
 pub struct BlockWithHash {

--- a/moved/src/lib.rs
+++ b/moved/src/lib.rs
@@ -10,7 +10,10 @@ use {
             state::StateMessage,
         },
     },
-    crate::{block::MovedBlockHash, state_actor::StatePayloadId},
+    crate::{
+        block::{InMemoryBlockRepository, MovedBlockHash},
+        state_actor::StatePayloadId,
+    },
     clap::Parser,
     flate2::read::GzDecoder,
     jsonwebtoken::{DecodingKey, Validation},
@@ -76,8 +79,13 @@ pub async fn run() {
     // TODO: think about channel size bound
     let (state_channel, rx) = mpsc::channel(1_000);
     let genesis_config = GenesisConfig::default();
-    let state =
-        state_actor::StateActor::new_in_memory(rx, genesis_config, StatePayloadId, MovedBlockHash);
+    let state = state_actor::StateActor::new_in_memory(
+        rx,
+        genesis_config,
+        StatePayloadId,
+        MovedBlockHash,
+        InMemoryBlockRepository::new(),
+    );
 
     let http_state_channel = state_channel.clone();
     let http_server_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 8545));

--- a/moved/src/methods/forkchoice_updated.rs
+++ b/moved/src/methods/forkchoice_updated.rs
@@ -15,6 +15,7 @@ use {
 
 #[cfg(test)]
 use {
+    crate::block::InMemoryBlockRepository,
     crate::genesis::config::GenesisConfig,
     crate::primitives::{Address, Bytes, B256, U64},
     std::str::FromStr,
@@ -241,6 +242,7 @@ async fn test_execute_v3() {
         genesis_config,
         0x03421ee50df45cacu64,
         B256::ZERO,
+        InMemoryBlockRepository::new(),
     );
     let state_handle = state.spawn();
     let request = example_request();

--- a/moved/src/methods/get_payload.rs
+++ b/moved/src/methods/get_payload.rs
@@ -12,7 +12,10 @@ use {
 
 #[cfg(test)]
 use {
-    crate::{genesis::config::GenesisConfig, methods::forkchoice_updated, primitives::B256},
+    crate::{
+        block::InMemoryBlockRepository, genesis::config::GenesisConfig,
+        methods::forkchoice_updated, primitives::B256,
+    },
     std::str::FromStr,
 };
 
@@ -104,6 +107,7 @@ async fn test_execute_v3() {
         genesis_config,
         0x03421ee50df45cacu64,
         head_hash,
+        InMemoryBlockRepository::new(),
     );
     let state_handle = state.spawn();
 

--- a/moved/src/methods/new_payload.rs
+++ b/moved/src/methods/new_payload.rs
@@ -14,6 +14,7 @@ use {
 #[cfg(test)]
 use {
     crate::{
+        block::InMemoryBlockRepository,
         genesis::config::GenesisConfig,
         methods::{forkchoice_updated, get_payload},
         primitives::{Address, Bytes, B2048, U256, U64},
@@ -275,6 +276,7 @@ async fn test_execute_v3() {
         B256::from(hex!(
             "c013e1ff1b8bca9f0d074618cc9e661983bc91d7677168b156765781aee775d3"
         )),
+        InMemoryBlockRepository::new(),
     );
     let state_handle = state.spawn();
 

--- a/moved/src/methods/send_raw_transaction.rs
+++ b/moved/src/methods/send_raw_transaction.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+use crate::{block::InMemoryBlockRepository, state_actor::StatePayloadId};
+
 use {
     crate::{
         json_utils::{self, access_state_error},
@@ -8,9 +11,6 @@ use {
     alloy_rlp::Decodable,
     tokio::sync::mpsc,
 };
-
-#[cfg(test)]
-use crate::state_actor::StatePayloadId;
 
 pub async fn execute(
     request: serde_json::Value,
@@ -68,6 +68,7 @@ async fn test_execute() {
         genesis_config,
         StatePayloadId,
         B256::ZERO,
+        InMemoryBlockRepository::new(),
     );
     let state_handle = state.spawn();
 


### PR DESCRIPTION
Closes #104 

This PR is about storing blocks created on new payload.

A lot of operations rely on having access to created blocks such as looking up a parent block.