### PR TITLE
feat: Create genesis block

### DIFF
--- a/moved/src/block/in_memory.rs
+++ b/moved/src/block/in_memory.rs
@@ -1,18 +1,40 @@
-use crate::block::{root::BlockRepository, BlockWithHash};
+use {
+    crate::{
+        block::{root::BlockRepository, BlockWithHash},
+        primitives::B256,
+    },
+    std::collections::HashMap,
+};
 
+/// Block repository that keeps data in memory.
+///
+/// The repository keeps data stored locally and its memory is not shared outside the struct.
 #[derive(Debug)]
 pub struct InMemoryBlockRepository {
+    /// Collection of blocks ordered by insertion.
     blocks: Vec<BlockWithHash>,
+    /// Map where key is a block hash and value is a position in the `blocks` vector.
+    hashes: HashMap<B256, usize>,
 }
 
 impl InMemoryBlockRepository {
     pub fn new() -> Self {
-        Self { blocks: Vec::new() }
+        Self {
+            blocks: Vec::new(),
+            hashes: HashMap::new(),
+        }
     }
 }
 
 impl BlockRepository for InMemoryBlockRepository {
     fn add(&mut self, block: BlockWithHash) {
+        let index = self.blocks.len();
+        self.hashes.insert(block.hash, index);
         self.blocks.push(block);
+    }
+
+    fn by_hash(&self, hash: B256) -> Option<BlockWithHash> {
+        let index = *self.hashes.get(&hash)?;
+        self.blocks.get(index).cloned()
     }
 }

--- a/moved/src/block/root.rs
+++ b/moved/src/block/root.rs
@@ -10,6 +10,7 @@ use {
 
 pub trait BlockRepository: Debug {
     fn add(&mut self, block: BlockWithHash);
+    fn by_hash(&self, hash: B256) -> Option<BlockWithHash>;
 }
 
 #[derive(Debug, Clone)]
@@ -25,7 +26,7 @@ impl BlockWithHash {
 }
 
 /// TODO: Add withdrawals
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Block {
     pub(crate) header: Header,
     pub(crate) transactions: Vec<ExtendedTxEnvelope>,
@@ -132,5 +133,10 @@ impl Header {
             nonce: 0,
             ..Default::default()
         }
+    }
+
+    pub fn with_state_root(mut self, state_root: B256) -> Self {
+        self.state_root = state_root;
+        self
     }
 }

--- a/moved/src/methods/forkchoice_updated.rs
+++ b/moved/src/methods/forkchoice_updated.rs
@@ -15,7 +15,7 @@ use {
 
 #[cfg(test)]
 use {
-    crate::block::InMemoryBlockRepository,
+    crate::block::{Block, BlockRepository, BlockWithHash, InMemoryBlockRepository},
     crate::genesis::config::GenesisConfig,
     crate::primitives::{Address, Bytes, B256, U64},
     std::str::FromStr,
@@ -237,12 +237,21 @@ async fn test_execute_v3() {
     let genesis_config = GenesisConfig::default();
     let (state_channel, rx) = tokio::sync::mpsc::channel(10);
 
+    let head_hash =
+        B256::from_str("0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d")
+            .unwrap();
+    let genesis_block = BlockWithHash::new(head_hash, Block::default());
+
+    let mut repository = InMemoryBlockRepository::new();
+    repository.add(genesis_block);
+
     let state = crate::state_actor::StateActor::new_in_memory(
         rx,
+        head_hash,
         genesis_config,
         0x03421ee50df45cacu64,
         B256::ZERO,
-        InMemoryBlockRepository::new(),
+        repository,
     );
     let state_handle = state.spawn();
     let request = example_request();

--- a/moved/src/methods/get_payload.rs
+++ b/moved/src/methods/get_payload.rs
@@ -13,8 +13,10 @@ use {
 #[cfg(test)]
 use {
     crate::{
-        block::InMemoryBlockRepository, genesis::config::GenesisConfig,
-        methods::forkchoice_updated, primitives::B256,
+        block::{Block, BlockRepository, BlockWithHash, InMemoryBlockRepository},
+        genesis::config::GenesisConfig,
+        methods::forkchoice_updated,
+        primitives::B256,
     },
     std::str::FromStr,
 };
@@ -101,13 +103,18 @@ async fn test_execute_v3() {
     let head_hash =
         B256::from_str("0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d")
             .unwrap();
+    let genesis_block = BlockWithHash::new(head_hash, Block::default());
+
+    let mut repository = InMemoryBlockRepository::new();
+    repository.add(genesis_block);
 
     let state = crate::state_actor::StateActor::new_in_memory(
         rx,
+        head_hash,
         genesis_config,
         0x03421ee50df45cacu64,
         head_hash,
-        InMemoryBlockRepository::new(),
+        repository,
     );
     let state_handle = state.spawn();
 

--- a/moved/src/methods/send_raw_transaction.rs
+++ b/moved/src/methods/send_raw_transaction.rs
@@ -65,6 +65,7 @@ async fn test_execute() {
     let (state_channel, rx) = tokio::sync::mpsc::channel(10);
     let state = crate::state_actor::StateActor::new_in_memory(
         rx,
+        B256::ZERO,
         genesis_config,
         StatePayloadId,
         B256::ZERO,


### PR DESCRIPTION
Validates the assumption that there is always a parent block.

Lookup of parent block is needed for some algorithms such as gas pricing.
