### PR TITLE
refactor(json-rpc): Move unit tests into a tests module

### DIFF
--- a/moved/src/methods/forkchoice_updated.rs
+++ b/moved/src/methods/forkchoice_updated.rs
@@ -13,14 +13,6 @@ use {
     tokio::sync::{mpsc, oneshot},
 };
 
-#[cfg(test)]
-use {
-    crate::block::{Block, BlockRepository, BlockWithHash, InMemoryBlockRepository},
-    crate::genesis::config::GenesisConfig,
-    crate::primitives::{Address, Bytes, B256, U64},
-    std::str::FromStr,
-};
-
 pub async fn execute_v3(
     request: serde_json::Value,
     state_channel: mpsc::Sender<StateMessage>,
@@ -97,166 +89,177 @@ async fn inner_execute_v3(
     })
 }
 
-#[test]
-fn test_parse_params_v3() {
-    let request: serde_json::Value = serde_json::from_str(r#"
-        {
-            "id": 30053,
-            "jsonrpc": "2.0",
-            "method": "engine_forkchoiceUpdatedV3",
-            "params": [
-            {
-                "finalizedBlockHash": "0x2c7cb7e2f79c2fa31f2b4280e96c34f7de981c6ccf5d0e998b51f5dc798fa53d",
-                "headBlockHash": "0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d",
-                "safeBlockHash": "0xc9488c812782fac769416f918718107ca8f44f98fd2fe7dbcc12b9f5afa276dd"
-            },
-            {
-                "gasLimit": "0x1c9c380",
-                "parentBeaconBlockRoot": "0x2bd857e239f7e5b5e6415608c76b90600d51fa0f7f0bbbc04e2d6861b3186f1c",
-                "prevRandao": "0xbde07f5d381bb84700433fe6c0ae077aa40eaad3a5de7abd298f0e3e27e6e4c9",
-                "suggestedFeeRecipient": "0x4200000000000000000000000000000000000011",
-                "timestamp": "0x6660737b",
-                "transactions": [
-                    "0x7ef8f8a0de86bef815fc910df65a9459ccb2b9a35fa8596dfcfed1ff01bbf28891d86d5e94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e2000000558000c5fc50000000000000000000000006660735b00000000000001a9000000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000017ae3f74f0134521a7d62a387ac75a5153bcd1aab1c7e003e9b9e15a5d8846363000000000000000000000000e25583099ba105d9ec0a67f5ae86d90e50036425"
-                ],
-                "withdrawals": []
-            }
-            ]
-        }
-    "#).unwrap();
-
-    let params = parse_params_v3(request).unwrap();
-
-    let expected_params = (
-        ForkchoiceStateV1 {
-            head_block_hash: B256::from_str(
-                "0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d",
-            )
-            .unwrap(),
-            safe_block_hash: B256::from_str(
-                "0xc9488c812782fac769416f918718107ca8f44f98fd2fe7dbcc12b9f5afa276dd",
-            )
-            .unwrap(),
-            finalized_block_hash: B256::from_str(
-                "0x2c7cb7e2f79c2fa31f2b4280e96c34f7de981c6ccf5d0e998b51f5dc798fa53d",
-            )
-            .unwrap(),
-        },
-        Some(PayloadAttributesV3 {
-            timestamp: U64::from_str_radix("6660737b", 16).unwrap(),
-            prev_randao: B256::from_str(
-                "0xbde07f5d381bb84700433fe6c0ae077aa40eaad3a5de7abd298f0e3e27e6e4c9",
-            )
-            .unwrap(),
-            suggested_fee_recipient: Address::from_str("0x4200000000000000000000000000000000000011")
-                .unwrap(),
-            withdrawals: Vec::new(),
-            parent_beacon_block_root: B256::from_str(
-                "0x2bd857e239f7e5b5e6415608c76b90600d51fa0f7f0bbbc04e2d6861b3186f1c",
-            )
-            .unwrap(),
-            transactions: vec![
-                Bytes::from_str("0x7ef8f8a0de86bef815fc910df65a9459ccb2b9a35fa8596dfcfed1ff01bbf28891d86d5e94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e2000000558000c5fc50000000000000000000000006660735b00000000000001a9000000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000017ae3f74f0134521a7d62a387ac75a5153bcd1aab1c7e003e9b9e15a5d8846363000000000000000000000000e25583099ba105d9ec0a67f5ae86d90e50036425").unwrap()
-            ],
-            gas_limit: U64::from_str_radix("1c9c380", 16).unwrap(),
-        }),
-    );
-
-    assert_eq!(params, expected_params);
-
-    let request: serde_json::Value = serde_json::from_str(r#"
-        {
-            "id": 32034,
-            "jsonrpc": "2.0",
-            "method": "engine_forkchoiceUpdatedV3",
-            "params": [
-                {
-                "finalizedBlockHash": "0x2c7cb7e2f79c2fa31f2b4280e96c34f7de981c6ccf5d0e998b51f5dc798fa53d",
-                "headBlockHash": "0xb412d0583c92bd00d1987291ba05a894af7483ff9b6e33891a47cf125f400ce2",
-                "safeBlockHash": "0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d"
-                },
-                null
-            ]
-        }
-    "#).unwrap();
-
-    let params = parse_params_v3(request).unwrap();
-
-    let expected_params = (
-        ForkchoiceStateV1 {
-            head_block_hash: B256::from_str(
-                "0xb412d0583c92bd00d1987291ba05a894af7483ff9b6e33891a47cf125f400ce2",
-            )
-            .unwrap(),
-            safe_block_hash: B256::from_str(
-                "0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d",
-            )
-            .unwrap(),
-            finalized_block_hash: B256::from_str(
-                "0x2c7cb7e2f79c2fa31f2b4280e96c34f7de981c6ccf5d0e998b51f5dc798fa53d",
-            )
-            .unwrap(),
-        },
-        None,
-    );
-
-    assert_eq!(params, expected_params);
-}
-
 #[cfg(test)]
-pub fn example_request() -> serde_json::Value {
-    serde_json::from_str(r#"
-    {
-        "id": 30053,
-        "jsonrpc": "2.0",
-        "method": "engine_forkchoiceUpdatedV3",
-        "params": [
-        {
-            "finalizedBlockHash": "0x2c7cb7e2f79c2fa31f2b4280e96c34f7de981c6ccf5d0e998b51f5dc798fa53d",
-            "headBlockHash": "0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d",
-            "safeBlockHash": "0xc9488c812782fac769416f918718107ca8f44f98fd2fe7dbcc12b9f5afa276dd"
+pub(super) mod tests {
+    use {
+        super::*,
+        crate::{
+            block::{Block, BlockRepository, BlockWithHash, InMemoryBlockRepository},
+            genesis::config::GenesisConfig,
+            primitives::{Address, Bytes, B256, U64},
         },
-        {
-            "gasLimit": "0x1c9c380",
-            "parentBeaconBlockRoot": "0x2bd857e239f7e5b5e6415608c76b90600d51fa0f7f0bbbc04e2d6861b3186f1c",
-            "prevRandao": "0xbde07f5d381bb84700433fe6c0ae077aa40eaad3a5de7abd298f0e3e27e6e4c9",
-            "suggestedFeeRecipient": "0x4200000000000000000000000000000000000011",
-            "timestamp": "0x6660737b",
-            "transactions": [
-                "0x7ef8f8a0de86bef815fc910df65a9459ccb2b9a35fa8596dfcfed1ff01bbf28891d86d5e94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e2000000558000c5fc50000000000000000000000006660735b00000000000001a9000000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000017ae3f74f0134521a7d62a387ac75a5153bcd1aab1c7e003e9b9e15a5d8846363000000000000000000000000e25583099ba105d9ec0a67f5ae86d90e50036425"
-            ],
-            "withdrawals": []
-        }
-        ]
+        std::str::FromStr,
+    };
+
+    pub fn example_request() -> serde_json::Value {
+        serde_json::from_str(r#"
+            {
+                "id": 30053,
+                "jsonrpc": "2.0",
+                "method": "engine_forkchoiceUpdatedV3",
+                "params": [
+                {
+                    "finalizedBlockHash": "0x2c7cb7e2f79c2fa31f2b4280e96c34f7de981c6ccf5d0e998b51f5dc798fa53d",
+                    "headBlockHash": "0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d",
+                    "safeBlockHash": "0xc9488c812782fac769416f918718107ca8f44f98fd2fe7dbcc12b9f5afa276dd"
+                },
+                {
+                    "gasLimit": "0x1c9c380",
+                    "parentBeaconBlockRoot": "0x2bd857e239f7e5b5e6415608c76b90600d51fa0f7f0bbbc04e2d6861b3186f1c",
+                    "prevRandao": "0xbde07f5d381bb84700433fe6c0ae077aa40eaad3a5de7abd298f0e3e27e6e4c9",
+                    "suggestedFeeRecipient": "0x4200000000000000000000000000000000000011",
+                    "timestamp": "0x6660737b",
+                    "transactions": [
+                        "0x7ef8f8a0de86bef815fc910df65a9459ccb2b9a35fa8596dfcfed1ff01bbf28891d86d5e94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e2000000558000c5fc50000000000000000000000006660735b00000000000001a9000000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000017ae3f74f0134521a7d62a387ac75a5153bcd1aab1c7e003e9b9e15a5d8846363000000000000000000000000e25583099ba105d9ec0a67f5ae86d90e50036425"
+                    ],
+                    "withdrawals": []
+                }
+                ]
+            }
+        "#).unwrap()
     }
-"#).unwrap()
-}
 
-#[tokio::test]
-async fn test_execute_v3() {
-    let genesis_config = GenesisConfig::default();
-    let (state_channel, rx) = tokio::sync::mpsc::channel(10);
+    #[test]
+    fn test_parse_params_v3() {
+        let request: serde_json::Value = serde_json::from_str(r#"
+            {
+                "id": 30053,
+                "jsonrpc": "2.0",
+                "method": "engine_forkchoiceUpdatedV3",
+                "params": [
+                {
+                    "finalizedBlockHash": "0x2c7cb7e2f79c2fa31f2b4280e96c34f7de981c6ccf5d0e998b51f5dc798fa53d",
+                    "headBlockHash": "0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d",
+                    "safeBlockHash": "0xc9488c812782fac769416f918718107ca8f44f98fd2fe7dbcc12b9f5afa276dd"
+                },
+                {
+                    "gasLimit": "0x1c9c380",
+                    "parentBeaconBlockRoot": "0x2bd857e239f7e5b5e6415608c76b90600d51fa0f7f0bbbc04e2d6861b3186f1c",
+                    "prevRandao": "0xbde07f5d381bb84700433fe6c0ae077aa40eaad3a5de7abd298f0e3e27e6e4c9",
+                    "suggestedFeeRecipient": "0x4200000000000000000000000000000000000011",
+                    "timestamp": "0x6660737b",
+                    "transactions": [
+                        "0x7ef8f8a0de86bef815fc910df65a9459ccb2b9a35fa8596dfcfed1ff01bbf28891d86d5e94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e2000000558000c5fc50000000000000000000000006660735b00000000000001a9000000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000017ae3f74f0134521a7d62a387ac75a5153bcd1aab1c7e003e9b9e15a5d8846363000000000000000000000000e25583099ba105d9ec0a67f5ae86d90e50036425"
+                    ],
+                    "withdrawals": []
+                }
+                ]
+            }
+        "#).unwrap();
 
-    let head_hash =
-        B256::from_str("0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d")
-            .unwrap();
-    let genesis_block = BlockWithHash::new(head_hash, Block::default());
+        let params = parse_params_v3(request).unwrap();
 
-    let mut repository = InMemoryBlockRepository::new();
-    repository.add(genesis_block);
+        let expected_params = (
+            ForkchoiceStateV1 {
+                head_block_hash: B256::from_str(
+                    "0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d",
+                )
+                    .unwrap(),
+                safe_block_hash: B256::from_str(
+                    "0xc9488c812782fac769416f918718107ca8f44f98fd2fe7dbcc12b9f5afa276dd",
+                )
+                    .unwrap(),
+                finalized_block_hash: B256::from_str(
+                    "0x2c7cb7e2f79c2fa31f2b4280e96c34f7de981c6ccf5d0e998b51f5dc798fa53d",
+                )
+                    .unwrap(),
+            },
+            Some(PayloadAttributesV3 {
+                timestamp: U64::from_str_radix("6660737b", 16).unwrap(),
+                prev_randao: B256::from_str(
+                    "0xbde07f5d381bb84700433fe6c0ae077aa40eaad3a5de7abd298f0e3e27e6e4c9",
+                )
+                    .unwrap(),
+                suggested_fee_recipient: Address::from_str("0x4200000000000000000000000000000000000011")
+                    .unwrap(),
+                withdrawals: Vec::new(),
+                parent_beacon_block_root: B256::from_str(
+                    "0x2bd857e239f7e5b5e6415608c76b90600d51fa0f7f0bbbc04e2d6861b3186f1c",
+                )
+                    .unwrap(),
+                transactions: vec![
+                    Bytes::from_str("0x7ef8f8a0de86bef815fc910df65a9459ccb2b9a35fa8596dfcfed1ff01bbf28891d86d5e94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e2000000558000c5fc50000000000000000000000006660735b00000000000001a9000000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000017ae3f74f0134521a7d62a387ac75a5153bcd1aab1c7e003e9b9e15a5d8846363000000000000000000000000e25583099ba105d9ec0a67f5ae86d90e50036425").unwrap()
+                ],
+                gas_limit: U64::from_str_radix("1c9c380", 16).unwrap(),
+            }),
+        );
 
-    let state = crate::state_actor::StateActor::new_in_memory(
-        rx,
-        head_hash,
-        genesis_config,
-        0x03421ee50df45cacu64,
-        B256::ZERO,
-        repository,
-    );
-    let state_handle = state.spawn();
-    let request = example_request();
+        assert_eq!(params, expected_params);
 
-    let expected_response: serde_json::Value = serde_json::from_str(r#"
+        let request: serde_json::Value = serde_json::from_str(r#"
+            {
+                "id": 32034,
+                "jsonrpc": "2.0",
+                "method": "engine_forkchoiceUpdatedV3",
+                "params": [
+                    {
+                    "finalizedBlockHash": "0x2c7cb7e2f79c2fa31f2b4280e96c34f7de981c6ccf5d0e998b51f5dc798fa53d",
+                    "headBlockHash": "0xb412d0583c92bd00d1987291ba05a894af7483ff9b6e33891a47cf125f400ce2",
+                    "safeBlockHash": "0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d"
+                    },
+                    null
+                ]
+            }
+        "#).unwrap();
+
+        let params = parse_params_v3(request).unwrap();
+
+        let expected_params = (
+            ForkchoiceStateV1 {
+                head_block_hash: B256::from_str(
+                    "0xb412d0583c92bd00d1987291ba05a894af7483ff9b6e33891a47cf125f400ce2",
+                )
+                .unwrap(),
+                safe_block_hash: B256::from_str(
+                    "0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d",
+                )
+                .unwrap(),
+                finalized_block_hash: B256::from_str(
+                    "0x2c7cb7e2f79c2fa31f2b4280e96c34f7de981c6ccf5d0e998b51f5dc798fa53d",
+                )
+                .unwrap(),
+            },
+            None,
+        );
+
+        assert_eq!(params, expected_params);
+    }
+
+    #[tokio::test]
+    async fn test_execute_v3() {
+        let genesis_config = GenesisConfig::default();
+        let (state_channel, rx) = tokio::sync::mpsc::channel(10);
+
+        let head_hash =
+            B256::from_str("0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d")
+                .unwrap();
+        let genesis_block = BlockWithHash::new(head_hash, Block::default());
+
+        let mut repository = InMemoryBlockRepository::new();
+        repository.add(genesis_block);
+
+        let state = crate::state_actor::StateActor::new_in_memory(
+            rx,
+            head_hash,
+            genesis_config,
+            0x03421ee50df45cacu64,
+            B256::ZERO,
+            repository,
+        );
+        let state_handle = state.spawn();
+        let request = example_request();
+
+        let expected_response: serde_json::Value = serde_json::from_str(r#"
         {
             "payloadStatus": {
                 "status": "VALID",
@@ -267,8 +270,9 @@ async fn test_execute_v3() {
         }
     "#).unwrap();
 
-    let response = execute_v3(request, state_channel).await.unwrap();
+        let response = execute_v3(request, state_channel).await.unwrap();
 
-    assert_eq!(response, expected_response);
-    state_handle.await.unwrap();
+        assert_eq!(response, expected_response);
+        state_handle.await.unwrap();
+    }
 }

--- a/moved/src/methods/get_payload.rs
+++ b/moved/src/methods/get_payload.rs
@@ -10,17 +10,6 @@ use {
     tokio::sync::{mpsc, oneshot},
 };
 
-#[cfg(test)]
-use {
-    crate::{
-        block::{Block, BlockRepository, BlockWithHash, InMemoryBlockRepository},
-        genesis::config::GenesisConfig,
-        methods::forkchoice_updated,
-        primitives::B256,
-    },
-    std::str::FromStr,
-};
-
 pub async fn execute_v3(
     request: serde_json::Value,
     state_channel: mpsc::Sender<StateMessage>,
@@ -71,114 +60,131 @@ async fn inner_execute_v3(
     })
 }
 
-#[test]
-fn test_parse_params_v3() {
-    let request: serde_json::Value = serde_json::from_str(
-        r#"
-        {
-            "id": 30054,
-            "jsonrpc": "2.0",
-            "method": "engine_getPayloadV3",
-            "params": [
-                "0x03421ee50df45cac"
-            ]
-        }
-    "#,
-    )
-    .unwrap();
-
-    let params = parse_params_v3(request).unwrap();
-
-    let expected_params = PayloadId::from_str("0x03421ee50df45cac").unwrap();
-
-    assert_eq!(params, expected_params);
-}
-
-#[tokio::test]
-async fn test_execute_v3() {
-    let genesis_config = GenesisConfig::default();
-    let (state_channel, rx) = tokio::sync::mpsc::channel(10);
-
-    // Set known block height
-    let head_hash =
-        B256::from_str("0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d")
-            .unwrap();
-    let genesis_block = BlockWithHash::new(head_hash, Block::default());
-
-    let mut repository = InMemoryBlockRepository::new();
-    repository.add(genesis_block);
-
-    let state = crate::state_actor::StateActor::new_in_memory(
-        rx,
-        head_hash,
-        genesis_config,
-        0x03421ee50df45cacu64,
-        head_hash,
-        repository,
-    );
-    let state_handle = state.spawn();
-
-    // Set head block hash
-    let msg = StateMessage::UpdateHead {
-        block_hash: head_hash,
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            block::{Block, BlockRepository, BlockWithHash, InMemoryBlockRepository},
+            genesis::config::GenesisConfig,
+            methods::forkchoice_updated,
+            primitives::B256,
+        },
+        std::str::FromStr,
     };
-    state_channel.send(msg).await.unwrap();
 
-    // Update the state with an execution payload
-    forkchoice_updated::execute_v3(forkchoice_updated::example_request(), state_channel.clone())
+    #[test]
+    fn test_parse_params_v3() {
+        let request: serde_json::Value = serde_json::from_str(
+            r#"
+            {
+                "id": 30054,
+                "jsonrpc": "2.0",
+                "method": "engine_getPayloadV3",
+                "params": [
+                    "0x03421ee50df45cac"
+                ]
+            }
+        "#,
+        )
+        .unwrap();
+
+        let params = parse_params_v3(request).unwrap();
+
+        let expected_params = PayloadId::from_str("0x03421ee50df45cac").unwrap();
+
+        assert_eq!(params, expected_params);
+    }
+
+    #[tokio::test]
+    async fn test_execute_v3() {
+        let genesis_config = GenesisConfig::default();
+        let (state_channel, rx) = tokio::sync::mpsc::channel(10);
+
+        // Set known block height
+        let head_hash =
+            B256::from_str("0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d")
+                .unwrap();
+        let genesis_block = BlockWithHash::new(head_hash, Block::default());
+
+        let mut repository = InMemoryBlockRepository::new();
+        repository.add(genesis_block);
+
+        let state = crate::state_actor::StateActor::new_in_memory(
+            rx,
+            head_hash,
+            genesis_config,
+            0x03421ee50df45cacu64,
+            head_hash,
+            repository,
+        );
+        let state_handle = state.spawn();
+
+        // Set head block hash
+        let msg = StateMessage::UpdateHead {
+            block_hash: head_hash,
+        };
+        state_channel.send(msg).await.unwrap();
+
+        // Update the state with an execution payload
+        forkchoice_updated::execute_v3(
+            forkchoice_updated::tests::example_request(),
+            state_channel.clone(),
+        )
         .await
         .unwrap();
 
-    let request: serde_json::Value = serde_json::from_str(
-        r#"
-        {
-            "id": 30054,
-            "jsonrpc": "2.0",
-            "method": "engine_getPayloadV3",
-            "params": [
-                "0x03421ee50df45cac"
-            ]
-        }
-    "#,
-    )
-    .unwrap();
+        let request: serde_json::Value = serde_json::from_str(
+            r#"
+            {
+                "id": 30054,
+                "jsonrpc": "2.0",
+                "method": "engine_getPayloadV3",
+                "params": [
+                    "0x03421ee50df45cac"
+                ]
+            }
+        "#,
+        )
+        .unwrap();
 
-    let expected_response: serde_json::Value = serde_json::from_str(r#"
-        {
-            "executionPayload": {
-                "parentHash": "0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d",
-                "feeRecipient": "0x4200000000000000000000000000000000000011",
-                "stateRoot": "0xf3a022e9d83ae2c38348e3b726a1ec25a9d6a5c2a15913d187e8beaa1c3b5d7d",
-                "receiptsRoot": "0x6f1da088070d8d62a333ef7a100f6b850b24de6ad964611823e33d6541aea16a",
-                "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                "prevRandao": "0xbde07f5d381bb84700433fe6c0ae077aa40eaad3a5de7abd298f0e3e27e6e4c9",
-                "blockNumber": "0x1",
-                "gasLimit": "0x1c9c380",
-                "gasUsed": "0x7",
-                "timestamp": "0x6660737b",
-                "extraData": "0x",
-                "baseFeePerGas": "0x0",
-                "blockHash": "0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d",
-                "transactions": [
-                "0x7ef8f8a0de86bef815fc910df65a9459ccb2b9a35fa8596dfcfed1ff01bbf28891d86d5e94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e2000000558000c5fc50000000000000000000000006660735b00000000000001a9000000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000017ae3f74f0134521a7d62a387ac75a5153bcd1aab1c7e003e9b9e15a5d8846363000000000000000000000000e25583099ba105d9ec0a67f5ae86d90e50036425"
-                ],
-                "withdrawals": [],
-                "blobGasUsed": "0x0",
-                "excessBlobGas": "0x0"
-            },
-            "blockValue": "0x0",
-            "blobsBundle": {
-                "commitments": [],
-                "proofs": [],
-                "blobs": []
-            },
-            "shouldOverrideBuilder": false,
-            "parentBeaconBlockRoot": "0x2bd857e239f7e5b5e6415608c76b90600d51fa0f7f0bbbc04e2d6861b3186f1c"
-        }
-    "#).unwrap();
+        let expected_response: serde_json::Value = serde_json::from_str(r#"
+            {
+                "executionPayload": {
+                    "parentHash": "0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d",
+                    "feeRecipient": "0x4200000000000000000000000000000000000011",
+                    "stateRoot": "0xf3a022e9d83ae2c38348e3b726a1ec25a9d6a5c2a15913d187e8beaa1c3b5d7d",
+                    "receiptsRoot": "0x6f1da088070d8d62a333ef7a100f6b850b24de6ad964611823e33d6541aea16a",
+                    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "prevRandao": "0xbde07f5d381bb84700433fe6c0ae077aa40eaad3a5de7abd298f0e3e27e6e4c9",
+                    "blockNumber": "0x1",
+                    "gasLimit": "0x1c9c380",
+                    "gasUsed": "0x7",
+                    "timestamp": "0x6660737b",
+                    "extraData": "0x",
+                    "baseFeePerGas": "0x0",
+                    "blockHash": "0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d",
+                    "transactions": [
+                    "0x7ef8f8a0de86bef815fc910df65a9459ccb2b9a35fa8596dfcfed1ff01bbf28891d86d5e94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e2000000558000c5fc50000000000000000000000006660735b00000000000001a9000000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000017ae3f74f0134521a7d62a387ac75a5153bcd1aab1c7e003e9b9e15a5d8846363000000000000000000000000e25583099ba105d9ec0a67f5ae86d90e50036425"
+                    ],
+                    "withdrawals": [],
+                    "blobGasUsed": "0x0",
+                    "excessBlobGas": "0x0"
+                },
+                "blockValue": "0x0",
+                "blobsBundle": {
+                    "commitments": [],
+                    "proofs": [],
+                    "blobs": []
+                },
+                "shouldOverrideBuilder": false,
+                "parentBeaconBlockRoot": "0x2bd857e239f7e5b5e6415608c76b90600d51fa0f7f0bbbc04e2d6861b3186f1c"
+            }
+        "#).unwrap();
 
-    let response = execute_v3(request, state_channel).await.unwrap();
+        let response = execute_v3(request, state_channel).await.unwrap();
 
-    assert_eq!(response, expected_response);
-    state_handle.await.unwrap();
+        assert_eq!(response, expected_response);
+        state_handle.await.unwrap();
+    }
 }

--- a/moved/src/methods/new_payload.rs
+++ b/moved/src/methods/new_payload.rs
@@ -11,18 +11,6 @@ use {
     tokio::sync::{mpsc, oneshot},
 };
 
-#[cfg(test)]
-use {
-    crate::{
-        block::{Block, BlockRepository, BlockWithHash, InMemoryBlockRepository},
-        genesis::config::GenesisConfig,
-        methods::{forkchoice_updated, get_payload},
-        primitives::{Address, Bytes, B2048, U256, U64},
-    },
-    alloy_primitives::hex,
-    std::str::FromStr,
-};
-
 pub async fn execute_v3(
     request: serde_json::Value,
     state_channel: mpsc::Sender<StateMessage>,
@@ -196,144 +184,24 @@ fn validate_payload(
     })
 }
 
-#[test]
-fn test_parse_params_v3() {
-    let request: serde_json::Value = serde_json::from_str(
-        r#"
-        {
-            "jsonrpc": "2.0",
-            "id": 9,
-            "method": "engine_newPayloadV3",
-            "params": [
-            {
-                "parentHash": "0x781f09c5b7629a7ca30668e440ea40557f01461ad6f105b371f61ff5824b2449",
-                "feeRecipient": "0x4200000000000000000000000000000000000011",
-                "stateRoot": "0x316850949fd480573fec2a2cb07c9c22d7f18a390d9ad4b6847a4326b1a4a5eb",
-                "receiptsRoot": "0x619a992b2d1905328560c3bd9c7fc79b57f012afbff3de92d7a82cfdf8aa186c",
-                "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                "prevRandao": "0x5e52abb859f1fff3a4bf38e076b67815214e8cff662055549b91ba33f5cb7fba",
-                "blockNumber": "0x1",
-                "gasLimit": "0x1c9c380",
-                "gasUsed": "0x2728a",
-                "timestamp": "0x666c9d8d",
-                "extraData": "0x",
-                "baseFeePerGas": "0x3b5dc100",
-                "blockHash": "0xc013e1ff1b8bca9f0d074618cc9e661983bc91d7677168b156765781aee775d3",
-                "transactions": [
-                "0x7ef8f8a0d449f5de7f558fa593dce80637d3a3f52cfaaee2913167371dd6ffd9014e431d94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e20000f424000000000000000000000000100000000666c9d8b0000000000000028000000000000000000000000000000000000000000000000000000000049165f0000000000000000000000000000000000000000000000000000000000000001d05450763214e6060d285b39ef5fe51ef9526395e5cef6ecb27ba06f9598f27d000000000000000000000000e25583099ba105d9ec0a67f5ae86d90e50036425"
-                ],
-                "withdrawals": [],
-                "blobGasUsed": "0x0",
-                "excessBlobGas": "0x0"
-            },
-            [],
-            "0x1a274bb1e783ec35804dee78ec3d7cecd03371f311b2f946500613e994f024a5"
-            ]
-        }
-    "#,
-    )
-    .unwrap();
-
-    let params = parse_params_v3(request).unwrap();
-
-    let expected_params = (
-        ExecutionPayloadV3 {
-            parent_hash: B256::from_str("0x781f09c5b7629a7ca30668e440ea40557f01461ad6f105b371f61ff5824b2449").unwrap(),
-            fee_recipient: Address::from_str("0x4200000000000000000000000000000000000011").unwrap(),
-            state_root: B256::from_str("0x316850949fd480573fec2a2cb07c9c22d7f18a390d9ad4b6847a4326b1a4a5eb").unwrap(),
-            receipts_root: B256::from_str("0x619a992b2d1905328560c3bd9c7fc79b57f012afbff3de92d7a82cfdf8aa186c").unwrap(),
-            logs_bloom: B2048::ZERO,
-            prev_randao: B256::from_str("0x5e52abb859f1fff3a4bf38e076b67815214e8cff662055549b91ba33f5cb7fba").unwrap(),
-            block_number: U64::from(1u64),
-            gas_limit: U64::from_str("0x1c9c380").unwrap(),
-            gas_used: U64::from_str("0x2728a").unwrap(),
-            timestamp: U64::from_str("0x666c9d8d").unwrap(),
-            extra_data: Vec::new().into(),
-            base_fee_per_gas: U256::from_str("0x3b5dc100").unwrap(),
-            block_hash: B256::from_str("0xc013e1ff1b8bca9f0d074618cc9e661983bc91d7677168b156765781aee775d3").unwrap(),
-            transactions: vec![
-                Bytes::from_str("0x7ef8f8a0d449f5de7f558fa593dce80637d3a3f52cfaaee2913167371dd6ffd9014e431d94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e20000f424000000000000000000000000100000000666c9d8b0000000000000028000000000000000000000000000000000000000000000000000000000049165f0000000000000000000000000000000000000000000000000000000000000001d05450763214e6060d285b39ef5fe51ef9526395e5cef6ecb27ba06f9598f27d000000000000000000000000e25583099ba105d9ec0a67f5ae86d90e50036425").unwrap()
-            ],
-            withdrawals: Vec::new(),
-            blob_gas_used: U64::ZERO,
-            excess_blob_gas: U64::ZERO,
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            block::{Block, BlockRepository, BlockWithHash, InMemoryBlockRepository},
+            genesis::config::GenesisConfig,
+            methods::{forkchoice_updated, get_payload},
+            primitives::{Address, Bytes, B2048, U256, U64},
         },
-        Vec::new(),
-        B256::from_str("0x1a274bb1e783ec35804dee78ec3d7cecd03371f311b2f946500613e994f024a5").unwrap()
-    );
+        alloy_primitives::hex,
+        std::str::FromStr,
+    };
 
-    assert_eq!(params, expected_params);
-}
-
-#[tokio::test]
-async fn test_execute_v3() {
-    let genesis_config = GenesisConfig::default();
-    let (state_channel, rx) = tokio::sync::mpsc::channel(10);
-
-    // Set known block height
-    let head_hash =
-        B256::from_str("0x781f09c5b7629a7ca30668e440ea40557f01461ad6f105b371f61ff5824b2449")
-            .unwrap();
-    let genesis_block = BlockWithHash::new(head_hash, Block::default());
-
-    let mut repository = InMemoryBlockRepository::new();
-    repository.add(genesis_block);
-
-    let state = crate::state_actor::StateActor::new_in_memory(
-        rx,
-        head_hash,
-        genesis_config,
-        0x0306d51fc5aa1533u64,
-        B256::from(hex!(
-            "c013e1ff1b8bca9f0d074618cc9e661983bc91d7677168b156765781aee775d3"
-        )),
-        repository,
-    );
-    let state_handle = state.spawn();
-
-    let fc_updated_request: serde_json::Value = serde_json::from_str(
-        r#"
-            {
-                "jsonrpc": "2.0",
-                "id": 7,
-                "method": "engine_forkchoiceUpdatedV3",
-                "params": [
-                {
-                    "headBlockHash": "0x781f09c5b7629a7ca30668e440ea40557f01461ad6f105b371f61ff5824b2449",
-                    "safeBlockHash": "0x781f09c5b7629a7ca30668e440ea40557f01461ad6f105b371f61ff5824b2449",
-                    "finalizedBlockHash": "0x781f09c5b7629a7ca30668e440ea40557f01461ad6f105b371f61ff5824b2449"
-                },
-                {
-                    "timestamp": "0x666c9d8d",
-                    "prevRandao": "0x5e52abb859f1fff3a4bf38e076b67815214e8cff662055549b91ba33f5cb7fba",
-                    "suggestedFeeRecipient": "0x4200000000000000000000000000000000000011",
-                    "withdrawals": [],
-                    "parentBeaconBlockRoot": "0x1a274bb1e783ec35804dee78ec3d7cecd03371f311b2f946500613e994f024a5",
-                    "transactions": [
-                    "0x7ef8f8a0d449f5de7f558fa593dce80637d3a3f52cfaaee2913167371dd6ffd9014e431d94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e20000f424000000000000000000000000100000000666c9d8b0000000000000028000000000000000000000000000000000000000000000000000000000049165f0000000000000000000000000000000000000000000000000000000000000001d05450763214e6060d285b39ef5fe51ef9526395e5cef6ecb27ba06f9598f27d000000000000000000000000e25583099ba105d9ec0a67f5ae86d90e50036425"
-                    ],
-                    "gasLimit": "0x1c9c380"
-                }
-                ]
-            }
-    "#,
-    )
-    .unwrap();
-    let get_payload_request: serde_json::Value = serde_json::from_str(
-        r#"
-            {
-                "jsonrpc": "2.0",
-                "id": 8,
-                "method": "engine_getPayloadV3",
-                "params": [
-                    "0x0306d51fc5aa1533"
-                ]
-            }
-    "#,
-    )
-    .unwrap();
-    let new_payload_request: serde_json::Value = serde_json::from_str(
-        r#"
+    #[test]
+    fn test_parse_params_v3() {
+        let request: serde_json::Value = serde_json::from_str(
+            r#"
             {
                 "jsonrpc": "2.0",
                 "id": 9,
@@ -364,33 +232,167 @@ async fn test_execute_v3() {
                 "0x1a274bb1e783ec35804dee78ec3d7cecd03371f311b2f946500613e994f024a5"
                 ]
             }
-    "#,
-    )
-    .unwrap();
+        "#,
+        ).unwrap();
 
-    forkchoice_updated::execute_v3(fc_updated_request, state_channel.clone())
-        .await
+        let params = parse_params_v3(request).unwrap();
+
+        let expected_params = (
+            ExecutionPayloadV3 {
+                parent_hash: B256::from_str("0x781f09c5b7629a7ca30668e440ea40557f01461ad6f105b371f61ff5824b2449").unwrap(),
+                fee_recipient: Address::from_str("0x4200000000000000000000000000000000000011").unwrap(),
+                state_root: B256::from_str("0x316850949fd480573fec2a2cb07c9c22d7f18a390d9ad4b6847a4326b1a4a5eb").unwrap(),
+                receipts_root: B256::from_str("0x619a992b2d1905328560c3bd9c7fc79b57f012afbff3de92d7a82cfdf8aa186c").unwrap(),
+                logs_bloom: B2048::ZERO,
+                prev_randao: B256::from_str("0x5e52abb859f1fff3a4bf38e076b67815214e8cff662055549b91ba33f5cb7fba").unwrap(),
+                block_number: U64::from(1u64),
+                gas_limit: U64::from_str("0x1c9c380").unwrap(),
+                gas_used: U64::from_str("0x2728a").unwrap(),
+                timestamp: U64::from_str("0x666c9d8d").unwrap(),
+                extra_data: Vec::new().into(),
+                base_fee_per_gas: U256::from_str("0x3b5dc100").unwrap(),
+                block_hash: B256::from_str("0xc013e1ff1b8bca9f0d074618cc9e661983bc91d7677168b156765781aee775d3").unwrap(),
+                transactions: vec![
+                    Bytes::from_str("0x7ef8f8a0d449f5de7f558fa593dce80637d3a3f52cfaaee2913167371dd6ffd9014e431d94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e20000f424000000000000000000000000100000000666c9d8b0000000000000028000000000000000000000000000000000000000000000000000000000049165f0000000000000000000000000000000000000000000000000000000000000001d05450763214e6060d285b39ef5fe51ef9526395e5cef6ecb27ba06f9598f27d000000000000000000000000e25583099ba105d9ec0a67f5ae86d90e50036425").unwrap()
+                ],
+                withdrawals: Vec::new(),
+                blob_gas_used: U64::ZERO,
+                excess_blob_gas: U64::ZERO,
+            },
+            Vec::new(),
+            B256::from_str("0x1a274bb1e783ec35804dee78ec3d7cecd03371f311b2f946500613e994f024a5").unwrap()
+        );
+
+        assert_eq!(params, expected_params);
+    }
+
+    #[tokio::test]
+    async fn test_execute_v3() {
+        let genesis_config = GenesisConfig::default();
+        let (state_channel, rx) = tokio::sync::mpsc::channel(10);
+
+        // Set known block height
+        let head_hash =
+            B256::from_str("0x781f09c5b7629a7ca30668e440ea40557f01461ad6f105b371f61ff5824b2449")
+                .unwrap();
+        let genesis_block = BlockWithHash::new(head_hash, Block::default());
+
+        let mut repository = InMemoryBlockRepository::new();
+        repository.add(genesis_block);
+
+        let state = crate::state_actor::StateActor::new_in_memory(
+            rx,
+            head_hash,
+            genesis_config,
+            0x0306d51fc5aa1533u64,
+            B256::from(hex!(
+                "c013e1ff1b8bca9f0d074618cc9e661983bc91d7677168b156765781aee775d3"
+            )),
+            repository,
+        );
+        let state_handle = state.spawn();
+
+        let fc_updated_request: serde_json::Value = serde_json::from_str(
+            r#"
+                {
+                    "jsonrpc": "2.0",
+                    "id": 7,
+                    "method": "engine_forkchoiceUpdatedV3",
+                    "params": [
+                    {
+                        "headBlockHash": "0x781f09c5b7629a7ca30668e440ea40557f01461ad6f105b371f61ff5824b2449",
+                        "safeBlockHash": "0x781f09c5b7629a7ca30668e440ea40557f01461ad6f105b371f61ff5824b2449",
+                        "finalizedBlockHash": "0x781f09c5b7629a7ca30668e440ea40557f01461ad6f105b371f61ff5824b2449"
+                    },
+                    {
+                        "timestamp": "0x666c9d8d",
+                        "prevRandao": "0x5e52abb859f1fff3a4bf38e076b67815214e8cff662055549b91ba33f5cb7fba",
+                        "suggestedFeeRecipient": "0x4200000000000000000000000000000000000011",
+                        "withdrawals": [],
+                        "parentBeaconBlockRoot": "0x1a274bb1e783ec35804dee78ec3d7cecd03371f311b2f946500613e994f024a5",
+                        "transactions": [
+                        "0x7ef8f8a0d449f5de7f558fa593dce80637d3a3f52cfaaee2913167371dd6ffd9014e431d94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e20000f424000000000000000000000000100000000666c9d8b0000000000000028000000000000000000000000000000000000000000000000000000000049165f0000000000000000000000000000000000000000000000000000000000000001d05450763214e6060d285b39ef5fe51ef9526395e5cef6ecb27ba06f9598f27d000000000000000000000000e25583099ba105d9ec0a67f5ae86d90e50036425"
+                        ],
+                        "gasLimit": "0x1c9c380"
+                    }
+                    ]
+                }
+        "#,
+        )
+            .unwrap();
+        let get_payload_request: serde_json::Value = serde_json::from_str(
+            r#"
+                {
+                    "jsonrpc": "2.0",
+                    "id": 8,
+                    "method": "engine_getPayloadV3",
+                    "params": [
+                        "0x0306d51fc5aa1533"
+                    ]
+                }
+        "#,
+        )
+        .unwrap();
+        let new_payload_request: serde_json::Value = serde_json::from_str(
+            r#"
+                {
+                    "jsonrpc": "2.0",
+                    "id": 9,
+                    "method": "engine_newPayloadV3",
+                    "params": [
+                    {
+                        "parentHash": "0x781f09c5b7629a7ca30668e440ea40557f01461ad6f105b371f61ff5824b2449",
+                        "feeRecipient": "0x4200000000000000000000000000000000000011",
+                        "stateRoot": "0x316850949fd480573fec2a2cb07c9c22d7f18a390d9ad4b6847a4326b1a4a5eb",
+                        "receiptsRoot": "0x619a992b2d1905328560c3bd9c7fc79b57f012afbff3de92d7a82cfdf8aa186c",
+                        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                        "prevRandao": "0x5e52abb859f1fff3a4bf38e076b67815214e8cff662055549b91ba33f5cb7fba",
+                        "blockNumber": "0x1",
+                        "gasLimit": "0x1c9c380",
+                        "gasUsed": "0x2728a",
+                        "timestamp": "0x666c9d8d",
+                        "extraData": "0x",
+                        "baseFeePerGas": "0x3b5dc100",
+                        "blockHash": "0xc013e1ff1b8bca9f0d074618cc9e661983bc91d7677168b156765781aee775d3",
+                        "transactions": [
+                        "0x7ef8f8a0d449f5de7f558fa593dce80637d3a3f52cfaaee2913167371dd6ffd9014e431d94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e20000f424000000000000000000000000100000000666c9d8b0000000000000028000000000000000000000000000000000000000000000000000000000049165f0000000000000000000000000000000000000000000000000000000000000001d05450763214e6060d285b39ef5fe51ef9526395e5cef6ecb27ba06f9598f27d000000000000000000000000e25583099ba105d9ec0a67f5ae86d90e50036425"
+                        ],
+                        "withdrawals": [],
+                        "blobGasUsed": "0x0",
+                        "excessBlobGas": "0x0"
+                    },
+                    [],
+                    "0x1a274bb1e783ec35804dee78ec3d7cecd03371f311b2f946500613e994f024a5"
+                    ]
+                }
+        "#,
+        )
         .unwrap();
 
-    get_payload::execute_v3(get_payload_request, state_channel.clone())
-        .await
-        .unwrap();
+        forkchoice_updated::execute_v3(fc_updated_request, state_channel.clone())
+            .await
+            .unwrap();
 
-    let response = execute_v3(new_payload_request, state_channel)
-        .await
-        .unwrap();
+        get_payload::execute_v3(get_payload_request, state_channel.clone())
+            .await
+            .unwrap();
 
-    let expected_response: serde_json::Value = serde_json::from_str(
-        r#"
+        let response = execute_v3(new_payload_request, state_channel)
+            .await
+            .unwrap();
+
+        let expected_response: serde_json::Value = serde_json::from_str(
+            r#"
             {
                 "status": "VALID",
                 "latestValidHash": "0xc013e1ff1b8bca9f0d074618cc9e661983bc91d7677168b156765781aee775d3",
                 "validationError": null
             }
-    "#,
-    )
-    .unwrap();
+            "#,
+        )
+        .unwrap();
 
-    assert_eq!(response, expected_response);
-    state_handle.await.unwrap();
+        assert_eq!(response, expected_response);
+        state_handle.await.unwrap();
+    }
 }


### PR DESCRIPTION
Moves tests into a tests module where it is conventional to keep them.

Keeping them outside makes it harder for maintanence such as keeping `use` statements correctly marked with `#[cfg(tests)]` and is overall messier.