### PR TITLE
refactor(state_actor): Remove side effects from constructors

### DIFF
--- a/moved/src/genesis/framework.rs
+++ b/moved/src/genesis/framework.rs
@@ -69,10 +69,10 @@ pub fn load_sui_framework_snapshot() -> &'static BTreeMap<ObjectID, SystemPackag
     &SUI_SYSTEM_PACKAGES
 }
 
-/// Initializes the in-memory storage with Aptos and Sui frameworks.
-pub fn init_storage(config: &GenesisConfig, storage: &mut impl State<Err = PartialVMError>) {
+/// Initializes the blockchain state with Aptos and Sui frameworks.
+pub fn init_state(config: &GenesisConfig, state: &mut impl State<Err = PartialVMError>) {
     let (change_set, table_change_set) =
-        deploy_framework(storage).expect("All bundle modules should be valid");
+        deploy_framework(state).expect("All bundle modules should be valid");
 
     // This function converts a `TableChange` to a move table extension struct.
     // InMemoryStorage relies on this conversion to apply the storage changes correctly.
@@ -102,11 +102,11 @@ pub fn init_storage(config: &GenesisConfig, storage: &mut impl State<Err = Parti
             .collect(),
     };
 
-    storage
+    state
         .apply_with_tables(change_set, table_change_set)
         .unwrap();
 
-    let actual_state_root = storage.state_root();
+    let actual_state_root = state.state_root();
     let expected_state_root = config.initial_state_root;
 
     assert_eq!(

--- a/moved/src/genesis/mod.rs
+++ b/moved/src/genesis/mod.rs
@@ -1,4 +1,4 @@
 pub mod config;
 mod framework;
 
-pub use framework::{init_storage, FRAMEWORK_ADDRESS};
+pub use framework::{init_state, FRAMEWORK_ADDRESS};

--- a/moved/src/lib.rs
+++ b/moved/src/lib.rs
@@ -15,8 +15,10 @@ use {
             Block, BlockHash, BlockRepository, BlockWithHash, Header, InMemoryBlockRepository,
             MovedBlockHash,
         },
+        genesis::init_state,
         primitives::B256,
         state_actor::StatePayloadId,
+        storage::InMemoryState,
     },
     clap::Parser,
     flate2::read::GzDecoder,
@@ -90,8 +92,12 @@ pub async fn run() {
     let head = genesis_block.hash;
     repository.add(genesis_block);
 
-    let state = state_actor::StateActor::new_in_memory(
+    let mut state = InMemoryState::new();
+    init_state(&genesis_config, &mut state);
+
+    let state = state_actor::StateActor::new(
         rx,
+        state,
         head,
         genesis_config,
         StatePayloadId,

--- a/moved/src/methods/forkchoice_updated.rs
+++ b/moved/src/methods/forkchoice_updated.rs
@@ -95,8 +95,9 @@ pub(super) mod tests {
         super::*,
         crate::{
             block::{Block, BlockRepository, BlockWithHash, InMemoryBlockRepository},
-            genesis::config::GenesisConfig,
+            genesis::{config::GenesisConfig, init_state},
             primitives::{Address, Bytes, B256, U64},
+            storage::InMemoryState,
         },
         alloy_primitives::hex,
     };
@@ -234,8 +235,12 @@ pub(super) mod tests {
         let mut repository = InMemoryBlockRepository::new();
         repository.add(genesis_block);
 
-        let state = crate::state_actor::StateActor::new_in_memory(
+        let mut state = InMemoryState::new();
+        init_state(&genesis_config, &mut state);
+
+        let state = crate::state_actor::StateActor::new(
             rx,
+            state,
             head_hash,
             genesis_config,
             0x03421ee50df45cacu64,

--- a/moved/src/methods/get_payload.rs
+++ b/moved/src/methods/get_payload.rs
@@ -66,9 +66,10 @@ mod tests {
         super::*,
         crate::{
             block::{Block, BlockRepository, BlockWithHash, InMemoryBlockRepository},
-            genesis::config::GenesisConfig,
+            genesis::{config::GenesisConfig, init_state},
             methods::forkchoice_updated,
             primitives::B256,
+            storage::InMemoryState,
         },
         alloy_primitives::hex,
     };
@@ -110,8 +111,12 @@ mod tests {
         let mut repository = InMemoryBlockRepository::new();
         repository.add(genesis_block);
 
-        let state = crate::state_actor::StateActor::new_in_memory(
+        let mut state = InMemoryState::new();
+        init_state(&genesis_config, &mut state);
+
+        let state = crate::state_actor::StateActor::new(
             rx,
+            state,
             head_hash,
             genesis_config,
             0x03421ee50df45cacu64,

--- a/moved/src/methods/new_payload.rs
+++ b/moved/src/methods/new_payload.rs
@@ -190,9 +190,10 @@ mod tests {
         super::*,
         crate::{
             block::{Block, BlockRepository, BlockWithHash, InMemoryBlockRepository},
-            genesis::config::GenesisConfig,
+            genesis::{config::GenesisConfig, init_state},
             methods::{forkchoice_updated, get_payload},
             primitives::{Address, Bytes, B2048, U256, U64},
+            storage::InMemoryState,
         },
         alloy_primitives::hex,
     };
@@ -279,8 +280,12 @@ mod tests {
         let mut repository = InMemoryBlockRepository::new();
         repository.add(genesis_block);
 
-        let state = crate::state_actor::StateActor::new_in_memory(
+        let mut state = InMemoryState::new();
+        init_state(&genesis_config, &mut state);
+
+        let state = crate::state_actor::StateActor::new(
             rx,
+            state,
             head_hash,
             genesis_config,
             0x0306d51fc5aa1533u64,

--- a/moved/src/methods/send_raw_transaction.rs
+++ b/moved/src/methods/send_raw_transaction.rs
@@ -60,15 +60,18 @@ async fn inner_execute(
 mod tests {
     use {
         super::*,
-        crate::{block::InMemoryBlockRepository, state_actor::StatePayloadId},
+        crate::{
+            block::InMemoryBlockRepository, state_actor::StatePayloadId, storage::InMemoryState,
+        },
     };
 
     #[tokio::test]
     async fn test_execute() {
         let genesis_config = crate::genesis::config::GenesisConfig::default();
         let (state_channel, rx) = tokio::sync::mpsc::channel(10);
-        let state = crate::state_actor::StateActor::new_in_memory(
+        let state = crate::state_actor::StateActor::new(
             rx,
+            InMemoryState::new(),
             B256::ZERO,
             genesis_config,
             StatePayloadId,

--- a/moved/src/move_execution/tests.rs
+++ b/moved/src/move_execution/tests.rs
@@ -1,7 +1,7 @@
 use {
     super::*,
     crate::{
-        genesis::{config::CHAIN_ID, init_storage},
+        genesis::{config::CHAIN_ID, init_state},
         primitives::{ToMoveAddress, B256, U256, U64},
         storage::{InMemoryState, State},
         tests::{signer::Signer, EVM_ADDRESS, PRIVATE_KEY},
@@ -765,7 +765,7 @@ fn deploy_contract(
     genesis_config: &GenesisConfig,
 ) -> (ModuleId, InMemoryState) {
     let mut state = InMemoryState::new();
-    init_storage(genesis_config, &mut state);
+    init_state(genesis_config, &mut state);
 
     let move_address = EVM_ADDRESS.to_move_address();
 


### PR DESCRIPTION
* Remove `new_in_memory` contructor
State actor should not be responsible for creating its own dependencies. That would be against dependency inversion.
* Remove side effect in `new` contructor. In the constructor a call to deploy frameworks create initial blockchain state, which may be unintended. Constructor should be responsible only for creating the instance, not for initializing the blockchain state. That makes two things untangeable and could work against us, for example, when starting the node from non empty state.
