### PR TITLE
feat: Compute transactions root

### DIFF
--- a/moved/src/block/root.rs
+++ b/moved/src/block/root.rs
@@ -140,6 +140,11 @@ impl Header {
         self
     }
 
+    pub fn with_transactions_root(mut self, transactions_root: B256) -> Self {
+        self.transactions_root = transactions_root;
+        self
+    }
+
     pub fn with_base_fee_per_gas(mut self, base_fee_per_gas: U256) -> Self {
         self.base_fee_per_gas = base_fee_per_gas;
         self

--- a/moved/src/state_actor.rs
+++ b/moved/src/state_actor.rs
@@ -173,15 +173,21 @@ impl<
 
         let execution_outcome = self.execute_transactions(&transactions);
 
+        let transactions_root = transactions
+            .iter()
+            .map(|(.., tx)| tx)
+            .map(alloy_rlp::encode)
+            .map(keccak256)
+            .merkle_root();
         let parent = self
             .block_repository
             .by_hash(self.head)
             .expect("Parent block should exist");
-        // TODO: Compute `transaction_root`
         // TODO: Compute `withdrawals_root`
         let header = Header::new(self.head, self.height + 1)
             .with_payload_attributes(payload_attributes)
             .with_execution_outcome(execution_outcome)
+            .with_transactions_root(transactions_root)
             .with_base_fee_per_gas(self.gas_fee.base_fee_per_gas(
                 parent.block.header.gas_limit,
                 parent.block.header.gas_used,


### PR DESCRIPTION
Closes #103 

The `transactionsRoot` is one of the block header's attributes. It is a root of a merkle trie where the leaf nodes are the transactions included in the block.

Previously we had this field as a part of the block header set to a constant value of zero.

This PR implements the proper transactions trie root calculation and sets it to the block header.