### PR TITLE
Remove integration test artifacts in the order created

### DIFF
--- a/server/src/tests/integration.rs
+++ b/server/src/tests/integration.rs
@@ -444,19 +444,20 @@ async fn deploy_erc20_token() -> Result<()> {
 fn cleanup_files() -> Result<()> {
     let base = "src/tests/optimism/packages/contracts-bedrock";
     std::fs::remove_dir_all("src/tests/optimism/l1_datadir")?;
-    std::fs::remove_dir_all("src/tests/optimism/datadir")?;
+    std::fs::remove_dir_all(format!("{}/artifacts", base))?;
     std::fs::remove_dir_all(format!("{}/broadcast", base))?;
     std::fs::remove_dir_all(format!("{}/cache", base))?;
     std::fs::remove_dir_all(format!("{}/forge-artifacts", base))?;
     std::fs::remove_file(format!("{}/deploy-config/moved.json", base))?;
-    std::fs::remove_file(format!("{}/deployments/31337-deploy.json", base))?;
     std::fs::remove_file(format!("{}/deployments/1337-deploy.json", base))?;
-    std::fs::remove_file(format!("{}/deployments/genesis.json", base))?;
-    std::fs::remove_file(format!("{}/deployments/jwt.txt", base))?;
-    std::fs::remove_file(format!("{}/deployments/rollup.json", base))?;
+    std::fs::remove_file(format!("{}/deployments/31337-deploy.json", base))?;
     std::fs::remove_file(format!("{}/state-dump-42069.json", base))?;
     std::fs::remove_file(format!("{}/state-dump-42069-delta.json", base))?;
     std::fs::remove_file(format!("{}/state-dump-42069-ecotone.json", base))?;
+    std::fs::remove_file(format!("{}/deployments/genesis.json", base))?;
+    std::fs::remove_file(format!("{}/deployments/jwt.txt", base))?;
+    std::fs::remove_file(format!("{}/deployments/rollup.json", base))?;
+    std::fs::remove_dir_all("src/tests/optimism/datadir")?;
     Ok(())
 }
 


### PR DESCRIPTION
### Description

When you partially run the integration test not all the artifacts are created. So the artifacts don't get fully cleared up for the next run because the `cleanup_files()` function quietly fails when a file doesn't exist, so it doesn't get a chance to delete rest of the artifacts.

### Changes
- Remove the files and folders in the order they are created

### Testing
Tested integration test step by step to check the order of artifacts created