### PR TITLE
Serialize deployed bytecode with higher level script or module enum

### DIFF
--- a/sdk/hardhat-example/yarn.lock
+++ b/sdk/hardhat-example/yarn.lock
@@ -37,6 +37,14 @@
     jwt-decode "^4.0.0"
     poseidon-lite "^0.2.0"
 
+"@benfen/bcs@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@benfen/bcs/-/bcs-0.1.0.tgz#22a8aeba7927ffcfd4b57cb3c97fc281fc4ff260"
+  integrity sha512-68bkzK2zkzTAz4sxSVvY6noPDD0kofwWLKiP2MJT31AykHQ8b9lIl4UdgMnIBka3I9A8Vdb/YvPxGAPbOE6A6Q==
+  dependencies:
+    bs58 "^5.0.0"
+    fast-sha256 "^1.3.0"
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -1244,6 +1252,11 @@ base-x@^3.0.2:
   dependencies:
     safe-buffer "^5.0.1"
 
+base-x@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-4.0.0.tgz#d0e3b7753450c73f8ad2389b5c018a4af7b2224a"
+  integrity sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==
+
 bech32@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
@@ -1338,6 +1351,13 @@ bs58@^4.0.0:
   integrity sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==
   dependencies:
     base-x "^3.0.2"
+
+bs58@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-5.0.0.tgz#865575b4d13c09ea2a84622df6c8cbeb54ffc279"
+  integrity sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==
+  dependencies:
+    base-x "^4.0.0"
 
 bs58check@^2.1.2:
   version "2.1.2"
@@ -2055,6 +2075,11 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-sha256@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-sha256/-/fast-sha256-1.3.0.tgz#7916ba2054eeb255982608cccd0f6660c79b7ae6"
+  integrity sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==
+
 fast-uri@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.1.tgz#cddd2eecfc83a71c1be2cc2ef2061331be8a7134"
@@ -2380,6 +2405,7 @@ hardhat-gas-reporter@^1.0.8:
 "hardhat-moved@file:../hardhat-moved":
   version "0.0.1"
   dependencies:
+    "@benfen/bcs" "^0.1.0"
     "@types/mocha" "^9.1.0"
     neverthrow "^4.3.1"
     toml "^3.0.0"

--- a/sdk/hardhat-moved/package.json
+++ b/sdk/hardhat-moved/package.json
@@ -20,6 +20,7 @@
         "prepublishOnly": "npm run build"
     },
     "dependencies": {
+        "@benfen/bcs": "^0.1.0",
         "@types/mocha": "^9.1.0",
         "neverthrow": "^4.3.1",
         "toml": "^3.0.0",

--- a/sdk/hardhat-moved/yarn.lock
+++ b/sdk/hardhat-moved/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@benfen/bcs@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@benfen/bcs/-/bcs-0.1.0.tgz#22a8aeba7927ffcfd4b57cb3c97fc281fc4ff260"
+  integrity sha512-68bkzK2zkzTAz4sxSVvY6noPDD0kofwWLKiP2MJT31AykHQ8b9lIl4UdgMnIBka3I9A8Vdb/YvPxGAPbOE6A6Q==
+  dependencies:
+    bs58 "^5.0.0"
+    fast-sha256 "^1.3.0"
+
 "@ethersproject/abi@^5.1.2":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.7.0.tgz#b3f3e045bbbeed1af3947335c247ad625a44e449"
@@ -613,6 +621,11 @@ base-x@^3.0.2:
   dependencies:
     safe-buffer "^5.0.1"
 
+base-x@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-4.0.0.tgz#d0e3b7753450c73f8ad2389b5c018a4af7b2224a"
+  integrity sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==
+
 binary-extensions@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
@@ -697,6 +710,13 @@ bs58@^4.0.0:
   integrity sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==
   dependencies:
     base-x "^3.0.2"
+
+bs58@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-5.0.0.tgz#865575b4d13c09ea2a84622df6c8cbeb54ffc279"
+  integrity sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==
+  dependencies:
+    base-x "^4.0.0"
 
 bs58check@^2.1.2:
   version "2.1.2"
@@ -1212,6 +1232,11 @@ evp_bytestokey@^1.0.3:
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
+
+fast-sha256@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-sha256/-/fast-sha256-1.3.0.tgz#7916ba2054eeb255982608cccd0f6660c79b7ae6"
+  integrity sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==
 
 fill-range@^7.1.1:
   version "7.1.1"


### PR DESCRIPTION
### Description

Adds a BCS enum serialization over the module bytecode to match the expected script or module execution selection. Closes #133 

### Changes
- imports a `bcs` package
- Serializes the module inside the `ScriptOrModule` enum

### Testing
Verified to make sure the transaction test BCS bytecode matches the SDK output.