### PR TITLE
feat: Get balance Ethereum API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6448,6 +6448,7 @@ dependencies = [
  "moved",
  "serde",
  "serde_json",
+ "test-case",
  "tokio",
 ]
 

--- a/engine-api/Cargo.toml
+++ b/engine-api/Cargo.toml
@@ -5,11 +5,12 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+alloy.workspace = true
 moved.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
-alloy.workspace = true
 
 [dev-dependencies]
 moved = { workspace = true, features = ["test-doubles"] }
+test-case.workspace = true

--- a/engine-api/src/method_name.rs
+++ b/engine-api/src/method_name.rs
@@ -10,6 +10,7 @@ pub enum MethodName {
     NewPayloadV3,
     SendRawTransaction,
     ChainId,
+    GetBalance,
 }
 
 impl FromStr for MethodName {
@@ -22,6 +23,7 @@ impl FromStr for MethodName {
             "engine_newPayloadV3" => Ok(Self::NewPayloadV3),
             "eth_sendRawTransaction" => Ok(Self::SendRawTransaction),
             "eth_chainId" => Ok(Self::ChainId),
+            "eth_getBalance" => Ok(Self::GetBalance),
             "engine_forkchoiceUpdatedV2" => Ok(Self::ForkChoiceUpdatedV2),
             "engine_getPayloadV2" => Ok(Self::GetPayloadV2),
             "engine_newPayloadV2" => Ok(Self::NewPayloadV2),

--- a/engine-api/src/methods/get_balance.rs
+++ b/engine-api/src/methods/get_balance.rs
@@ -1,0 +1,90 @@
+use {
+    crate::{json_utils, json_utils::access_state_error, jsonrpc::JsonRpcError},
+    alloy::{eips::BlockNumberOrTag, primitives::Address},
+    moved::types::state::StateMessage,
+    serde_json::Value,
+    tokio::sync::{mpsc, oneshot},
+};
+
+pub async fn execute(
+    request: Value,
+    state_channel: mpsc::Sender<StateMessage>,
+) -> Result<Value, JsonRpcError> {
+    let (address, block_number) = parse_params(request)?;
+    let response = inner_execute(address, block_number, state_channel).await?;
+
+    // Format the balance as a hex string
+    Ok(serde_json::to_value(format!("0x{:x}", response))
+        .expect("Must be able to JSON-serialize response"))
+}
+
+fn parse_params(request: Value) -> Result<(Address, BlockNumberOrTag), JsonRpcError> {
+    let params = json_utils::get_params_list(&request);
+    match params {
+        [] => Err(JsonRpcError {
+            code: -32602,
+            data: request,
+            message: "Not enough params".into(),
+        }),
+        [a, b] => {
+            let address: Address = json_utils::deserialize(a)?;
+            let block_number: BlockNumberOrTag = json_utils::deserialize(b)?;
+            Ok((address, block_number))
+        }
+        _ => Err(JsonRpcError {
+            code: -32602,
+            data: request,
+            message: "Too many params".into(),
+        }),
+    }
+}
+
+async fn inner_execute(
+    address: Address,
+    block_number: BlockNumberOrTag,
+    state_channel: mpsc::Sender<StateMessage>,
+) -> Result<u64, JsonRpcError> {
+    let (tx, rx) = oneshot::channel();
+    let msg = StateMessage::GetBalance {
+        address,
+        block_number,
+        response_channel: tx,
+    };
+    state_channel.send(msg).await.map_err(access_state_error)?;
+    let response = rx.await.map_err(access_state_error)?;
+    Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, moved::primitives::U64, std::str::FromStr, test_case::test_case};
+
+    #[test_case("0x1")]
+    #[test_case("latest")]
+    #[test_case("pending")]
+    fn test_parse_params_with_block_number(block: &str) {
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_getBalance",
+            "params": [
+                "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+                block,
+            ],
+            "id": 1
+        });
+
+        let (address, block_number) = parse_params(request).unwrap();
+        assert_eq!(
+            address,
+            Address::from_str("0x742d35Cc6634C0532925a3b844Bc454e4438f44e").unwrap()
+        );
+        match block {
+            "latest" => assert_eq!(block_number, BlockNumberOrTag::Latest),
+            "pending" => assert_eq!(block_number, BlockNumberOrTag::Pending),
+            _ => assert_eq!(
+                block_number,
+                BlockNumberOrTag::Number(U64::from_str(block).unwrap().into_limbs()[0])
+            ),
+        }
+    }
+}

--- a/engine-api/src/methods/get_balance.rs
+++ b/engine-api/src/methods/get_balance.rs
@@ -2,14 +2,13 @@ use {
     crate::{json_utils, json_utils::access_state_error, jsonrpc::JsonRpcError},
     alloy::{eips::BlockNumberOrTag, primitives::Address},
     moved::types::state::StateMessage,
-    serde_json::Value,
     tokio::sync::{mpsc, oneshot},
 };
 
 pub async fn execute(
-    request: Value,
+    request: serde_json::Value,
     state_channel: mpsc::Sender<StateMessage>,
-) -> Result<Value, JsonRpcError> {
+) -> Result<serde_json::Value, JsonRpcError> {
     let (address, block_number) = parse_params(request)?;
     let response = inner_execute(address, block_number, state_channel).await?;
 
@@ -18,7 +17,7 @@ pub async fn execute(
         .expect("Must be able to JSON-serialize response"))
 }
 
-fn parse_params(request: Value) -> Result<(Address, BlockNumberOrTag), JsonRpcError> {
+fn parse_params(request: serde_json::Value) -> Result<(Address, BlockNumberOrTag), JsonRpcError> {
     let params = json_utils::get_params_list(&request);
     match params {
         [] => Err(JsonRpcError {
@@ -57,7 +56,18 @@ async fn inner_execute(
 
 #[cfg(test)]
 mod tests {
-    use {super::*, moved::primitives::U64, std::str::FromStr, test_case::test_case};
+    use {
+        super::*,
+        moved::{
+            block::{Eip1559GasFee, InMemoryBlockRepository},
+            genesis::init_state,
+            primitives::{B256, U256, U64},
+            state_actor::StatePayloadId,
+            storage::InMemoryState,
+        },
+        std::str::FromStr,
+        test_case::test_case,
+    };
 
     #[test_case("0x1")]
     #[test_case("latest")]
@@ -67,7 +77,7 @@ mod tests {
             "jsonrpc": "2.0",
             "method": "eth_getBalance",
             "params": [
-                "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+                "0x0000000000000000000000000000000000000001",
                 block,
             ],
             "id": 1
@@ -76,7 +86,7 @@ mod tests {
         let (address, block_number) = parse_params(request).unwrap();
         assert_eq!(
             address,
-            Address::from_str("0x742d35Cc6634C0532925a3b844Bc454e4438f44e").unwrap()
+            Address::from_str("0x0000000000000000000000000000000000000001").unwrap()
         );
         match block {
             "latest" => assert_eq!(block_number, BlockNumberOrTag::Latest),
@@ -86,5 +96,46 @@ mod tests {
                 BlockNumberOrTag::Number(U64::from_str(block).unwrap().into_limbs()[0])
             ),
         }
+    }
+
+    #[test_case("0x1")]
+    #[test_case("latest")]
+    #[test_case("pending")]
+    #[tokio::test]
+    async fn test_execute(block: &str) {
+        let genesis_config = moved::genesis::config::GenesisConfig::default();
+        let mut state = InMemoryState::new();
+        init_state(&genesis_config, &mut state);
+
+        let (state_channel, rx) = mpsc::channel(10);
+        let state_actor = moved::state_actor::StateActor::new(
+            rx,
+            state,
+            B256::ZERO,
+            genesis_config,
+            StatePayloadId,
+            B256::ZERO,
+            InMemoryBlockRepository::default(),
+            Eip1559GasFee::default(),
+            U256::ZERO,
+            (),
+        );
+
+        let state_handle = state_actor.spawn();
+        let request: serde_json::Value = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_getBalance",
+            "params": [
+                "0x0000000000000000000000000000000000000001",
+                block,
+            ],
+            "id": 1
+        });
+
+        let expected_response: serde_json::Value = serde_json::from_str(r#""0x0""#).unwrap();
+        let response = execute(request, state_channel).await.unwrap();
+
+        assert_eq!(response, expected_response);
+        state_handle.await.unwrap();
     }
 }

--- a/engine-api/src/methods/mod.rs
+++ b/engine-api/src/methods/mod.rs
@@ -1,5 +1,6 @@
 pub mod chain_id;
 pub mod forkchoice_updated;
+pub mod get_balance;
 pub mod get_payload;
 pub mod new_payload;
 pub mod send_raw_transaction;

--- a/engine-api/src/request.rs
+++ b/engine-api/src/request.rs
@@ -48,6 +48,7 @@ async fn inner_handle_request(
         NewPayloadV3 => new_payload::execute_v3(request, state_channel).await,
         SendRawTransaction => send_raw_transaction::execute(request, state_channel).await,
         ChainId => chain_id::execute(state_channel).await,
+        GetBalance => get_balance::execute(request, state_channel).await,
         ForkChoiceUpdatedV2 => todo!(),
         GetPayloadV2 => todo!(),
         NewPayloadV2 => todo!(),

--- a/moved/src/move_execution/eth_token.rs
+++ b/moved/src/move_execution/eth_token.rs
@@ -198,7 +198,8 @@ pub fn get_eth_balance<G: GasMeter>(
     }
 }
 
-/// Simplified API for getting the base token balance for use in tests.
+/// Simplified API for getting the base token balance with no side effects.
+/// Use it only for view methods as it does not use a VM session in the request pipeline.
 pub fn quick_get_eth_balance(
     account: &AccountAddress,
     state: &(impl MoveResolver<PartialVMError> + TableResolver),

--- a/moved/src/move_execution/eth_token.rs
+++ b/moved/src/move_execution/eth_token.rs
@@ -1,18 +1,19 @@
 use {
-    crate::{genesis::FRAMEWORK_ADDRESS, EthToken},
+    crate::{genesis::FRAMEWORK_ADDRESS, types::session_id::SessionId, EthToken},
+    aptos_table_natives::TableResolver,
+    move_binary_format::errors::PartialVMError,
     move_core_types::{
         account_address::AccountAddress, ident_str, identifier::IdentStr,
-        language_storage::ModuleId, value::MoveValue,
+        language_storage::ModuleId, resolver::MoveResolver, value::MoveValue,
     },
-    move_vm_runtime::{module_traversal::TraversalContext, session::Session},
-    move_vm_types::{gas::GasMeter, values::Value},
-};
-
-#[cfg(test)]
-use {
-    crate::types::session_id::SessionId, aptos_table_natives::TableResolver,
-    move_binary_format::errors::PartialVMError, move_core_types::resolver::MoveResolver,
-    move_vm_runtime::module_traversal::TraversalStorage, move_vm_types::gas::UnmeteredGasMeter,
+    move_vm_runtime::{
+        module_traversal::{TraversalContext, TraversalStorage},
+        session::Session,
+    },
+    move_vm_types::{
+        gas::{GasMeter, UnmeteredGasMeter},
+        values::Value,
+    },
 };
 
 const TOKEN_ADMIN: AccountAddress = FRAMEWORK_ADDRESS;
@@ -198,7 +199,6 @@ pub fn get_eth_balance<G: GasMeter>(
 }
 
 /// Simplified API for getting the base token balance for use in tests.
-#[cfg(test)]
 pub fn quick_get_eth_balance(
     account: &AccountAddress,
     state: &(impl MoveResolver<PartialVMError> + TableResolver),

--- a/moved/src/move_execution/mod.rs
+++ b/moved/src/move_execution/mod.rs
@@ -1,5 +1,5 @@
 pub use {
-    eth_token::{BaseTokenAccounts, MovedBaseTokenAccounts},
+    eth_token::{quick_get_eth_balance, BaseTokenAccounts, MovedBaseTokenAccounts},
     gas::{CreateEcotoneL1GasFee, CreateL1GasFee, EcotoneL1GasFee, L1GasFee, L1GasFeeInput},
 };
 

--- a/moved/src/state_actor.rs
+++ b/moved/src/state_actor.rs
@@ -6,10 +6,10 @@ use {
         genesis::config::GenesisConfig,
         merkle_tree::MerkleRootExt,
         move_execution::{
-            execute_transaction, BaseTokenAccounts, CreateL1GasFee, L1GasFee, L1GasFeeInput,
-            LogsBloom,
+            execute_transaction, quick_get_eth_balance, BaseTokenAccounts, CreateL1GasFee,
+            L1GasFee, L1GasFeeInput, LogsBloom,
         },
-        primitives::{ToSaturatedU64, B256, U256, U64},
+        primitives::{ToMoveAddress, ToSaturatedU64, B256, U256, U64},
         storage::State,
         types::{
             state::{
@@ -171,6 +171,16 @@ impl<
             }
             StateMessage::ChainId { response_channel } => {
                 response_channel.send(self.genesis_config.chain_id).ok();
+            }
+            StateMessage::GetBalance {
+                address,
+                response_channel,
+                ..
+            } => {
+                // TODO: Support balance from arbitrary blocks
+                let account = address.to_move_address();
+                let balance = quick_get_eth_balance(&account, self.state.resolver());
+                response_channel.send(balance).ok();
             }
         }
     }

--- a/moved/src/types/session_id.rs
+++ b/moved/src/types/session_id.rs
@@ -15,6 +15,7 @@ use {
 /// his is based on the corresponding [Aptos type](https://github.com/aptos-labs/aptos-core/blob/aptos-node-v1.14.0/aptos-move/aptos-vm/src/move_vm_ext/session/session_id.rs#L16)
 /// plus the extra parameter Aptos includes in its
 /// [session creation function](https://github.com/aptos-labs/aptos-core/blob/aptos-node-v1.14.0/aptos-move/aptos-vm/src/move_vm_ext/vm.rs#L130).
+#[derive(Default)]
 pub struct SessionId {
     pub txn_hash: [u8; 32],
     pub script_hash: Option<[u8; 32]>,
@@ -72,19 +73,6 @@ impl SessionId {
             script_hash: None,
             chain_id,
             user_txn_context: Some(user_context),
-        }
-    }
-}
-
-/// A default session id to use in tests where we don't care about the transaction details.
-#[cfg(test)]
-impl Default for SessionId {
-    fn default() -> Self {
-        Self {
-            txn_hash: [0; 32],
-            script_hash: None,
-            chain_id: 1,
-            user_txn_context: None,
         }
     }
 }

--- a/moved/src/types/state.rs
+++ b/moved/src/types/state.rs
@@ -9,7 +9,7 @@ use {
         primitives::{Address, Bytes, ToU64, B2048, B256, U256, U64},
         state_actor::NewPayloadIdInput,
     },
-    alloy::consensus::transaction::TxEnvelope,
+    alloy::{consensus::transaction::TxEnvelope, eips::BlockNumberOrTag},
     alloy_rlp::Encodable,
     tokio::sync::oneshot,
 };
@@ -93,6 +93,11 @@ pub enum StateMessage {
         tx: TxEnvelope,
     },
     ChainId {
+        response_channel: oneshot::Sender<u64>,
+    },
+    GetBalance {
+        address: Address,
+        block_number: BlockNumberOrTag,
         response_channel: oneshot::Sender<u64>,
     },
 }


### PR DESCRIPTION
### Description
Returns the requested account balance from `eth_token`. Part of #47

### Changes
- Create a new engine API method
- Open up `eth_token`'s quick balance lookup and use it to implement get balance API

### Testing
- Added a few block number parsing tests since they can be string literal or a hex number ie. `"latest"`, `"0x1"`
- Made sure the API gets called via the integration test and an external client like Postman

### Notes
While testing with the integration test, noticed that the `state_channel` gets closed after a few requests. This is happening at the top level server requests and it happens even without this API. Haven't found a solution yet and looking into this issue. If a solution comes up we can include it in this PR or we create a separate bug issue for it.