### PR TITLE
chore: Switch back to Github runners

### DIFF
--- a/.github/workflows/build_and_run_tests.yaml
+++ b/.github/workflows/build_and_run_tests.yaml
@@ -12,7 +12,7 @@ env:
 jobs:
   build_and_run_tests:
     name: latest
-    runs-on: codebuild-MovedNetworkBuild-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/clippy_check.yaml
+++ b/.github/workflows/clippy_check.yaml
@@ -15,7 +15,7 @@ jobs:
     clippy_check:
       name: latest
       permissions: write-all
-      runs-on: codebuild-MovedNetworkBuild-${{ github.run_id }}-${{ github.run_attempt }}
+      runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v4
         - uses: actions-rs/toolchain@v1

--- a/.github/workflows/format_check.yaml
+++ b/.github/workflows/format_check.yaml
@@ -12,7 +12,7 @@ env:
 jobs:
   format_check:
     name: latest
-    runs-on: codebuild-MovedNetworkBuild-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/format_check.yaml
+++ b/.github/workflows/format_check.yaml
@@ -19,5 +19,6 @@ jobs:
         with:
           default: true
           toolchain: nightly
+      - run: rustup component add rustfmt
       - name: format
         run: cargo +nightly fmt -- --check

--- a/.github/workflows/format_check.yaml
+++ b/.github/workflows/format_check.yaml
@@ -19,6 +19,6 @@ jobs:
         with:
           default: true
           toolchain: nightly
-      - run: rustup component add rustfmt
+      - run: rustup component add --toolchain nightly rustfmt
       - name: format
         run: cargo +nightly fmt -- --check


### PR DESCRIPTION
### Description
Now that the repo is public, we can switch back to running the actions on Github machines.

### Changes
- Change `runs-on` back to default `ubuntu-latest`

### Testing
The PR's checks will run the checks