### PR TITLE
feat: Chain Id Ethereum API

### DIFF
--- a/engine-api/src/method_name.rs
+++ b/engine-api/src/method_name.rs
@@ -9,6 +9,7 @@ pub enum MethodName {
     GetPayloadV3,
     NewPayloadV3,
     SendRawTransaction,
+    ChainId,
 }
 
 impl FromStr for MethodName {
@@ -20,6 +21,7 @@ impl FromStr for MethodName {
             "engine_getPayloadV3" => Ok(Self::GetPayloadV3),
             "engine_newPayloadV3" => Ok(Self::NewPayloadV3),
             "eth_sendRawTransaction" => Ok(Self::SendRawTransaction),
+            "eth_chainId" => Ok(Self::ChainId),
             "engine_forkchoiceUpdatedV2" => Ok(Self::ForkChoiceUpdatedV2),
             "engine_getPayloadV2" => Ok(Self::GetPayloadV2),
             "engine_newPayloadV2" => Ok(Self::NewPayloadV2),

--- a/engine-api/src/methods/chain_id.rs
+++ b/engine-api/src/methods/chain_id.rs
@@ -5,7 +5,6 @@ use {
 };
 
 pub async fn execute(
-    _request: serde_json::Value,
     state_channel: mpsc::Sender<StateMessage>,
 ) -> Result<serde_json::Value, JsonRpcError> {
     let response = inner_execute(state_channel).await?;
@@ -52,16 +51,9 @@ mod tests {
         );
         let state_handle = state.spawn();
 
-        let request = serde_json::json!({
-            "id": 30054,
-            "jsonrpc": "2.0",
-            "method": "eth_chainId",
-            "params": []
-        });
-
         let expected_response: serde_json::Value = serde_json::from_str(r#""0x194""#).unwrap();
 
-        let response = execute(request, state_channel).await.unwrap();
+        let response = execute(state_channel).await.unwrap();
 
         assert_eq!(response, expected_response);
         state_handle.await.unwrap();

--- a/engine-api/src/methods/chain_id.rs
+++ b/engine-api/src/methods/chain_id.rs
@@ -52,17 +52,12 @@ mod tests {
         );
         let state_handle = state.spawn();
 
-        let request: serde_json::Value = serde_json::from_str(
-            r#"
-            {
-                "id": 30054,
-                "jsonrpc": "2.0",
-                "method": "eth_chainId",
-                "params": []
-            }
-        "#,
-        )
-        .unwrap();
+        let request = serde_json::json!({
+            "id": 30054,
+            "jsonrpc": "2.0",
+            "method": "eth_chainId",
+            "params": []
+        });
 
         let expected_response: serde_json::Value = serde_json::from_str(r#""0x194""#).unwrap();
 

--- a/engine-api/src/methods/chain_id.rs
+++ b/engine-api/src/methods/chain_id.rs
@@ -1,24 +1,56 @@
 use {
-    crate::jsonrpc::JsonRpcError,
-    moved::{genesis::config::CHAIN_ID, types::state::StateMessage},
-    tokio::sync::mpsc,
+    crate::{json_utils::access_state_error, jsonrpc::JsonRpcError},
+    moved::types::state::StateMessage,
+    tokio::sync::{mpsc, oneshot},
 };
 
 pub async fn execute(
     _request: serde_json::Value,
-    _state_channel: mpsc::Sender<StateMessage>,
+    state_channel: mpsc::Sender<StateMessage>,
 ) -> Result<serde_json::Value, JsonRpcError> {
-    Ok(serde_json::to_value(format!("0x{:x}", CHAIN_ID))
+    let response = inner_execute(state_channel).await?;
+    Ok(serde_json::to_value(format!("{response:#x}"))
         .expect("Must be able to JSON-serialize response"))
+}
+
+async fn inner_execute(state_channel: mpsc::Sender<StateMessage>) -> Result<u64, JsonRpcError> {
+    let (tx, rx) = oneshot::channel();
+    let msg = StateMessage::ChainId {
+        response_channel: tx,
+    };
+    state_channel.send(msg).await.map_err(access_state_error)?;
+    rx.await.map_err(access_state_error)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {
+        super::*,
+        moved::{
+            block::{Eip1559GasFee, InMemoryBlockRepository},
+            primitives::{B256, U256},
+            state_actor::StatePayloadId,
+            storage::InMemoryState,
+        },
+    };
 
     #[tokio::test]
     async fn test_execute() {
-        let (state_channel, _rx) = mpsc::channel(10);
+        let genesis_config = moved::genesis::config::GenesisConfig::default();
+        let (state_channel, rx) = mpsc::channel(10);
+        let state = moved::state_actor::StateActor::new(
+            rx,
+            InMemoryState::new(),
+            B256::ZERO,
+            genesis_config,
+            StatePayloadId,
+            B256::ZERO,
+            InMemoryBlockRepository::default(),
+            Eip1559GasFee::default(),
+            U256::ZERO,
+            (),
+        );
+        let state_handle = state.spawn();
 
         let request: serde_json::Value = serde_json::from_str(
             r#"
@@ -37,5 +69,6 @@ mod tests {
         let response = execute(request, state_channel).await.unwrap();
 
         assert_eq!(response, expected_response);
+        state_handle.await.unwrap();
     }
 }

--- a/engine-api/src/methods/chain_id.rs
+++ b/engine-api/src/methods/chain_id.rs
@@ -1,0 +1,41 @@
+use {
+    crate::jsonrpc::JsonRpcError,
+    moved::{genesis::config::CHAIN_ID, types::state::StateMessage},
+    tokio::sync::mpsc,
+};
+
+pub async fn execute(
+    _request: serde_json::Value,
+    _state_channel: mpsc::Sender<StateMessage>,
+) -> Result<serde_json::Value, JsonRpcError> {
+    Ok(serde_json::to_value(format!("0x{:x}", CHAIN_ID))
+        .expect("Must be able to JSON-serialize response"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_execute() {
+        let (state_channel, _rx) = mpsc::channel(10);
+
+        let request: serde_json::Value = serde_json::from_str(
+            r#"
+            {
+                "id": 30054,
+                "jsonrpc": "2.0",
+                "method": "eth_chainId",
+                "params": []
+            }
+        "#,
+        )
+        .unwrap();
+
+        let expected_response: serde_json::Value = serde_json::from_str(r#""0x194""#).unwrap();
+
+        let response = execute(request, state_channel).await.unwrap();
+
+        assert_eq!(response, expected_response);
+    }
+}

--- a/engine-api/src/methods/mod.rs
+++ b/engine-api/src/methods/mod.rs
@@ -1,3 +1,4 @@
+pub mod chain_id;
 pub mod forkchoice_updated;
 pub mod get_payload;
 pub mod new_payload;

--- a/engine-api/src/request.rs
+++ b/engine-api/src/request.rs
@@ -47,7 +47,7 @@ async fn inner_handle_request(
         GetPayloadV3 => get_payload::execute_v3(request, state_channel).await,
         NewPayloadV3 => new_payload::execute_v3(request, state_channel).await,
         SendRawTransaction => send_raw_transaction::execute(request, state_channel).await,
-        ChainId => chain_id::execute(request, state_channel).await,
+        ChainId => chain_id::execute(state_channel).await,
         ForkChoiceUpdatedV2 => todo!(),
         GetPayloadV2 => todo!(),
         NewPayloadV2 => todo!(),

--- a/engine-api/src/request.rs
+++ b/engine-api/src/request.rs
@@ -47,6 +47,7 @@ async fn inner_handle_request(
         GetPayloadV3 => get_payload::execute_v3(request, state_channel).await,
         NewPayloadV3 => new_payload::execute_v3(request, state_channel).await,
         SendRawTransaction => send_raw_transaction::execute(request, state_channel).await,
+        ChainId => chain_id::execute(request, state_channel).await,
         ForkChoiceUpdatedV2 => todo!(),
         GetPayloadV2 => todo!(),
         NewPayloadV2 => todo!(),

--- a/moved/src/state_actor.rs
+++ b/moved/src/state_actor.rs
@@ -171,6 +171,9 @@ impl<
                 self.mem_pool
                     .insert(tx_hash, (ExtendedTxEnvelope::Canonical(tx), encoded));
             }
+            StateMessage::ChainId { response_channel } => {
+                response_channel.send(self.genesis_config.chain_id).ok();
+            }
         }
     }
 

--- a/moved/src/types/state.rs
+++ b/moved/src/types/state.rs
@@ -34,6 +34,9 @@ pub enum StateMessage {
     AddTransaction {
         tx: TxEnvelope,
     },
+    ChainId {
+        response_channel: oneshot::Sender<u64>,
+    },
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
### Description
Returns the Moved Network chain ID for the `eth_chainId` call. Part of https://github.com/MovedNetwork/op-move/issues/47

### Changes
- Return a static response. There's no need to go through the state channel.

### Testing
- Added a unit test for the `execute` method
- Tested with the integration test. Call to `eth_chainId` returns the chain id in the `op_move_response` as below:
```json
{
  "request": {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "eth_chainId"
  },
  "geth_response": {
    "jsonrpc": "2.0",
    "id": 1,
    "result": "0xa455"
  },
  "op_move_response": {
    "id": 1,
    "jsonrpc": "2.0",
    "result": "0x194"
  },
  "port": "9551"
}
```