### PR TITLE
Fix(transactions): Include script hash in session ID when it is present

### DIFF
--- a/moved/src/move_execution/canonical.rs
+++ b/moved/src/move_execution/canonical.rs
@@ -55,6 +55,7 @@ pub(super) fn execute_canonical_transaction(
         tx_hash,
         genesis_config,
         block_header,
+        tx_data.script_hash(),
     );
     let mut session = create_vm_session(&move_vm, state, session_id);
     let traversal_storage = TraversalStorage::new();

--- a/moved/src/types/session_id.rs
+++ b/moved/src/types/session_id.rs
@@ -32,7 +32,7 @@ impl SessionId {
         tx_hash: &B256,
         genesis_config: &GenesisConfig,
         block_header: HeaderForExecution,
-        script_hash: Option<[u8; 32]>,
+        script_hash: Option<B256>,
     ) -> Self {
         let chain_id = u8_chain_id(genesis_config);
         let sender = tx.signer.to_move_address();
@@ -48,7 +48,7 @@ impl SessionId {
         );
         Self {
             txn_hash: tx_hash.0,
-            script_hash,
+            script_hash: script_hash.map(|x| x.0),
             chain_id,
             user_txn_context: Some(user_context),
             block_header,

--- a/moved/src/types/session_id.rs
+++ b/moved/src/types/session_id.rs
@@ -32,6 +32,7 @@ impl SessionId {
         tx_hash: &B256,
         genesis_config: &GenesisConfig,
         block_header: HeaderForExecution,
+        script_hash: Option<[u8; 32]>,
     ) -> Self {
         let chain_id = u8_chain_id(genesis_config);
         let sender = tx.signer.to_move_address();
@@ -47,8 +48,7 @@ impl SessionId {
         );
         Self {
             txn_hash: tx_hash.0,
-            // TODO: support script transactions
-            script_hash: None,
+            script_hash,
             chain_id,
             user_txn_context: Some(user_context),
             block_header,

--- a/moved/src/types/transactions.rs
+++ b/moved/src/types/transactions.rs
@@ -309,11 +309,11 @@ impl TransactionData {
         }
     }
 
-    pub fn script_hash(&self) -> Option<[u8; 32]> {
+    pub fn script_hash(&self) -> Option<B256> {
         if let Self::ScriptOrModule(ScriptOrModule::Script(script)) = self {
             let bytes = bcs::to_bytes(script).expect("Script must serialize");
             let hash = alloy::primitives::keccak256(bytes);
-            Some(hash.0)
+            Some(hash)
         } else {
             None
         }

--- a/moved/src/types/transactions.rs
+++ b/moved/src/types/transactions.rs
@@ -308,6 +308,16 @@ impl TransactionData {
             None
         }
     }
+
+    pub fn script_hash(&self) -> Option<[u8; 32]> {
+        if let Self::ScriptOrModule(ScriptOrModule::Script(script)) = self {
+            let bytes = bcs::to_bytes(script).expect("Script must serialize");
+            let hash = alloy::primitives::keccak256(bytes);
+            Some(hash.0)
+        } else {
+            None
+        }
+    }
 }
 
 pub(crate) trait ToLog {


### PR DESCRIPTION
### Description
While working on #143 I noticed a TODO left on `SessionId` which should have been fixed as part of #122 . This is an oversight on my part so I am fixing it here.

### Changes
- Include script hash in the `SessionId` when available.

### Testing
- Existing tests