### PR TITLE
Feat(genesis): Deploy L2 EVM contracts at genesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6457,6 +6457,7 @@ dependencies = [
  "once_cell",
  "revm",
  "serde",
+ "serde_json",
  "sha2 0.10.8",
  "smallvec",
  "sui-framework",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.1.0"
 edition = "2021"
 
 [workspace.dependencies]
-alloy = { version = "0.5", features = ["full", "rlp", "serde", "signer-keystore"] }
+alloy = { version = "0.5", features = ["full", "genesis", "rlp", "serde", "signer-keystore"] }
 alloy-rlp = { version = "0.3", features = ["derive"] }
 anyhow = "1"
 aptos-framework = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.14.0" }

--- a/moved/Cargo.toml
+++ b/moved/Cargo.toml
@@ -32,6 +32,7 @@ move-vm-types.workspace = true
 once_cell.workspace = true
 revm.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 sha2.workspace = true
 smallvec.workspace = true
 sui-framework.workspace = true

--- a/moved/src/genesis/config.rs
+++ b/moved/src/genesis/config.rs
@@ -4,6 +4,7 @@ use {
     aptos_gas_schedule::{InitialGasSchedule, VMGasParameters},
     aptos_vm_types::storage::StorageGasParameters,
     move_core_types::account_address::AccountAddress,
+    std::path::{Path, PathBuf},
 };
 
 pub const CHAIN_ID: u64 = 404;
@@ -21,6 +22,8 @@ pub struct GenesisConfig {
     pub initial_state_root: B256,
     pub gas_costs: GasCosts,
     pub treasury: AccountAddress,
+    // TODO: the genesis config should be self-contained instead of referring to an external file.
+    pub l2_contract_genesis: PathBuf,
 }
 
 impl Default for GasCosts {
@@ -38,10 +41,11 @@ impl Default for GenesisConfig {
         Self {
             chain_id: CHAIN_ID,
             initial_state_root: B256::from(hex!(
-                "42b5f5c32cf1bb32e09bf6b9f8eb1c2d2bb1b3a79b84a23afa3f06af6d1171b0"
+                "cb4475f0e47539e8ada1163493102bf56f2e125c315ae76d4b142e7e8f395b29"
             )),
             gas_costs: GasCosts::default(),
             treasury: AccountAddress::ONE, // todo: fill in the real address
+            l2_contract_genesis: Path::new("../moved/src/tests/res/l2_genesis_tests.json").into(),
         }
     }
 }

--- a/moved/src/genesis/framework.rs
+++ b/moved/src/genesis/framework.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{genesis::config::GenesisConfig, move_execution::create_move_vm, storage::State},
+    crate::{move_execution::create_move_vm, storage::State},
     aptos_framework::ReleaseBundle,
     aptos_table_natives::{NativeTableContext, TableChange, TableChangeSet},
     move_binary_format::errors::PartialVMError,
@@ -70,7 +70,7 @@ pub fn load_sui_framework_snapshot() -> &'static BTreeMap<ObjectID, SystemPackag
 }
 
 /// Initializes the blockchain state with Aptos and Sui frameworks.
-pub fn init_state(config: &GenesisConfig, state: &mut impl State<Err = PartialVMError>) {
+pub fn init_state(state: &mut impl State<Err = PartialVMError>) {
     let (change_set, table_change_set) =
         deploy_framework(state).expect("All bundle modules should be valid");
 
@@ -105,14 +105,6 @@ pub fn init_state(config: &GenesisConfig, state: &mut impl State<Err = PartialVM
     state
         .apply_with_tables(change_set, table_change_set)
         .unwrap();
-
-    let actual_state_root = state.state_root();
-    let expected_state_root = config.initial_state_root;
-
-    assert_eq!(
-        actual_state_root, expected_state_root,
-        "Fatal Error: Genesis state root mismatch"
-    );
 }
 
 fn deploy_framework(

--- a/moved/src/genesis/l2_contracts.rs
+++ b/moved/src/genesis/l2_contracts.rs
@@ -1,0 +1,12 @@
+use {
+    crate::{move_execution, storage::State},
+    alloy::genesis::Genesis,
+    move_binary_format::errors::PartialVMError,
+};
+
+pub fn init_state(genesis: Genesis, state: &mut impl State<Err = PartialVMError>) {
+    let changes = move_execution::genesis_state_changes(genesis, state.resolver());
+    state
+        .apply(changes)
+        .expect("L2 contract changes must apply");
+}

--- a/moved/src/genesis/mod.rs
+++ b/moved/src/genesis/mod.rs
@@ -1,4 +1,32 @@
+use {
+    self::config::GenesisConfig, crate::storage::State, move_binary_format::errors::PartialVMError,
+};
+
+pub use framework::FRAMEWORK_ADDRESS;
+
 pub mod config;
 mod framework;
+mod l2_contracts;
 
-pub use framework::{init_state, FRAMEWORK_ADDRESS};
+pub fn init_state(config: &GenesisConfig, state: &mut impl State<Err = PartialVMError>) {
+    // Read L2 contract data
+    let l2_genesis_file = std::fs::File::open(&config.l2_contract_genesis)
+        .expect("L2 contracts genesis file must exist");
+    let l2_contract_genesis =
+        serde_json::from_reader(l2_genesis_file).expect("L2 genesis file must parse successfully");
+
+    // Deploy Move/Aptos/Sui frameworks
+    framework::init_state(state);
+
+    // Deploy OP stack L2 contracts
+    l2_contracts::init_state(l2_contract_genesis, state);
+
+    // Validate final state
+    let actual_state_root = state.state_root();
+    let expected_state_root = config.initial_state_root;
+
+    assert_eq!(
+        actual_state_root, expected_state_root,
+        "Fatal Error: Genesis state root mismatch"
+    );
+}

--- a/moved/src/move_execution/mod.rs
+++ b/moved/src/move_execution/mod.rs
@@ -1,5 +1,6 @@
 pub use {
     eth_token::{quick_get_eth_balance, BaseTokenAccounts, MovedBaseTokenAccounts},
+    evm_native::genesis_state_changes,
     gas::{CreateEcotoneL1GasFee, CreateL1GasFee, EcotoneL1GasFee, L1GasFee, L1GasFeeInput},
 };
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -20,6 +20,7 @@ use {
         fs,
         io::Read,
         net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+        path::Path,
         time::SystemTime,
     },
     tokio::sync::mpsc,
@@ -66,7 +67,15 @@ static JWTSECRET: Lazy<Vec<u8>> = Lazy::new(|| {
 pub async fn run() {
     // TODO: think about channel size bound
     let (state_channel, rx) = mpsc::channel(1_000);
-    let genesis_config = GenesisConfig::default();
+
+    // TODO: genesis should come from a file (path specified by CLI)
+    let genesis_config = GenesisConfig {
+        l2_contract_genesis: Path::new(
+            "src/tests/optimism/packages/contracts-bedrock/deployments/genesis.json",
+        )
+        .into(),
+        ..Default::default()
+    };
 
     let block_hash = MovedBlockHash;
     let genesis_block = create_genesis_block(&block_hash, &genesis_config);


### PR DESCRIPTION
### Description
This PR extends the genesis process to include deploying the EVM contracts coming from OP stack. These contracts are taken directly from the `genesis.json` file created by `op-node`. For the purpose of testing in the `moved` module, a new file is added to `moved/src/tests/res`. This file comes from the genesis file generated by the integration test. The integration test itself uses the file it generates.

The reason to re-use the same file to initialize op-move as is used for op-geth is because we want op-move to essentially be a drop-in replacement for op-geth.

### Changes
- OP stack L2 EVM contracts included in Moved genesis state

### Testing
Existing tests (including integration test)

### Notes
There are a few new TODOs added in this PR, but they are P2 (not devnet blocking) in my opinion.