### PR TITLE
feat: Implement block fetching queries and integrate with JSON-RPC API methods

### DIFF
--- a/engine-api/src/methods/get_block_by_hash.rs
+++ b/engine-api/src/methods/get_block_by_hash.rs
@@ -1,12 +1,14 @@
 use {
-    crate::{json_utils, jsonrpc::JsonRpcError, schema::GetBlockResponse},
-    alloy::hex,
-    moved::{
-        block::{Block, ExtendedBlock},
-        primitives::{B256, U256},
-        types::state::{BlockResponse, StateMessage},
+    crate::{
+        json_utils::{self, access_state_error},
+        jsonrpc::JsonRpcError,
+        schema::GetBlockResponse,
     },
-    tokio::sync::mpsc,
+    moved::{
+        primitives::B256,
+        types::state::{Query, StateMessage},
+    },
+    tokio::sync::{mpsc, oneshot},
 };
 
 pub async fn execute(
@@ -19,20 +21,21 @@ pub async fn execute(
 }
 
 async fn inner_execute(
-    _block_hash: B256,
-    _include_transactions: bool,
-    _state_channel: mpsc::Sender<StateMessage>,
+    hash: B256,
+    include_transactions: bool,
+    state_channel: mpsc::Sender<StateMessage>,
 ) -> Result<Option<GetBlockResponse>, JsonRpcError> {
-    // TODO: Replace dummy response
-    Ok(Some(GetBlockResponse::from(BlockResponse::from(
-        ExtendedBlock::new(
-            B256::new(hex!(
-                "e56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d"
-            )),
-            U256::ZERO,
-            Block::default(),
-        ),
-    ))))
+    let (response_channel, rx) = oneshot::channel();
+    let msg = Query::BlockByHash {
+        hash,
+        include_transactions,
+        response_channel,
+    }
+    .into();
+    state_channel.send(msg).await.map_err(access_state_error)?;
+    let maybe_response = rx.await.map_err(access_state_error)?;
+
+    Ok(maybe_response.map(GetBlockResponse::from))
 }
 
 fn parse_params(request: serde_json::Value) -> Result<(B256, bool), JsonRpcError> {
@@ -54,7 +57,10 @@ mod tests {
         super::*,
         alloy::hex,
         moved::{
-            block::{Block, BlockRepository, Eip1559GasFee, InMemoryBlockRepository},
+            block::{
+                Block, BlockMemory, BlockRepository, Eip1559GasFee, InMemoryBlockQueries,
+                InMemoryBlockRepository,
+            },
             genesis::{config::GenesisConfig, init_state},
             primitives::U256,
             storage::InMemoryState,
@@ -88,8 +94,9 @@ mod tests {
         ));
         let genesis_block = Block::default().with_hash(head_hash).with_value(U256::ZERO);
 
+        let mut block_memory = BlockMemory::new();
         let mut repository = InMemoryBlockRepository::new();
-        repository.add(genesis_block);
+        repository.add(&mut block_memory, genesis_block);
 
         let mut state = InMemoryState::new();
         init_state(&genesis_config, &mut state);
@@ -105,6 +112,8 @@ mod tests {
             Eip1559GasFee::default(),
             U256::ZERO,
             (),
+            InMemoryBlockQueries,
+            block_memory,
         );
         let state_handle = state.spawn();
         let request = example_request();

--- a/engine-api/src/methods/send_raw_transaction.rs
+++ b/engine-api/src/methods/send_raw_transaction.rs
@@ -6,7 +6,7 @@ use {
     alloy::{consensus::transaction::TxEnvelope, rlp::Decodable},
     moved::{
         primitives::{Bytes, B256},
-        types::state::StateMessage,
+        types::state::{Command, StateMessage},
     },
     tokio::sync::mpsc,
 };
@@ -52,7 +52,7 @@ async fn inner_execute(
 ) -> Result<B256, JsonRpcError> {
     let tx_hash = tx.tx_hash().0.into();
 
-    let msg = StateMessage::AddTransaction { tx };
+    let msg = Command::AddTransaction { tx }.into();
     state_channel.send(msg).await.map_err(access_state_error)?;
 
     Ok(tx_hash)
@@ -63,7 +63,7 @@ mod tests {
     use {
         super::*,
         moved::{
-            block::{Eip1559GasFee, InMemoryBlockRepository},
+            block::{BlockMemory, Eip1559GasFee, InMemoryBlockQueries, InMemoryBlockRepository},
             primitives::U256,
             state_actor::StatePayloadId,
             storage::InMemoryState,
@@ -86,6 +86,8 @@ mod tests {
             Eip1559GasFee::default(),
             U256::ZERO,
             (),
+            InMemoryBlockQueries,
+            BlockMemory::new(),
         );
         let state_handle = state.spawn();
 

--- a/moved/src/block/in_memory.rs
+++ b/moved/src/block/in_memory.rs
@@ -1,21 +1,67 @@
 use {
     crate::{
-        block::{root::BlockRepository, ExtendedBlock},
+        block::{
+            root::{BlockQueries, BlockRepository},
+            ExtendedBlock,
+        },
         primitives::B256,
+        types::state::BlockResponse,
     },
     std::collections::HashMap,
 };
 
-/// Block repository that keeps data in memory.
+/// A storage for blocks that keeps data in memory.
 ///
-/// The repository keeps data stored locally and its memory is not shared outside the struct.
+/// The repository keeps data stored locally and its memory is not shared outside the struct. It
+/// maintains a set of indices for efficient lookup.
 #[derive(Debug)]
-pub struct InMemoryBlockRepository {
+pub struct BlockMemory {
     /// Collection of blocks ordered by insertion.
     blocks: Vec<ExtendedBlock>,
     /// Map where key is a block hash and value is a position in the `blocks` vector.
     hashes: HashMap<B256, usize>,
+    /// Map where key is a block height and value is a position in the `blocks` vector.
+    heights: HashMap<u64, usize>,
 }
+
+impl Default for BlockMemory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BlockMemory {
+    pub fn new() -> Self {
+        Self {
+            blocks: Vec::new(),
+            hashes: HashMap::new(),
+            heights: HashMap::new(),
+        }
+    }
+}
+
+impl BlockMemory {
+    pub fn add(&mut self, block: ExtendedBlock) {
+        let index = self.blocks.len();
+        self.hashes.insert(block.hash, index);
+        self.heights.insert(block.block.header.number, index);
+        self.blocks.push(block);
+    }
+
+    pub fn by_hash(&self, hash: B256) -> Option<ExtendedBlock> {
+        let index = *self.hashes.get(&hash)?;
+        self.blocks.get(index).cloned()
+    }
+
+    pub fn by_height(&self, height: u64) -> Option<ExtendedBlock> {
+        let index = *self.heights.get(&height)?;
+        self.blocks.get(index).cloned()
+    }
+}
+
+/// Block repository that works with in memory backing store [`BlockMemory`].
+#[derive(Debug)]
+pub struct InMemoryBlockRepository;
 
 impl Default for InMemoryBlockRepository {
     fn default() -> Self {
@@ -25,22 +71,30 @@ impl Default for InMemoryBlockRepository {
 
 impl InMemoryBlockRepository {
     pub fn new() -> Self {
-        Self {
-            blocks: Vec::new(),
-            hashes: HashMap::new(),
-        }
+        Self
     }
 }
 
-impl BlockRepository for InMemoryBlockRepository {
-    fn add(&mut self, block: ExtendedBlock) {
-        let index = self.blocks.len();
-        self.hashes.insert(block.hash, index);
-        self.blocks.push(block);
+impl BlockRepository<BlockMemory> for InMemoryBlockRepository {
+    fn add(&mut self, mem: &mut BlockMemory, block: ExtendedBlock) {
+        mem.add(block)
     }
 
-    fn by_hash(&self, hash: B256) -> Option<ExtendedBlock> {
-        let index = *self.hashes.get(&hash)?;
-        self.blocks.get(index).cloned()
+    fn by_hash(&self, mem: &BlockMemory, hash: B256) -> Option<ExtendedBlock> {
+        mem.by_hash(hash)
+    }
+}
+
+/// Block query implementation that works with in memory backing store [`BlockMemory`].
+#[derive(Debug)]
+pub struct InMemoryBlockQueries;
+
+impl BlockQueries<BlockMemory> for InMemoryBlockQueries {
+    fn by_hash(&self, mem: &BlockMemory, hash: B256) -> Option<BlockResponse> {
+        mem.by_hash(hash).map(Into::into)
+    }
+
+    fn by_height(&self, mem: &BlockMemory, height: u64) -> Option<BlockResponse> {
+        mem.by_height(height).map(Into::into)
     }
 }

--- a/moved/src/block/mod.rs
+++ b/moved/src/block/mod.rs
@@ -12,6 +12,6 @@ mod root;
 pub use {
     gas::{Eip1559GasFee, GasFee},
     hash::{BlockHash, MovedBlockHash},
-    in_memory::InMemoryBlockRepository,
-    root::{Block, BlockRepository, ExtendedBlock, Header, HeaderForExecution},
+    in_memory::{BlockMemory, InMemoryBlockQueries, InMemoryBlockRepository},
+    root::{Block, BlockQueries, BlockRepository, ExtendedBlock, Header, HeaderForExecution},
 };

--- a/moved/src/block/root.rs
+++ b/moved/src/block/root.rs
@@ -1,15 +1,20 @@
 use {
     crate::{
         primitives::{Address, Bytes, B2048, B256, U256},
-        types::transactions::ExtendedTxEnvelope,
+        types::{state::BlockResponse, transactions::ExtendedTxEnvelope},
     },
     alloy::{primitives::hex, rlp::RlpEncodable},
     std::fmt::Debug,
 };
 
-pub trait BlockRepository: Debug {
-    fn add(&mut self, block: ExtendedBlock);
-    fn by_hash(&self, hash: B256) -> Option<ExtendedBlock>;
+pub trait BlockQueries<Storage>: Debug {
+    fn by_hash(&self, storage: &Storage, hash: B256) -> Option<BlockResponse>;
+    fn by_height(&self, storage: &Storage, height: u64) -> Option<BlockResponse>;
+}
+
+pub trait BlockRepository<Storage>: Debug {
+    fn add(&mut self, storage: &mut Storage, block: ExtendedBlock);
+    fn by_hash(&self, storage: &Storage, hash: B256) -> Option<ExtendedBlock>;
 }
 
 #[derive(Debug, Clone)]

--- a/moved/src/types/state.rs
+++ b/moved/src/types/state.rs
@@ -76,6 +76,12 @@ pub struct BlobsBundle {
 
 #[derive(Debug)]
 pub enum StateMessage {
+    Command(Command),
+    Query(Query),
+}
+
+#[derive(Debug)]
+pub enum Command {
     UpdateHead {
         block_hash: B256,
     },
@@ -94,6 +100,16 @@ pub enum StateMessage {
     AddTransaction {
         tx: TxEnvelope,
     },
+}
+
+impl From<Command> for StateMessage {
+    fn from(value: Command) -> Self {
+        Self::Command(value)
+    }
+}
+
+#[derive(Debug)]
+pub enum Query {
     ChainId {
         response_channel: oneshot::Sender<u64>,
     },
@@ -102,6 +118,22 @@ pub enum StateMessage {
         block_number: BlockNumberOrTag,
         response_channel: oneshot::Sender<U256>,
     },
+    BlockByHash {
+        hash: B256,
+        include_transactions: bool,
+        response_channel: oneshot::Sender<Option<BlockResponse>>,
+    },
+    BlockByHeight {
+        height: BlockNumberOrTag,
+        include_transactions: bool,
+        response_channel: oneshot::Sender<Option<BlockResponse>>,
+    },
+}
+
+impl From<Query> for StateMessage {
+    fn from(value: Query) -> Self {
+        Self::Query(value)
+    }
 }
 
 pub type BlockResponse = alloy::rpc::types::Block<alloy::rpc::types::Transaction>;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -5,8 +5,8 @@ use {
     jsonwebtoken::{DecodingKey, Validation},
     moved::{
         block::{
-            Block, BlockHash, BlockRepository, Eip1559GasFee, ExtendedBlock, Header,
-            InMemoryBlockRepository, MovedBlockHash,
+            Block, BlockHash, BlockMemory, BlockRepository, Eip1559GasFee, ExtendedBlock, Header,
+            InMemoryBlockQueries, InMemoryBlockRepository, MovedBlockHash,
         },
         genesis::{config::GenesisConfig, init_state},
         move_execution::{CreateEcotoneL1GasFee, MovedBaseTokenAccounts},
@@ -80,9 +80,10 @@ pub async fn run() {
     let block_hash = MovedBlockHash;
     let genesis_block = create_genesis_block(&block_hash, &genesis_config);
 
+    let mut block_memory = BlockMemory::new();
     let mut repository = InMemoryBlockRepository::new();
     let head = genesis_block.hash;
-    repository.add(genesis_block);
+    repository.add(&mut block_memory, genesis_block);
 
     let mut state = InMemoryState::new();
     init_state(&genesis_config, &mut state);
@@ -102,6 +103,8 @@ pub async fn run() {
         ),
         CreateEcotoneL1GasFee,
         base_token,
+        InMemoryBlockQueries,
+        block_memory,
     );
 
     let http_state_channel = state_channel.clone();


### PR DESCRIPTION
- Separate commands and queries in `StateActor`
- Introduce new `BlockQueries` trait specialized for dealing with block fetching
- Share context with both `BlockRepository` and `BlockQuery` to avoid introducing locks by moving the ownership one layer above

Part of #47 