### PR TITLE
Feat(rpc): implementation for eth_getTransactionCount

### DIFF
--- a/engine-api/src/method_name.rs
+++ b/engine-api/src/method_name.rs
@@ -13,6 +13,7 @@ pub enum MethodName {
     GetBalance,
     GetBlockByHash,
     GetBlockByNumber,
+    GetNonce,
 }
 
 impl FromStr for MethodName {
@@ -28,6 +29,7 @@ impl FromStr for MethodName {
             "engine_newPayloadV3" => Self::NewPayloadV3,
             "eth_chainId" => Self::ChainId,
             "eth_getBalance" => Self::GetBalance,
+            "eth_getTransactionCount" => Self::GetNonce,
             "eth_getBlockByHash" => Self::GetBlockByHash,
             "eth_getBlockByNumber" => Self::GetBlockByNumber,
             "eth_sendRawTransaction" => Self::SendRawTransaction,

--- a/engine-api/src/methods/get_nonce.rs
+++ b/engine-api/src/methods/get_nonce.rs
@@ -1,0 +1,149 @@
+use {
+    crate::{json_utils, json_utils::access_state_error, jsonrpc::JsonRpcError},
+    alloy::{eips::BlockNumberOrTag, primitives::Address},
+    moved::types::state::{Query, StateMessage},
+    tokio::sync::{mpsc, oneshot},
+};
+
+pub async fn execute(
+    request: serde_json::Value,
+    state_channel: mpsc::Sender<StateMessage>,
+) -> Result<serde_json::Value, JsonRpcError> {
+    let (address, block_number) = parse_params(request)?;
+    let response = inner_execute(address, block_number, state_channel).await?;
+
+    // Format the balance as a hex string
+    Ok(serde_json::to_value(format!("0x{:x}", response))
+        .expect("Must be able to JSON-serialize response"))
+}
+
+fn parse_params(request: serde_json::Value) -> Result<(Address, BlockNumberOrTag), JsonRpcError> {
+    let params = json_utils::get_params_list(&request);
+    match params {
+        [] => Err(JsonRpcError {
+            code: -32602,
+            data: request,
+            message: "Not enough params".into(),
+        }),
+        [a] => {
+            let address: Address = json_utils::deserialize(a)?;
+            Ok((address, BlockNumberOrTag::Latest))
+        }
+        [a, b] => {
+            let address: Address = json_utils::deserialize(a)?;
+            let block_number: BlockNumberOrTag = json_utils::deserialize(b)?;
+            Ok((address, block_number))
+        }
+        _ => Err(JsonRpcError {
+            code: -32602,
+            data: request,
+            message: "Too many params".into(),
+        }),
+    }
+}
+
+async fn inner_execute(
+    address: Address,
+    block_number: BlockNumberOrTag,
+    state_channel: mpsc::Sender<StateMessage>,
+) -> Result<u64, JsonRpcError> {
+    let (tx, rx) = oneshot::channel();
+    let msg = Query::GetNonce {
+        address,
+        block_number,
+        response_channel: tx,
+    }
+    .into();
+    state_channel.send(msg).await.map_err(access_state_error)?;
+    let response = rx.await.map_err(access_state_error)?;
+    Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        moved::{
+            block::{BlockMemory, Eip1559GasFee, InMemoryBlockQueries, InMemoryBlockRepository},
+            genesis::init_state,
+            primitives::{B256, U256, U64},
+            state_actor::StatePayloadId,
+            storage::InMemoryState,
+        },
+        std::str::FromStr,
+        test_case::test_case,
+    };
+
+    #[test_case("0x1")]
+    #[test_case("latest")]
+    #[test_case("pending")]
+    fn test_parse_params_with_block_number(block: &str) {
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_getNonce",
+            "params": [
+                "0x0000000000000000000000000000000000000001",
+                block,
+            ],
+            "id": 1
+        });
+
+        let (address, block_number) = parse_params(request).unwrap();
+        assert_eq!(
+            address,
+            Address::from_str("0x0000000000000000000000000000000000000001").unwrap()
+        );
+        match block {
+            "latest" => assert_eq!(block_number, BlockNumberOrTag::Latest),
+            "pending" => assert_eq!(block_number, BlockNumberOrTag::Pending),
+            _ => assert_eq!(
+                block_number,
+                BlockNumberOrTag::Number(U64::from_str(block).unwrap().into_limbs()[0])
+            ),
+        }
+    }
+
+    #[test_case("0x1")]
+    #[test_case("latest")]
+    #[test_case("pending")]
+    #[tokio::test]
+    async fn test_execute(block: &str) {
+        let genesis_config = moved::genesis::config::GenesisConfig::default();
+        let mut state = InMemoryState::new();
+        init_state(&genesis_config, &mut state);
+
+        let (state_channel, rx) = mpsc::channel(10);
+
+        let state_actor = moved::state_actor::StateActor::new(
+            rx,
+            state,
+            B256::ZERO,
+            genesis_config,
+            StatePayloadId,
+            B256::ZERO,
+            InMemoryBlockRepository::new(),
+            Eip1559GasFee::default(),
+            U256::ZERO,
+            (),
+            InMemoryBlockQueries,
+            BlockMemory::new(),
+        );
+
+        let state_handle = state_actor.spawn();
+        let request: serde_json::Value = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_getNonce",
+            "params": [
+                "0x0000000000000000000000000000000000000001",
+                block,
+            ],
+            "id": 1
+        });
+
+        let expected_response: serde_json::Value = serde_json::from_str(r#""0x0""#).unwrap();
+        let response = execute(request, state_channel).await.unwrap();
+
+        assert_eq!(response, expected_response);
+        state_handle.await.unwrap();
+    }
+}

--- a/engine-api/src/methods/mod.rs
+++ b/engine-api/src/methods/mod.rs
@@ -3,6 +3,7 @@ pub mod forkchoice_updated;
 pub mod get_balance;
 pub mod get_block_by_hash;
 pub mod get_block_by_number;
+pub mod get_nonce;
 pub mod get_payload;
 pub mod new_payload;
 pub mod send_raw_transaction;

--- a/engine-api/src/request.rs
+++ b/engine-api/src/request.rs
@@ -49,6 +49,7 @@ async fn inner_handle_request(
         SendRawTransaction => send_raw_transaction::execute(request, state_channel).await,
         ChainId => chain_id::execute(state_channel).await,
         GetBalance => get_balance::execute(request, state_channel).await,
+        GetNonce => get_nonce::execute(request, state_channel).await,
         GetBlockByHash => get_block_by_hash::execute(request, state_channel).await,
         GetBlockByNumber => get_block_by_number::execute(request, state_channel).await,
         ForkChoiceUpdatedV2 => todo!(),

--- a/moved/src/move_execution/mod.rs
+++ b/moved/src/move_execution/mod.rs
@@ -2,6 +2,7 @@ pub use {
     eth_token::{quick_get_eth_balance, BaseTokenAccounts, MovedBaseTokenAccounts},
     evm_native::genesis_state_changes,
     gas::{CreateEcotoneL1GasFee, CreateL1GasFee, EcotoneL1GasFee, L1GasFee, L1GasFeeInput},
+    nonces::quick_get_nonce,
 };
 
 use {

--- a/moved/src/move_execution/nonces.rs
+++ b/moved/src/move_execution/nonces.rs
@@ -1,17 +1,51 @@
 use {
-    crate::{genesis::FRAMEWORK_ADDRESS, Error, InvalidTransactionCause, NonceChecking},
+    crate::{
+        genesis::FRAMEWORK_ADDRESS, types::session_id::SessionId, Error, InvalidTransactionCause,
+        NonceChecking,
+    },
+    aptos_table_natives::TableResolver,
+    move_binary_format::errors::PartialVMError,
     move_core_types::{
         account_address::AccountAddress, ident_str, identifier::IdentStr,
-        language_storage::ModuleId, value::MoveValue,
+        language_storage::ModuleId, resolver::MoveResolver, value::MoveValue,
     },
-    move_vm_runtime::{module_traversal::TraversalContext, session::Session},
-    move_vm_types::{gas::GasMeter, values::Value},
+    move_vm_runtime::{
+        module_traversal::{TraversalContext, TraversalStorage},
+        session::Session,
+    },
+    move_vm_types::{
+        gas::{GasMeter, UnmeteredGasMeter},
+        values::Value,
+    },
 };
 
 const ACCOUNT_MODULE_NAME: &IdentStr = ident_str!("account");
 const CREATE_ACCOUNT_FUNCTION_NAME: &IdentStr = ident_str!("create_account_if_does_not_exist");
 const GET_NONCE_FUNCTION_NAME: &IdentStr = ident_str!("get_sequence_number");
 const INCREMENT_NONCE_FUNCTION_NAME: &IdentStr = ident_str!("increment_sequence_number");
+
+/// Useful in tests and queries. Do not use in transaction execution
+/// since this method creates a new session and does not charge gas.
+pub fn quick_get_nonce(
+    address: &AccountAddress,
+    state: &(impl MoveResolver<PartialVMError> + TableResolver),
+) -> u64 {
+    let move_vm = super::create_move_vm().expect("Must create MoveVM");
+    let mut session = super::create_vm_session(&move_vm, state, SessionId::default());
+    let traversal_storage = TraversalStorage::new();
+    let mut traversal_context = TraversalContext::new(&traversal_storage);
+    let mut gas_meter = UnmeteredGasMeter;
+    let account_module_id = ModuleId::new(FRAMEWORK_ADDRESS, ACCOUNT_MODULE_NAME.into());
+    let addr_arg = bcs::to_bytes(address).expect("address can serialize");
+    get_account_nonce(
+        &account_module_id,
+        &addr_arg,
+        &mut session,
+        &mut traversal_context,
+        &mut gas_meter,
+    )
+    .unwrap_or_default()
+}
 
 pub(super) fn check_nonce<G: GasMeter>(
     tx_nonce: u64,
@@ -34,38 +68,13 @@ pub(super) fn check_nonce<G: GasMeter>(
         )
         .map_err(|_| Error::nonce_invariant_violation(NonceChecking::AnyAccountCanBeCreated))?;
 
-    let account_nonce = {
-        let return_values = session
-            .execute_function_bypass_visibility(
-                &account_module_id,
-                GET_NONCE_FUNCTION_NAME,
-                Vec::new(),
-                vec![addr_arg.as_slice()],
-                gas_meter,
-                traversal_context,
-            )
-            .map_err(|_| Error::nonce_invariant_violation(NonceChecking::GetNonceAlwaysSucceeds))?
-            .return_values;
-        let (raw_output, layout) =
-            return_values
-                .first()
-                .ok_or(Error::nonce_invariant_violation(
-                    NonceChecking::GetNonceReturnsAValue,
-                ))?;
-        let value = Value::simple_deserialize(raw_output, layout)
-            .ok_or(Error::nonce_invariant_violation(
-                NonceChecking::GetNoneReturnDeserializes,
-            ))?
-            .as_move_value(layout);
-        match value {
-            MoveValue::U64(nonce) => nonce,
-            _ => {
-                return Err(Error::nonce_invariant_violation(
-                    NonceChecking::GetNonceReturnsU64,
-                ));
-            }
-        }
-    };
+    let account_nonce = get_account_nonce(
+        &account_module_id,
+        &addr_arg,
+        session,
+        traversal_context,
+        gas_meter,
+    )?;
 
     if tx_nonce != account_nonce {
         Err(InvalidTransactionCause::IncorrectNonce {
@@ -91,4 +100,40 @@ pub(super) fn check_nonce<G: GasMeter>(
         })?;
 
     Ok(())
+}
+
+fn get_account_nonce<G: GasMeter>(
+    account_module_id: &ModuleId,
+    addr_arg: &[u8],
+    session: &mut Session,
+    traversal_context: &mut TraversalContext,
+    gas_meter: &mut G,
+) -> Result<u64, Error> {
+    let return_values = session
+        .execute_function_bypass_visibility(
+            account_module_id,
+            GET_NONCE_FUNCTION_NAME,
+            Vec::new(),
+            vec![addr_arg],
+            gas_meter,
+            traversal_context,
+        )
+        .map_err(|_| Error::nonce_invariant_violation(NonceChecking::GetNonceAlwaysSucceeds))?
+        .return_values;
+    let (raw_output, layout) = return_values
+        .first()
+        .ok_or(Error::nonce_invariant_violation(
+            NonceChecking::GetNonceReturnsAValue,
+        ))?;
+    let value = Value::simple_deserialize(raw_output, layout)
+        .ok_or(Error::nonce_invariant_violation(
+            NonceChecking::GetNoneReturnDeserializes,
+        ))?
+        .as_move_value(layout);
+    match value {
+        MoveValue::U64(nonce) => Ok(nonce),
+        _ => Err(Error::nonce_invariant_violation(
+            NonceChecking::GetNonceReturnsU64,
+        )),
+    }
 }

--- a/moved/src/state_actor.rs
+++ b/moved/src/state_actor.rs
@@ -10,8 +10,8 @@ use {
         genesis::config::GenesisConfig,
         merkle_tree::MerkleRootExt,
         move_execution::{
-            execute_transaction, quick_get_eth_balance, BaseTokenAccounts, CreateL1GasFee,
-            L1GasFee, L1GasFeeInput, LogsBloom,
+            execute_transaction, quick_get_eth_balance, quick_get_nonce, BaseTokenAccounts,
+            CreateL1GasFee, L1GasFee, L1GasFeeInput, LogsBloom,
         },
         primitives::{ToMoveAddress, ToSaturatedU64, B256, U256, U64},
         storage::State,
@@ -151,6 +151,16 @@ impl<
                 let account = address.to_move_address();
                 let balance = quick_get_eth_balance(&account, self.state.resolver());
                 response_channel.send(balance).ok()
+            }
+            Query::GetNonce {
+                address,
+                response_channel,
+                ..
+            } => {
+                // TODO: Support nonce from arbitrary blocks
+                let address = address.to_move_address();
+                let nonce = quick_get_nonce(&address, self.state.resolver());
+                response_channel.send(nonce).ok()
             }
             Query::BlockByHash {
                 hash,

--- a/moved/src/types/state.rs
+++ b/moved/src/types/state.rs
@@ -118,6 +118,11 @@ pub enum Query {
         block_number: BlockNumberOrTag,
         response_channel: oneshot::Sender<U256>,
     },
+    GetNonce {
+        address: Address,
+        block_number: BlockNumberOrTag,
+        response_channel: oneshot::Sender<u64>,
+    },
     BlockByHash {
         hash: B256,
         include_transactions: bool,


### PR DESCRIPTION
### Description
Implementation for `eth_getTransactionCount` RPC method in op-move.

### Changes
- New Query type for getting account nonces
- New quick_get_nonce API

### Testing
- New test in the same style as other RPC modules