### PR TITLE
refactor(block): Convert `Storage` generic parameter into associated type

### DIFF
--- a/moved/src/block/in_memory.rs
+++ b/moved/src/block/in_memory.rs
@@ -75,7 +75,9 @@ impl InMemoryBlockRepository {
     }
 }
 
-impl BlockRepository<BlockMemory> for InMemoryBlockRepository {
+impl BlockRepository for InMemoryBlockRepository {
+    type Storage = BlockMemory;
+
     fn add(&mut self, mem: &mut BlockMemory, block: ExtendedBlock) {
         mem.add(block)
     }
@@ -89,7 +91,9 @@ impl BlockRepository<BlockMemory> for InMemoryBlockRepository {
 #[derive(Debug)]
 pub struct InMemoryBlockQueries;
 
-impl BlockQueries<BlockMemory> for InMemoryBlockQueries {
+impl BlockQueries for InMemoryBlockQueries {
+    type Storage = BlockMemory;
+
     fn by_hash(&self, mem: &BlockMemory, hash: B256) -> Option<BlockResponse> {
         mem.by_hash(hash).map(Into::into)
     }

--- a/moved/src/block/root.rs
+++ b/moved/src/block/root.rs
@@ -7,14 +7,16 @@ use {
     std::fmt::Debug,
 };
 
-pub trait BlockQueries<Storage>: Debug {
-    fn by_hash(&self, storage: &Storage, hash: B256) -> Option<BlockResponse>;
-    fn by_height(&self, storage: &Storage, height: u64) -> Option<BlockResponse>;
+pub trait BlockQueries: Debug {
+    type Storage;
+    fn by_hash(&self, storage: &Self::Storage, hash: B256) -> Option<BlockResponse>;
+    fn by_height(&self, storage: &Self::Storage, height: u64) -> Option<BlockResponse>;
 }
 
-pub trait BlockRepository<Storage>: Debug {
-    fn add(&mut self, storage: &mut Storage, block: ExtendedBlock);
-    fn by_hash(&self, storage: &Storage, hash: B256) -> Option<ExtendedBlock>;
+pub trait BlockRepository: Debug {
+    type Storage;
+    fn add(&mut self, storage: &mut Self::Storage, block: ExtendedBlock);
+    fn by_hash(&self, storage: &Self::Storage, hash: B256) -> Option<ExtendedBlock>;
 }
 
 #[derive(Debug, Clone)]

--- a/moved/src/state_actor.rs
+++ b/moved/src/state_actor.rs
@@ -42,11 +42,11 @@ pub struct StateActor<
     S: State,
     P: NewPayloadId,
     H: BlockHash,
-    R: BlockRepository<M>,
+    R: BlockRepository<Storage = M>,
     G: GasFee,
     L1G: CreateL1GasFee,
     B: BaseTokenAccounts,
-    Q: BlockQueries<M>,
+    Q: BlockQueries<Storage = M>,
     M,
 > {
     genesis_config: GenesisConfig,
@@ -71,11 +71,11 @@ impl<
         S: State<Err = PartialVMError> + Send + Sync + 'static,
         P: NewPayloadId + Send + Sync + 'static,
         H: BlockHash + Send + Sync + 'static,
-        R: BlockRepository<M> + Send + Sync + 'static,
+        R: BlockRepository<Storage = M> + Send + Sync + 'static,
         G: GasFee + Send + Sync + 'static,
         L1G: CreateL1GasFee + Send + Sync + 'static,
         B: BaseTokenAccounts + Send + Sync + 'static,
-        Q: BlockQueries<M> + Send + Sync + 'static,
+        Q: BlockQueries<Storage = M> + Send + Sync + 'static,
         M: Send + Sync + 'static,
     > StateActor<S, P, H, R, G, L1G, B, Q, M>
 {
@@ -95,11 +95,11 @@ impl<
         S: State<Err = PartialVMError>,
         P: NewPayloadId,
         H: BlockHash,
-        R: BlockRepository<M>,
+        R: BlockRepository<Storage = M>,
         G: GasFee,
         L1G: CreateL1GasFee,
         B: BaseTokenAccounts,
-        Q: BlockQueries<M>,
+        Q: BlockQueries<Storage = M>,
         M,
     > StateActor<S, P, H, R, G, L1G, B, Q, M>
 {


### PR DESCRIPTION
### Description
Since the trait implementation exist only for one specialization of the generic type, it makes sense for it to be associated type rather than a generic parameter.

### Changes
- Convert `Storage` generic parameter into associated type

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt
