### PR TITLE
feat(eth-api): Implement `include_transactions` parameter for block fetching

### DIFF
--- a/engine-api/src/methods/get_block_by_hash.rs
+++ b/engine-api/src/methods/get_block_by_hash.rs
@@ -100,7 +100,8 @@ mod tests {
             "blobGasUsed": "0x0",
             "excessBlobGas": "0x0",
             "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "uncles": []
+            "uncles": [],
+            "transactions": []
         }"#).unwrap();
 
         let response = execute(request, state_channel).await.unwrap();

--- a/engine-api/src/methods/get_block_by_number.rs
+++ b/engine-api/src/methods/get_block_by_number.rs
@@ -97,7 +97,8 @@ mod tests {
             "blobGasUsed": "0x0",
             "excessBlobGas": "0x0",
             "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "uncles": []
+            "uncles": [],
+            "transactions": []
         }"#).unwrap();
 
         let response = execute(request, state_channel).await.unwrap();

--- a/engine-api/src/schema/eth/block.rs
+++ b/engine-api/src/schema/eth/block.rs
@@ -1,16 +1,15 @@
 pub use alloy::eips::BlockNumberOrTag;
 
 use {
-    alloy::rpc,
-    moved::types::state::BlockResponse,
+    moved::types::state::{BlockResponse, RpcBlock},
     serde::{Deserialize, Serialize},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct GetBlockResponse(pub rpc::types::Block<rpc::types::Transaction>);
+pub struct GetBlockResponse(pub RpcBlock);
 
 impl From<BlockResponse> for GetBlockResponse {
     fn from(value: BlockResponse) -> Self {
-        Self(value)
+        Self(value.0)
     }
 }

--- a/moved/src/block/in_memory.rs
+++ b/moved/src/block/in_memory.rs
@@ -94,11 +94,33 @@ pub struct InMemoryBlockQueries;
 impl BlockQueries for InMemoryBlockQueries {
     type Storage = BlockMemory;
 
-    fn by_hash(&self, mem: &BlockMemory, hash: B256) -> Option<BlockResponse> {
-        mem.by_hash(hash).map(Into::into)
+    fn by_hash(
+        &self,
+        mem: &BlockMemory,
+        hash: B256,
+        include_transactions: bool,
+    ) -> Option<BlockResponse> {
+        if include_transactions {
+            mem.by_hash(hash)
+                .map(BlockResponse::from_block_with_transactions)
+        } else {
+            mem.by_hash(hash)
+                .map(BlockResponse::from_block_with_transaction_hashes)
+        }
     }
 
-    fn by_height(&self, mem: &BlockMemory, height: u64) -> Option<BlockResponse> {
-        mem.by_height(height).map(Into::into)
+    fn by_height(
+        &self,
+        mem: &BlockMemory,
+        height: u64,
+        include_transactions: bool,
+    ) -> Option<BlockResponse> {
+        if include_transactions {
+            mem.by_height(height)
+                .map(BlockResponse::from_block_with_transactions)
+        } else {
+            mem.by_height(height)
+                .map(BlockResponse::from_block_with_transaction_hashes)
+        }
     }
 }

--- a/moved/src/block/root.rs
+++ b/moved/src/block/root.rs
@@ -9,8 +9,20 @@ use {
 
 pub trait BlockQueries: Debug {
     type Storage;
-    fn by_hash(&self, storage: &Self::Storage, hash: B256) -> Option<BlockResponse>;
-    fn by_height(&self, storage: &Self::Storage, height: u64) -> Option<BlockResponse>;
+
+    fn by_hash(
+        &self,
+        storage: &Self::Storage,
+        hash: B256,
+        include_transactions: bool,
+    ) -> Option<BlockResponse>;
+
+    fn by_height(
+        &self,
+        storage: &Self::Storage,
+        height: u64,
+        include_transactions: bool,
+    ) -> Option<BlockResponse>;
 }
 
 pub trait BlockRepository: Debug {


### PR DESCRIPTION
### Description
Implement `include_transactions` parameter for block fetching

### Changes
- Converts the transactions into its full RPC representation
- Computes hashes if full transactions are not included

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt
