### PR TITLE
Fix(sdk): Match bytecode version to default 6

### DIFF
--- a/sdk/hardhat-moved/src/index.ts
+++ b/sdk/hardhat-moved/src/index.ts
@@ -170,8 +170,9 @@ async function movePackageBuild(moveType: MoveType, movePath: string, packagePat
     }
 
     // Aptos and Sui uses different subcommands to build a package
+    // Use the default bytecode version 6 for Aptos repo tag `aptos-node-v1.14.0`
     const cmd = moveType === MoveType.Aptos
-        ? `${movePath} move compile --package-dir ${packagePath} --skip-fetch-latest-git-deps`
+        ? `${movePath} move compile --package-dir ${packagePath} --skip-fetch-latest-git-deps --bytecode-version 6`
         : `${movePath} move build --path ${packagePath} --force --skip-fetch-latest-git-deps`;
 
     const [e, stdout, stderr] = await executeChildProcess(cmd);


### PR DESCRIPTION
### Description
Deploying a contract through the SDK fails the bytecode version verification. The current CLI uses version 7, but `op-move` requires version 6 until we upgrade the Aptos repo tag to the latest.

### Changes
Explicitly provide the version in the compilation command.

### Testing
✓ Tested the compiled module code in `eth_estimateGas` test.