### PR TITLE
Feat(rpc): Simulate transaction for gas estimation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,7 @@ dependencies = [
  "const-hex",
  "derive_more 1.0.0",
  "foldhash",
+ "getrandom 0.2.15",
  "hashbrown 0.15.2",
  "hex-literal",
  "indexmap 2.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.1.0"
 edition = "2021"
 
 [workspace.dependencies]
-alloy = { version = "0.6", features = ["full", "genesis", "rlp", "serde", "signer-keystore"] }
+alloy = { version = "0.6", features = ["full", "genesis", "getrandom", "rlp", "serde", "signer-keystore"] }
 alloy-rlp = { version = "0.3", features = ["derive"] }
 anyhow = "1"
 aptos-framework = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.14.0" }

--- a/engine-api/src/json_utils.rs
+++ b/engine-api/src/json_utils.rs
@@ -30,3 +30,7 @@ pub fn deserialize<T: DeserializeOwned>(x: &serde_json::Value) -> Result<T, Json
 pub fn access_state_error<E: fmt::Debug>(e: E) -> JsonRpcError {
     JsonRpcError::access_state_error(e)
 }
+
+pub fn transaction_error<E: fmt::Debug>(e: E) -> JsonRpcError {
+    JsonRpcError::without_data(32603, format!("Invalid transaction: {e:?}"))
+}

--- a/engine-api/src/json_utils.rs
+++ b/engine-api/src/json_utils.rs
@@ -32,5 +32,5 @@ pub fn access_state_error<E: fmt::Debug>(e: E) -> JsonRpcError {
 }
 
 pub fn transaction_error<E: fmt::Debug>(e: E) -> JsonRpcError {
-    JsonRpcError::without_data(32603, format!("Invalid transaction: {e:?}"))
+    JsonRpcError::without_data(3, format!("Execution reverted: {e:?}"))
 }

--- a/engine-api/src/methods/estimate_gas.rs
+++ b/engine-api/src/methods/estimate_gas.rs
@@ -110,16 +110,15 @@ mod tests {
             "method": "eth_estimateGas",
             "params": [
                 {
-                    "from": "0x0000000000000000000000000000000000000001",
-                    "to": null,
-                    "input": "0xa11ce0"
+                    "from": "0x8fd379246834eac74b8419ffda202cf8051f7a03",
+                    "input": "0x01fd01a11ceb0b0600000009010002020204030614051a0e07283d0865200a8501050c8a01490dd3010200000001080000020001000003000200000400030000050403000105010101030002060c0301070307636f756e74657207436f756e7465720e636f756e7465725f657869737473096765745f636f756e7409696e6372656d656e74077075626c69736801690000000000000000000000008fd379246834eac74b8419ffda202cf8051f7a0300020106030001000003030b00290002010100010003050b002b00100014020201040100050b0b002a000f000c010a0114060100000000000000160b0115020301040003050b000b0112002d0002000000"
                 },
                 block,
             ],
             "id": 1
         });
 
-        let expected_response: serde_json::Value = serde_json::from_str(r#""0x0""#).unwrap();
+        let expected_response: serde_json::Value = serde_json::from_str(r#""0x3""#).unwrap();
         let response = execute(request, state_channel).await.unwrap();
 
         assert_eq!(response, expected_response);

--- a/moved/src/move_execution/mod.rs
+++ b/moved/src/move_execution/mod.rs
@@ -44,7 +44,7 @@ mod deposited;
 mod eth_token;
 mod evm_native;
 mod execute;
-mod gas;
+pub(crate) mod gas;
 mod nonces;
 mod tag_validation;
 

--- a/moved/src/types/state.rs
+++ b/moved/src/types/state.rs
@@ -149,7 +149,7 @@ pub enum Query {
     EstimateGas {
         transaction: TransactionRequest,
         block_number: BlockNumberOrTag,
-        response_channel: oneshot::Sender<u64>,
+        response_channel: oneshot::Sender<crate::Result<u64>>,
     },
     Call {
         transaction: TransactionRequest,

--- a/moved/src/types/transactions.rs
+++ b/moved/src/types/transactions.rs
@@ -11,7 +11,7 @@ use {
         eips::{eip2930::AccessList, eip7702::SignedAuthorization},
         primitives::{Address, Bloom, Bytes, ChainId, Log, LogData, TxKind, B256, U256, U64},
         rlp::{Buf, Decodable, Encodable, RlpDecodable, RlpEncodable},
-        rpc::types::TransactionTrait,
+        rpc::types::{TransactionRequest, TransactionTrait},
     },
     aptos_types::transaction::{EntryFunction, Module, Script},
     move_core_types::{
@@ -479,6 +479,25 @@ impl TransactionData {
             Some(hash)
         } else {
             None
+        }
+    }
+}
+
+impl From<TransactionRequest> for NormalizedEthTransaction {
+    fn from(value: TransactionRequest) -> Self {
+        Self {
+            signer: value.from.unwrap_or_default(),
+            to: value.to.unwrap_or_default(),
+            nonce: value.nonce.unwrap_or_default(),
+            value: value.value.unwrap_or_default(),
+            chain_id: value.chain_id,
+            gas_limit: U256::from(value.gas.unwrap_or(u64::MAX)),
+            max_priority_fee_per_gas: U256::from(
+                value.max_priority_fee_per_gas.unwrap_or_default(),
+            ),
+            max_fee_per_gas: U256::from(value.max_fee_per_gas.unwrap_or_default()),
+            data: value.input.input.unwrap_or_default(),
+            access_list: value.access_list.unwrap_or_default(),
         }
     }
 }


### PR DESCRIPTION
### Description
Accept real estimate gas requests by simulating the transaction and returning the gas used.

### Changes
- Simulate a transaction in `state_actor`.
- Use real module code as input, taken from SDK counter example.
- Normalize transaction request from user.
- Update `alloy` features to support random B256 generation.

### Testing
✓ Unit test is updated with a real deployment example.