### PR TITLE
feat: Add state queries for balance and nonce retrieval of any known block height

### DIFF
--- a/engine-api/src/jsonrpc.rs
+++ b/engine-api/src/jsonrpc.rs
@@ -33,7 +33,7 @@ impl JsonRpcError {
     }
 
     pub fn block_not_found(block_number: BlockNumberOrTag) -> Self {
-        JsonRpcError::without_data(-32001, format!("block not found: {block_number}"))
+        JsonRpcError::without_data(-32001, format!("Block not found: {block_number}"))
     }
 }
 

--- a/engine-api/src/jsonrpc.rs
+++ b/engine-api/src/jsonrpc.rs
@@ -1,4 +1,5 @@
 use {
+    crate::schema::BlockNumberOrTag,
     std::fmt,
     tokio::sync::{mpsc::error::SendError, oneshot::error::RecvError},
 };
@@ -29,6 +30,10 @@ impl JsonRpcError {
 
     pub fn access_state_error<E: fmt::Debug>(e: E) -> JsonRpcError {
         Self::without_data(-1, format!("Failed to access state: {e:?}"))
+    }
+
+    pub fn block_not_found(block_number: BlockNumberOrTag) -> Self {
+        JsonRpcError::without_data(-32001, format!("block not found: {block_number}"))
     }
 }
 

--- a/engine-api/src/methods/get_balance.rs
+++ b/engine-api/src/methods/get_balance.rs
@@ -44,13 +44,13 @@ fn parse_params(request: serde_json::Value) -> Result<(Address, BlockNumberOrTag
 
 async fn inner_execute(
     address: Address,
-    block_number: BlockNumberOrTag,
+    height: BlockNumberOrTag,
     state_channel: mpsc::Sender<StateMessage>,
 ) -> Result<Option<U256>, JsonRpcError> {
     let (tx, rx) = oneshot::channel();
     let msg = Query::BalanceByHeight {
         address,
-        height: block_number,
+        height,
         response_channel: tx,
     }
     .into();
@@ -101,12 +101,8 @@ mod tests {
     #[test_case("pending")]
     #[tokio::test]
     async fn test_execute(block: &str) {
-        let (state_actor, state_channel) = create_state_actor_with_mock_state_queries(
-            1,
-            AccountAddress::new(hex!(
-                "0000000000000000000000000000000000000000000000000000000000000001"
-            )),
-        );
+        let (state_actor, state_channel) =
+            create_state_actor_with_mock_state_queries(AccountAddress::ONE, 1);
 
         let state_handle = state_actor.spawn();
         let request: serde_json::Value = serde_json::json!({
@@ -131,10 +127,10 @@ mod tests {
         let expected_balance = 5;
         let height = 3;
         let (state_actor, state_channel) = create_state_actor_with_mock_state_queries(
-            height,
             AccountAddress::new(hex!(
                 "0000000000000000000000002222222222222223333333333333333333111100"
             )),
+            height,
         );
         let address = "2222222222222223333333333333333333111100";
 

--- a/engine-api/src/methods/get_balance.rs
+++ b/engine-api/src/methods/get_balance.rs
@@ -47,9 +47,9 @@ async fn inner_execute(
     state_channel: mpsc::Sender<StateMessage>,
 ) -> Result<U256, JsonRpcError> {
     let (tx, rx) = oneshot::channel();
-    let msg = Query::GetBalance {
+    let msg = Query::BalanceByHeight {
         address,
-        block_number,
+        height: block_number,
         response_channel: tx,
     }
     .into();

--- a/engine-api/src/methods/get_balance.rs
+++ b/engine-api/src/methods/get_balance.rs
@@ -13,11 +13,12 @@ pub async fn execute(
     state_channel: mpsc::Sender<StateMessage>,
 ) -> Result<serde_json::Value, JsonRpcError> {
     let (address, block_number) = parse_params(request)?;
-    let response = inner_execute(address, block_number, state_channel).await?;
+    let response = inner_execute(address, block_number, state_channel)
+        .await?
+        .ok_or(JsonRpcError::block_not_found(block_number))?;
 
     // Format the balance as a hex string
-    Ok(serde_json::to_value(format!("0x{:x}", response))
-        .expect("Must be able to JSON-serialize response"))
+    Ok(serde_json::Value::String(format!("0x{:x}", response)))
 }
 
 fn parse_params(request: serde_json::Value) -> Result<(Address, BlockNumberOrTag), JsonRpcError> {
@@ -45,7 +46,7 @@ async fn inner_execute(
     address: Address,
     block_number: BlockNumberOrTag,
     state_channel: mpsc::Sender<StateMessage>,
-) -> Result<U256, JsonRpcError> {
+) -> Result<Option<U256>, JsonRpcError> {
     let (tx, rx) = oneshot::channel();
     let msg = Query::BalanceByHeight {
         address,
@@ -61,13 +62,9 @@ async fn inner_execute(
 #[cfg(test)]
 mod tests {
     use {
-        super::*,
-        crate::methods::tests::{create_state_actor, create_state_actor_with_mock_state_queries},
-        alloy::hex,
-        move_core_types::account_address::AccountAddress,
-        moved::primitives::U64,
-        std::str::FromStr,
-        test_case::test_case,
+        super::*, crate::methods::tests::create_state_actor_with_mock_state_queries, alloy::hex,
+        move_core_types::account_address::AccountAddress, moved::primitives::U64,
+        std::str::FromStr, test_case::test_case,
     };
 
     #[test_case("0x1")]
@@ -104,7 +101,12 @@ mod tests {
     #[test_case("pending")]
     #[tokio::test]
     async fn test_execute(block: &str) {
-        let (state_actor, state_channel) = create_state_actor();
+        let (state_actor, state_channel) = create_state_actor_with_mock_state_queries(
+            1,
+            AccountAddress::new(hex!(
+                "0000000000000000000000000000000000000000000000000000000000000001"
+            )),
+        );
 
         let state_handle = state_actor.spawn();
         let request: serde_json::Value = serde_json::json!({
@@ -117,7 +119,7 @@ mod tests {
             "id": 1
         });
 
-        let expected_response: serde_json::Value = serde_json::from_str(r#""0x0""#).unwrap();
+        let expected_response: serde_json::Value = serde_json::from_str(r#""0x5""#).unwrap();
         let response = execute(request, state_channel).await.unwrap();
 
         assert_eq!(response, expected_response);

--- a/engine-api/src/methods/get_balance.rs
+++ b/engine-api/src/methods/get_balance.rs
@@ -61,8 +61,13 @@ async fn inner_execute(
 #[cfg(test)]
 mod tests {
     use {
-        super::*, crate::methods::tests::create_state_actor, moved::primitives::U64,
-        std::str::FromStr, test_case::test_case,
+        super::*,
+        crate::methods::tests::{create_state_actor, create_state_actor_with_mock_state_queries},
+        alloy::hex,
+        move_core_types::account_address::AccountAddress,
+        moved::primitives::U64,
+        std::str::FromStr,
+        test_case::test_case,
     };
 
     #[test_case("0x1")]
@@ -113,6 +118,36 @@ mod tests {
         });
 
         let expected_response: serde_json::Value = serde_json::from_str(r#""0x0""#).unwrap();
+        let response = execute(request, state_channel).await.unwrap();
+
+        assert_eq!(response, expected_response);
+        state_handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_endpoint_returns_json_encoded_balance_query_result_successfully() {
+        let expected_balance = 5;
+        let height = 3;
+        let (state_actor, state_channel) = create_state_actor_with_mock_state_queries(
+            height,
+            AccountAddress::new(hex!(
+                "0000000000000000000000002222222222222223333333333333333333111100"
+            )),
+        );
+        let address = "2222222222222223333333333333333333111100";
+
+        let state_handle = state_actor.spawn();
+        let request: serde_json::Value = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_getBalance",
+            "params": [
+                format!("0x{address}"),
+                format!("0x{height}"),
+            ],
+            "id": 1
+        });
+
+        let expected_response = serde_json::Value::String(format!("0x{expected_balance}"));
         let response = execute(request, state_channel).await.unwrap();
 
         assert_eq!(response, expected_response);

--- a/engine-api/src/methods/get_nonce.rs
+++ b/engine-api/src/methods/get_nonce.rs
@@ -48,9 +48,9 @@ async fn inner_execute(
     state_channel: mpsc::Sender<StateMessage>,
 ) -> Result<u64, JsonRpcError> {
     let (tx, rx) = oneshot::channel();
-    let msg = Query::GetNonce {
+    let msg = Query::NonceByHeight {
         address,
-        block_number,
+        height: block_number,
         response_channel: tx,
     }
     .into();

--- a/engine-api/src/methods/get_nonce.rs
+++ b/engine-api/src/methods/get_nonce.rs
@@ -44,20 +44,18 @@ fn parse_params(request: serde_json::Value) -> Result<(Address, BlockNumberOrTag
 
 async fn inner_execute(
     address: Address,
-    block_number: BlockNumberOrTag,
+    height: BlockNumberOrTag,
     state_channel: mpsc::Sender<StateMessage>,
 ) -> Result<u64, JsonRpcError> {
     let (tx, rx) = oneshot::channel();
     let msg = Query::NonceByHeight {
         address,
-        height: block_number,
+        height,
         response_channel: tx,
     }
     .into();
     state_channel.send(msg).await.map_err(access_state_error)?;
-    let response = rx
-        .await?
-        .ok_or(JsonRpcError::block_not_found(block_number))?;
+    let response = rx.await?.ok_or(JsonRpcError::block_not_found(height))?;
 
     Ok(response)
 }
@@ -104,12 +102,8 @@ mod tests {
     #[test_case("pending")]
     #[tokio::test]
     async fn test_execute(block: &str) {
-        let (state_actor, state_channel) = create_state_actor_with_mock_state_queries(
-            1,
-            AccountAddress::new(hex!(
-                "0000000000000000000000000000000000000000000000000000000000000001"
-            )),
-        );
+        let (state_actor, state_channel) =
+            create_state_actor_with_mock_state_queries(AccountAddress::ONE, 1);
 
         let state_handle = state_actor.spawn();
         let request: serde_json::Value = serde_json::json!({
@@ -134,10 +128,10 @@ mod tests {
         let expected_nonce = 3;
         let height = 2;
         let (state_actor, state_channel) = create_state_actor_with_mock_state_queries(
-            height,
             AccountAddress::new(hex!(
                 "0000000000000000000000002222222222222223333333333333333333111100"
             )),
+            height,
         );
         let address = "2222222222222223333333333333333333111100";
 

--- a/engine-api/src/methods/get_payload.rs
+++ b/engine-api/src/methods/get_payload.rs
@@ -71,8 +71,8 @@ mod tests {
                 InMemoryBlockRepository,
             },
             genesis::{self, config::GenesisConfig},
-            move_execution::{InMemoryStateQueries, StateMemory},
             primitives::{B256, U256},
+            state_actor::InMemoryStateQueries,
             storage::InMemoryState,
             types::state::Command,
         },
@@ -118,8 +118,7 @@ mod tests {
 
         let mut state = InMemoryState::new();
         let (changes, table_changes) = genesis::init(&genesis_config, &state);
-        let state_memory = StateMemory::from_genesis(changes.clone());
-        genesis::apply(changes, table_changes, &genesis_config, &mut state);
+        genesis::apply(changes.clone(), table_changes, &genesis_config, &mut state);
 
         let state = moved::state_actor::StateActor::new(
             rx,
@@ -135,7 +134,8 @@ mod tests {
             (),
             InMemoryBlockQueries,
             block_memory,
-            InMemoryStateQueries::new(state_memory),
+            InMemoryStateQueries::from_genesis(changes),
+            moved::state_actor::StateActor::on_tx_noop(),
             moved::state_actor::StateActor::on_tx_batch_noop(),
         );
         let state_handle = state.spawn();
@@ -174,7 +174,7 @@ mod tests {
                 "executionPayload": {
                     "parentHash": "0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d",
                     "feeRecipient": "0x4200000000000000000000000000000000000011",
-                    "stateRoot": "0xc69848607093504f7acf479f516dcfaee088091e88e1f465ea74244307e8d676",
+                    "stateRoot": "0xf2c849eacf34ce3985cdc176ce9d0adb2bbcef8fd1e4952d9ceb7d55486469e9",
                     "receiptsRoot": "0x05fddc251b06be4b6305c662f0ffa27284ed876b673b02cbc2f6cab452bd8bb6",
                     "logsBloom": "0x00000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000400",
                     "prevRandao": "0xbde07f5d381bb84700433fe6c0ae077aa40eaad3a5de7abd298f0e3e27e6e4c9",

--- a/engine-api/src/methods/get_payload.rs
+++ b/engine-api/src/methods/get_payload.rs
@@ -136,6 +136,7 @@ mod tests {
             InMemoryBlockQueries,
             block_memory,
             InMemoryStateQueries::new(state_memory),
+            Box::new(|| Box::new(|_, _| {})),
         );
         let state_handle = state.spawn();
 

--- a/engine-api/src/methods/get_payload.rs
+++ b/engine-api/src/methods/get_payload.rs
@@ -136,7 +136,7 @@ mod tests {
             InMemoryBlockQueries,
             block_memory,
             InMemoryStateQueries::new(state_memory),
-            Box::new(|| Box::new(|_, _| {})),
+            moved::state_actor::StateActor::on_tx_batch_noop(),
         );
         let state_handle = state.spawn();
 

--- a/engine-api/src/methods/get_payload.rs
+++ b/engine-api/src/methods/get_payload.rs
@@ -125,6 +125,7 @@ mod tests {
             rx,
             state,
             head_hash,
+            0,
             genesis_config,
             0x03421ee50df45cacu64,
             head_hash,

--- a/engine-api/src/methods/mod.rs
+++ b/engine-api/src/methods/mod.rs
@@ -74,6 +74,7 @@ pub mod tests {
             rx,
             state,
             head_hash,
+            0,
             genesis_config,
             0x03421ee50df45cacu64,
             MovedBlockHash,

--- a/engine-api/src/methods/mod.rs
+++ b/engine-api/src/methods/mod.rs
@@ -89,7 +89,7 @@ pub mod tests {
             InMemoryBlockQueries,
             block_memory,
             InMemoryStateQueries::new(state_memory),
-            Box::new(|| Box::new(|_, _| {})),
+            StateActor::on_tx_batch_noop(),
         );
         (state, state_channel)
     }
@@ -191,7 +191,7 @@ pub mod tests {
             (),
             (),
             MockStateQueries(height, address),
-            Box::new(|| Box::new(|_, _| {})),
+            StateActor::on_tx_batch_noop(),
         );
         (state, state_channel)
     }

--- a/engine-api/src/methods/mod.rs
+++ b/engine-api/src/methods/mod.rs
@@ -28,15 +28,19 @@ pub mod tests {
         move_core_types::account_address::AccountAddress,
         moved::{
             block::{
-                Block, BlockMemory, BlockRepository, Eip1559GasFee, InMemoryBlockQueries,
-                InMemoryBlockRepository, MovedBlockHash,
+                Block, BlockHash, BlockMemory, BlockQueries, BlockRepository, Eip1559GasFee,
+                GasFee, InMemoryBlockQueries, InMemoryBlockRepository, MovedBlockHash,
             },
             genesis::{
                 config::{GenesisConfig, CHAIN_ID},
                 self,
             },
-            move_execution::{InMemoryStateQueries, MovedBaseTokenAccounts, StateMemory},
+            move_execution::{
+                BaseTokenAccounts, CreateL1GasFee, InMemoryStateQueries, MovedBaseTokenAccounts,
+                StateMemory, StateQueries,
+            },
             primitives::{Address, B256, U256, U64},
+            state_actor::{MockStateQueries, NewPayloadId, StateActor},
             storage::InMemoryState,
             types::{
                 state::{Command, Payload, StateMessage},
@@ -148,5 +152,45 @@ pub mod tests {
         .into();
         channel.send(msg).await.map_err(access_state_error).unwrap();
         receiver.await.map_err(access_state_error).unwrap();
+    }
+
+    pub fn create_state_actor_with_mock_state_queries(
+        height: u64,
+        address: AccountAddress,
+    ) -> (
+        StateActor<
+            InMemoryState,
+            impl NewPayloadId,
+            impl BlockHash,
+            impl BlockRepository<Storage = ()>,
+            impl GasFee,
+            impl CreateL1GasFee,
+            impl BaseTokenAccounts,
+            impl BlockQueries<Storage = ()>,
+            (),
+            impl StateQueries,
+        >,
+        Sender<StateMessage>,
+    ) {
+        let (state_channel, rx) = mpsc::channel(10);
+        let state = StateActor::new(
+            rx,
+            InMemoryState::new(),
+            B256::new(hex!(
+                "e56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d"
+            )),
+            0,
+            GenesisConfig::default(),
+            0x03421ee50df45cacu64,
+            MovedBlockHash,
+            (),
+            Eip1559GasFee::default(),
+            U256::ZERO,
+            MovedBaseTokenAccounts::new(AccountAddress::ONE),
+            (),
+            (),
+            MockStateQueries(height, address),
+        );
+        (state, state_channel)
     }
 }

--- a/engine-api/src/methods/mod.rs
+++ b/engine-api/src/methods/mod.rs
@@ -32,8 +32,8 @@ pub mod tests {
                 GasFee, InMemoryBlockQueries, InMemoryBlockRepository, MovedBlockHash,
             },
             genesis::{
-                config::{GenesisConfig, CHAIN_ID},
                 self,
+                config::{GenesisConfig, CHAIN_ID},
             },
             move_execution::{BaseTokenAccounts, CreateL1GasFee, MovedBaseTokenAccounts},
             primitives::{Address, B256, U256, U64},

--- a/engine-api/src/methods/mod.rs
+++ b/engine-api/src/methods/mod.rs
@@ -74,7 +74,7 @@ pub mod tests {
         let state_memory = StateMemory::from_genesis(changes.clone());
         genesis::apply(changes, table_changes, &genesis_config, &mut state);
 
-        let state = moved::state_actor::StateActor::new(
+        let state = StateActor::new(
             rx,
             state,
             head_hash,
@@ -89,6 +89,7 @@ pub mod tests {
             InMemoryBlockQueries,
             block_memory,
             InMemoryStateQueries::new(state_memory),
+            Box::new(|| Box::new(|_, _| {})),
         );
         (state, state_channel)
     }
@@ -190,6 +191,7 @@ pub mod tests {
             (),
             (),
             MockStateQueries(height, address),
+            Box::new(|| Box::new(|_, _| {})),
         );
         (state, state_channel)
     }

--- a/engine-api/src/methods/mod.rs
+++ b/engine-api/src/methods/mod.rs
@@ -155,8 +155,8 @@ pub mod tests {
     }
 
     pub fn create_state_actor_with_mock_state_queries(
-        height: u64,
         address: AccountAddress,
+        height: u64,
     ) -> (
         StateActor<
             InMemoryState,
@@ -189,7 +189,7 @@ pub mod tests {
             MovedBaseTokenAccounts::new(AccountAddress::ONE),
             (),
             (),
-            MockStateQueries(height, address),
+            MockStateQueries(address, height),
             StateActor::on_tx_noop(),
             StateActor::on_tx_batch_noop(),
         );

--- a/engine-api/src/methods/new_payload.rs
+++ b/engine-api/src/methods/new_payload.rs
@@ -310,6 +310,7 @@ mod tests {
             InMemoryBlockQueries,
             block_memory,
             InMemoryStateQueries::new(state_memory),
+            Box::new(|| Box::new(|_, _| {})),
         );
         let state_handle = state.spawn();
 

--- a/engine-api/src/methods/new_payload.rs
+++ b/engine-api/src/methods/new_payload.rs
@@ -297,6 +297,7 @@ mod tests {
             rx,
             state,
             head_hash,
+            0,
             genesis_config,
             0x0306d51fc5aa1533u64,
             B256::from(hex!(

--- a/engine-api/src/methods/new_payload.rs
+++ b/engine-api/src/methods/new_payload.rs
@@ -199,8 +199,8 @@ mod tests {
                 InMemoryBlockRepository,
             },
             genesis::{self, config::GenesisConfig},
-            move_execution::{InMemoryStateQueries, StateMemory},
             primitives::{Address, Bytes, B2048, U256, U64},
+            state_actor::InMemoryStateQueries,
             storage::InMemoryState,
         },
     };
@@ -290,8 +290,7 @@ mod tests {
 
         let mut state = InMemoryState::new();
         let (changes, table_changes) = genesis::init(&genesis_config, &state);
-        let state_memory = StateMemory::from_genesis(changes.clone());
-        genesis::apply(changes, table_changes, &genesis_config, &mut state);
+        genesis::apply(changes.clone(), table_changes, &genesis_config, &mut state);
 
         let state = moved::state_actor::StateActor::new(
             rx,
@@ -309,7 +308,8 @@ mod tests {
             (),
             InMemoryBlockQueries,
             block_memory,
-            InMemoryStateQueries::new(state_memory),
+            InMemoryStateQueries::from_genesis(changes),
+            moved::state_actor::StateActor::on_tx_noop(),
             moved::state_actor::StateActor::on_tx_batch_noop(),
         );
         let state_handle = state.spawn();

--- a/engine-api/src/methods/new_payload.rs
+++ b/engine-api/src/methods/new_payload.rs
@@ -310,7 +310,7 @@ mod tests {
             InMemoryBlockQueries,
             block_memory,
             InMemoryStateQueries::new(state_memory),
-            Box::new(|| Box::new(|_, _| {})),
+            moved::state_actor::StateActor::on_tx_batch_noop(),
         );
         let state_handle = state.spawn();
 

--- a/moved/src/block/in_memory.rs
+++ b/moved/src/block/in_memory.rs
@@ -124,3 +124,30 @@ impl BlockQueries for InMemoryBlockQueries {
         }
     }
 }
+
+#[cfg(any(feature = "test-doubles", test))]
+mod test_doubles {
+    use super::*;
+
+    impl BlockQueries for () {
+        type Storage = ();
+
+        fn by_hash(&self, _: &Self::Storage, _: B256, _: bool) -> Option<BlockResponse> {
+            None
+        }
+
+        fn by_height(&self, _: &Self::Storage, _: u64, _: bool) -> Option<BlockResponse> {
+            None
+        }
+    }
+
+    impl BlockRepository for () {
+        type Storage = ();
+
+        fn add(&mut self, _storage: &mut Self::Storage, _block: ExtendedBlock) {}
+
+        fn by_hash(&self, _storage: &Self::Storage, _hash: B256) -> Option<ExtendedBlock> {
+            None
+        }
+    }
+}

--- a/moved/src/genesis/config.rs
+++ b/moved/src/genesis/config.rs
@@ -41,7 +41,7 @@ impl Default for GenesisConfig {
         Self {
             chain_id: CHAIN_ID,
             initial_state_root: B256::from(hex!(
-                "1e593e412b2c9ed74732e9798d7a51d03f5ed10eb4abe5b4e09226a7bfd2db50"
+                "b5553bd1ab606b26e0881d1f42abd99293ce22762d513e03f3103c0f1ec54a1b"
             )),
             gas_costs: GasCosts::default(),
             treasury: AccountAddress::ONE, // todo: fill in the real address

--- a/moved/src/genesis/config.rs
+++ b/moved/src/genesis/config.rs
@@ -41,7 +41,7 @@ impl Default for GenesisConfig {
         Self {
             chain_id: CHAIN_ID,
             initial_state_root: B256::from(hex!(
-                "f17c78c498a96d429b3f6a40da3699b3becaab435b7fd2cc73abded66acdcb91"
+                "1e593e412b2c9ed74732e9798d7a51d03f5ed10eb4abe5b4e09226a7bfd2db50"
             )),
             gas_costs: GasCosts::default(),
             treasury: AccountAddress::ONE, // todo: fill in the real address

--- a/moved/src/genesis/framework.rs
+++ b/moved/src/genesis/framework.rs
@@ -227,8 +227,8 @@ mod tests {
             .count();
         assert_eq!(sui_framework_len, SUI_MODULES_LEN);
 
-        let mut state = InMemoryState::new();
-        let (change_set, _) = deploy_framework(&mut state).unwrap();
+        let state = InMemoryState::new();
+        let (change_set, _) = deploy_framework(&state).unwrap();
         assert_eq!(change_set.modules().count(), TOTAL_MODULES_LEN);
     }
 }

--- a/moved/src/genesis/l2_contracts.rs
+++ b/moved/src/genesis/l2_contracts.rs
@@ -2,11 +2,9 @@ use {
     crate::{move_execution, storage::State},
     alloy::genesis::Genesis,
     move_binary_format::errors::PartialVMError,
+    move_core_types::effects::ChangeSet,
 };
 
-pub fn init_state(genesis: Genesis, state: &mut impl State<Err = PartialVMError>) {
-    let changes = move_execution::genesis_state_changes(genesis, state.resolver());
-    state
-        .apply(changes)
-        .expect("L2 contract changes must apply");
+pub fn init_state(genesis: Genesis, state: &impl State<Err = PartialVMError>) -> ChangeSet {
+    move_execution::genesis_state_changes(genesis, state.resolver())
 }

--- a/moved/src/move_execution/gas.rs
+++ b/moved/src/move_execution/gas.rs
@@ -139,13 +139,13 @@ impl L1GasFee for EcotoneL1GasFee {
 pub trait CreateL1GasFee {
     /// Extracts parameters from deposit transaction and creates the algorithm for calculating L1
     /// gas cost.
-    fn for_deposit(&self, data: &[u8]) -> impl L1GasFee + '_;
+    fn for_deposit(&self, data: &[u8]) -> impl L1GasFee + 'static;
 }
 
 pub struct CreateEcotoneL1GasFee;
 
 impl CreateL1GasFee for CreateEcotoneL1GasFee {
-    fn for_deposit(&self, data: &[u8]) -> impl L1GasFee + '_ {
+    fn for_deposit(&self, data: &[u8]) -> impl L1GasFee + 'static {
         let l1_base_fee = U256::from_be_slice(&data[36..68]);
         let l1_blob_base_fee = U256::from_be_slice(&data[68..100]);
         let l1_base_fee_scalar =
@@ -177,7 +177,7 @@ mod tests {
     }
 
     impl CreateL1GasFee for U256 {
-        fn for_deposit(&self, _data: &[u8]) -> impl L1GasFee + '_ {
+        fn for_deposit(&self, _data: &[u8]) -> impl L1GasFee + 'static {
             *self
         }
     }

--- a/moved/src/move_execution/mod.rs
+++ b/moved/src/move_execution/mod.rs
@@ -3,7 +3,7 @@ pub use {
     evm_native::genesis_state_changes,
     gas::{CreateEcotoneL1GasFee, CreateL1GasFee, EcotoneL1GasFee, L1GasFee, L1GasFeeInput},
     nonces::quick_get_nonce,
-    state::{InMemoryStateQueries, StateMemory, StateQueries},
+    state::{Balance, BlockHeight, InMemoryStateQueries, Nonce, StateMemory, StateQueries},
 };
 
 use {
@@ -48,9 +48,9 @@ mod execute;
 mod gas;
 mod nonces;
 pub(crate) mod simulate;
+mod state;
 mod tag_validation;
 
-mod state;
 #[cfg(test)]
 mod tests;
 

--- a/moved/src/move_execution/mod.rs
+++ b/moved/src/move_execution/mod.rs
@@ -1,5 +1,5 @@
 pub use {
-    eth_token::{quick_get_eth_balance, BaseTokenAccounts, MovedBaseTokenAccounts},
+    eth_token::{mint_eth, quick_get_eth_balance, BaseTokenAccounts, MovedBaseTokenAccounts},
     evm_native::genesis_state_changes,
     gas::{CreateEcotoneL1GasFee, CreateL1GasFee, EcotoneL1GasFee, L1GasFee, L1GasFeeInput},
     nonces::quick_get_nonce,

--- a/moved/src/move_execution/mod.rs
+++ b/moved/src/move_execution/mod.rs
@@ -2,8 +2,7 @@ pub use {
     eth_token::{mint_eth, quick_get_eth_balance, BaseTokenAccounts, MovedBaseTokenAccounts},
     evm_native::genesis_state_changes,
     gas::{CreateEcotoneL1GasFee, CreateL1GasFee, EcotoneL1GasFee, L1GasFee, L1GasFeeInput},
-    nonces::quick_get_nonce,
-    state::{Balance, BlockHeight, InMemoryStateQueries, Nonce, StateMemory, StateQueries},
+    nonces::{check_nonce, quick_get_nonce},
 };
 
 use {
@@ -48,7 +47,6 @@ mod execute;
 mod gas;
 mod nonces;
 pub(crate) mod simulate;
-mod state;
 mod tag_validation;
 
 #[cfg(test)]

--- a/moved/src/move_execution/mod.rs
+++ b/moved/src/move_execution/mod.rs
@@ -49,6 +49,7 @@ mod nonces;
 pub(crate) mod simulate;
 mod tag_validation;
 
+mod state;
 #[cfg(test)]
 mod tests;
 

--- a/moved/src/move_execution/mod.rs
+++ b/moved/src/move_execution/mod.rs
@@ -3,6 +3,7 @@ pub use {
     evm_native::genesis_state_changes,
     gas::{CreateEcotoneL1GasFee, CreateL1GasFee, EcotoneL1GasFee, L1GasFee, L1GasFeeInput},
     nonces::quick_get_nonce,
+    state::{InMemoryStateQueries, StateMemory, StateQueries},
 };
 
 use {

--- a/moved/src/move_execution/nonces.rs
+++ b/moved/src/move_execution/nonces.rs
@@ -47,7 +47,7 @@ pub fn quick_get_nonce(
     .unwrap_or_default()
 }
 
-pub(super) fn check_nonce<G: GasMeter>(
+pub fn check_nonce<G: GasMeter>(
     tx_nonce: u64,
     signer: &AccountAddress,
     session: &mut Session,

--- a/moved/src/move_execution/state.rs
+++ b/moved/src/move_execution/state.rs
@@ -12,9 +12,9 @@ use {
     std::ops::Bound,
 };
 
-type Balance = U256;
-type Nonce = u64;
-type BlockHeight = u64;
+pub type Balance = U256;
+pub type Nonce = u64;
+pub type BlockHeight = u64;
 
 pub trait StateQueries {
     /// The associated storage type for querying the blockchain state.

--- a/moved/src/move_execution/state.rs
+++ b/moved/src/move_execution/state.rs
@@ -33,8 +33,6 @@ pub trait StateQueries {
     /// Queries the blockchain state version corresponding with block `height` for the nonce value
     /// associated with `account`.
     fn nonce_at(&self, account: AccountAddress, height: BlockHeight) -> Nonce;
-
-    fn add(&mut self, changes: ChangeSet);
 }
 
 #[derive(Debug)]
@@ -91,6 +89,10 @@ impl InMemoryStateQueries {
     pub fn new(storage: StateMemory) -> Self {
         Self { storage }
     }
+
+    pub fn add(&mut self, change: ChangeSet) {
+        self.storage.add(change);
+    }
 }
 
 impl StateQueries for InMemoryStateQueries {
@@ -118,10 +120,6 @@ impl StateQueries for InMemoryStateQueries {
         let resolver = self.storage.resolver(Bound::Included(height as usize));
 
         quick_get_nonce(&account, &resolver)
-    }
-
-    fn add(&mut self, change: ChangeSet) {
-        self.storage.add(change);
     }
 }
 

--- a/moved/src/move_execution/state.rs
+++ b/moved/src/move_execution/state.rs
@@ -33,6 +33,8 @@ pub trait StateQueries {
     /// Queries the blockchain state version corresponding with block `height` for the nonce value
     /// associated with `account`.
     fn nonce_at(&self, account: AccountAddress, height: BlockHeight) -> Nonce;
+
+    fn add(&mut self, changes: ChangeSet);
 }
 
 #[derive(Debug)]
@@ -89,10 +91,6 @@ impl InMemoryStateQueries {
     pub fn new(storage: StateMemory) -> Self {
         Self { storage }
     }
-
-    pub fn add(&mut self, change: ChangeSet) {
-        self.storage.add(change);
-    }
 }
 
 impl StateQueries for InMemoryStateQueries {
@@ -120,6 +118,10 @@ impl StateQueries for InMemoryStateQueries {
         let resolver = self.storage.resolver(Bound::Included(height as usize));
 
         quick_get_nonce(&account, &resolver)
+    }
+
+    fn add(&mut self, change: ChangeSet) {
+        self.storage.add(change);
     }
 }
 

--- a/moved/src/move_execution/state.rs
+++ b/moved/src/move_execution/state.rs
@@ -1,0 +1,360 @@
+use {
+    crate::{
+        move_execution::{quick_get_eth_balance, quick_get_nonce},
+        primitives::U256,
+    },
+    move_binary_format::errors::PartialVMError,
+    move_core_types::{
+        account_address::AccountAddress, effects::ChangeSet, resolver::MoveResolver,
+    },
+    move_table_extension::TableResolver,
+    move_vm_test_utils::InMemoryStorage,
+    std::ops::Bound,
+};
+
+type Balance = U256;
+type Nonce = u64;
+type BlockHeight = u64;
+
+pub trait StateQuery {
+    /// The associated storage type for querying the blockchain state.
+    type Storage;
+
+    /// Queries the current blockchain state for amount of base token associated with `account`.
+    fn balance(&self, account: AccountAddress) -> Balance;
+
+    /// Queries the blockchain state version corresponding with block `height` for amount of base
+    /// token associated with `account`.
+    fn balance_at(&self, account: AccountAddress, height: BlockHeight) -> Balance;
+
+    /// Queries the current blockchain state for the nonce value associated with `account`.
+    fn nonce(&self, account: AccountAddress) -> Nonce;
+
+    /// Queries the blockchain state version corresponding with block `height` for the nonce value
+    /// associated with `account`.
+    fn nonce_at(&self, account: AccountAddress, height: BlockHeight) -> Nonce;
+}
+
+#[derive(Debug, Default)]
+pub struct InMemoryStateQueryStorage {
+    changes: Vec<ChangeSet>,
+}
+
+impl InMemoryStateQueryStorage {
+    pub fn add(&mut self, change: ChangeSet) {
+        self.changes.push(change);
+    }
+
+    pub fn resolver(
+        &self,
+        upper: Bound<usize>,
+    ) -> impl MoveResolver<PartialVMError> + TableResolver {
+        let mut state = InMemoryStorage::new();
+
+        for change in self.changes[(Bound::Included(0), upper)].iter() {
+            state.apply(change.clone()).expect(
+                "The changeset should be applicable as it was previously applied in write storage",
+            );
+        }
+
+        state
+    }
+}
+
+#[derive(Debug)]
+pub struct InMemoryStateQuery {
+    storage: InMemoryStateQueryStorage,
+}
+
+impl InMemoryStateQuery {
+    pub fn new(storage: InMemoryStateQueryStorage) -> Self {
+        Self { storage }
+    }
+
+    pub fn add(&mut self, change: ChangeSet) {
+        self.storage.add(change);
+    }
+}
+
+impl StateQuery for InMemoryStateQuery {
+    type Storage = InMemoryStateQueryStorage;
+
+    fn balance(&self, account: AccountAddress) -> Balance {
+        let resolver = self.storage.resolver(Bound::Unbounded);
+
+        quick_get_eth_balance(&account, &resolver)
+    }
+
+    fn balance_at(&self, account: AccountAddress, height: BlockHeight) -> Balance {
+        let resolver = self.storage.resolver(Bound::Included(height as usize));
+
+        quick_get_eth_balance(&account, &resolver)
+    }
+
+    fn nonce(&self, account: AccountAddress) -> Nonce {
+        let resolver = self.storage.resolver(Bound::Unbounded);
+
+        quick_get_nonce(&account, &resolver)
+    }
+
+    fn nonce_at(&self, account: AccountAddress, height: BlockHeight) -> Nonce {
+        let resolver = self.storage.resolver(Bound::Included(height as usize));
+
+        quick_get_nonce(&account, &resolver)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            genesis::{config::GenesisConfig, init_state},
+            move_execution::{
+                create_move_vm, create_vm_session, eth_token::mint_eth, nonces::check_nonce,
+            },
+            primitives::B256,
+            storage::{InMemoryState, State},
+            types::session_id::SessionId,
+        },
+        alloy::hex,
+        move_table_extension::TableChangeSet,
+        move_vm_runtime::module_traversal::{TraversalContext, TraversalStorage},
+        move_vm_types::gas::UnmeteredGasMeter,
+    };
+
+    struct StateSpy(InMemoryState, ChangeSet);
+
+    impl State for StateSpy {
+        type Err = <InMemoryState as State>::Err;
+
+        fn apply(&mut self, changes: ChangeSet) -> Result<(), Self::Err> {
+            self.1.squash(changes.clone()).unwrap();
+            self.0.apply(changes)
+        }
+
+        fn apply_with_tables(
+            &mut self,
+            changes: ChangeSet,
+            table_changes: TableChangeSet,
+        ) -> Result<(), Self::Err> {
+            self.1.squash(changes.clone()).unwrap();
+            self.0.apply_with_tables(changes, table_changes)
+        }
+
+        fn resolver(&self) -> &(impl MoveResolver<Self::Err> + TableResolver) {
+            self.0.resolver()
+        }
+
+        fn state_root(&self) -> B256 {
+            self.0.state_root()
+        }
+    }
+
+    fn mint_one_eth(
+        state: &mut impl State<Err = PartialVMError>,
+        addr: AccountAddress,
+    ) -> ChangeSet {
+        let move_vm = create_move_vm().unwrap();
+        let mut session = create_vm_session(&move_vm, state.resolver(), SessionId::default());
+        let traversal_storage = TraversalStorage::new();
+        let mut traversal_context = TraversalContext::new(&traversal_storage);
+        let mut gas_meter = UnmeteredGasMeter;
+
+        mint_eth(
+            &addr,
+            U256::from(1u64),
+            &mut session,
+            &mut traversal_context,
+            &mut gas_meter,
+        )
+        .unwrap();
+
+        let changes = session.finish().unwrap();
+
+        state.apply(changes.clone()).unwrap();
+
+        changes
+    }
+
+    #[test]
+    fn test_query_fetches_latest_balance() {
+        let state = InMemoryState::new();
+        let mut state = StateSpy(state, ChangeSet::new());
+
+        let genesis_config = GenesisConfig::default();
+        init_state(&genesis_config, &mut state);
+
+        let (mut state, genesis_changes) = (state.0, state.1);
+
+        let addr = AccountAddress::TWO;
+
+        let mut storage = InMemoryStateQueryStorage::default();
+
+        storage.add(genesis_changes);
+        storage.add(mint_one_eth(&mut state, addr));
+
+        let query = InMemoryStateQuery::new(storage);
+
+        let actual_balance = query.balance(addr);
+        let expected_balance = U256::from(1u64);
+
+        assert_eq!(actual_balance, expected_balance);
+    }
+
+    #[test]
+    fn test_query_fetches_older_balance() {
+        let state = InMemoryState::new();
+        let mut state = StateSpy(state, ChangeSet::new());
+
+        let genesis_config = GenesisConfig::default();
+        init_state(&genesis_config, &mut state);
+
+        let (mut state, genesis_changes) = (state.0, state.1);
+
+        let addr = AccountAddress::TWO;
+        let mut storage = InMemoryStateQueryStorage::default();
+
+        storage.add(genesis_changes);
+        storage.add(mint_one_eth(&mut state, addr));
+        storage.add(mint_one_eth(&mut state, addr));
+        storage.add(mint_one_eth(&mut state, addr));
+
+        let query = InMemoryStateQuery::new(storage);
+
+        let actual_balance = query.balance_at(addr, 1);
+        let expected_balance = U256::from(1u64);
+
+        assert_eq!(actual_balance, expected_balance);
+    }
+
+    #[test]
+    fn test_query_fetches_zero_balance_for_non_existent_account() {
+        let state = InMemoryState::new();
+        let mut state = StateSpy(state, ChangeSet::new());
+
+        let genesis_config = GenesisConfig::default();
+        init_state(&genesis_config, &mut state);
+
+        let genesis_changes = state.1;
+
+        let addr = AccountAddress::new(hex!(
+            "123456136717634683648732647632874638726487fefefefefeefefefefefff"
+        ));
+
+        let mut storage = InMemoryStateQueryStorage::default();
+
+        storage.add(genesis_changes);
+
+        let query = InMemoryStateQuery::new(storage);
+
+        let actual_balance = query.balance(addr);
+        let expected_balance = U256::ZERO;
+
+        assert_eq!(actual_balance, expected_balance);
+    }
+
+    fn inc_one_nonce(
+        old_nonce: u64,
+        state: &mut impl State<Err = PartialVMError>,
+        addr: AccountAddress,
+    ) -> ChangeSet {
+        let move_vm = create_move_vm().unwrap();
+        let mut session = create_vm_session(&move_vm, state.resolver(), SessionId::default());
+        let traversal_storage = TraversalStorage::new();
+        let mut traversal_context = TraversalContext::new(&traversal_storage);
+        let mut gas_meter = UnmeteredGasMeter;
+
+        check_nonce(
+            old_nonce,
+            &addr,
+            &mut session,
+            &mut traversal_context,
+            &mut gas_meter,
+        )
+        .unwrap();
+
+        let changes = session.finish().unwrap();
+
+        state.apply(changes.clone()).unwrap();
+
+        changes
+    }
+
+    #[test]
+    fn test_query_fetches_latest_nonce() {
+        let state = InMemoryState::new();
+        let mut state = StateSpy(state, ChangeSet::new());
+
+        let genesis_config = GenesisConfig::default();
+        init_state(&genesis_config, &mut state);
+
+        let (mut state, genesis_changes) = (state.0, state.1);
+
+        let addr = AccountAddress::TWO;
+
+        let mut storage = InMemoryStateQueryStorage::default();
+
+        storage.add(genesis_changes);
+        storage.add(inc_one_nonce(0, &mut state, addr));
+
+        let query = InMemoryStateQuery::new(storage);
+
+        let actual_nonce = query.nonce(addr);
+        let expected_nonce = 1u64;
+
+        assert_eq!(actual_nonce, expected_nonce);
+    }
+
+    #[test]
+    fn test_query_fetches_older_nonce() {
+        let state = InMemoryState::new();
+        let mut state = StateSpy(state, ChangeSet::new());
+
+        let genesis_config = GenesisConfig::default();
+        init_state(&genesis_config, &mut state);
+
+        let (mut state, genesis_changes) = (state.0, state.1);
+
+        let addr = AccountAddress::TWO;
+        let mut storage = InMemoryStateQueryStorage::default();
+
+        storage.add(genesis_changes);
+        storage.add(inc_one_nonce(0, &mut state, addr));
+        storage.add(inc_one_nonce(1, &mut state, addr));
+        storage.add(inc_one_nonce(2, &mut state, addr));
+
+        let query = InMemoryStateQuery::new(storage);
+
+        let actual_nonce = query.nonce_at(addr, 1);
+        let expected_nonce = 1u64;
+
+        assert_eq!(actual_nonce, expected_nonce);
+    }
+
+    #[test]
+    fn test_query_fetches_zero_nonce_for_non_existent_account() {
+        let state = InMemoryState::new();
+        let mut state = StateSpy(state, ChangeSet::new());
+
+        let genesis_config = GenesisConfig::default();
+        init_state(&genesis_config, &mut state);
+
+        let genesis_changes = state.1;
+
+        let addr = AccountAddress::new(hex!(
+            "123456136717634683648732647632874638726487fefefefefeefefefefefff"
+        ));
+
+        let mut storage = InMemoryStateQueryStorage::default();
+
+        storage.add(genesis_changes);
+
+        let query = InMemoryStateQuery::new(storage);
+
+        let actual_nonce = query.nonce(addr);
+        let expected_nonce = 0u64;
+
+        assert_eq!(actual_nonce, expected_nonce);
+    }
+}

--- a/moved/src/move_execution/tests/mod.rs
+++ b/moved/src/move_execution/tests/mod.rs
@@ -4,7 +4,7 @@ use {
     super::*,
     crate::{
         block::HeaderForExecution,
-        genesis::{config::CHAIN_ID, init_state, L2_CROSS_DOMAIN_MESSENGER_ADDRESS},
+        genesis::{config::CHAIN_ID, init_and_apply, L2_CROSS_DOMAIN_MESSENGER_ADDRESS},
         move_execution::eth_token::quick_get_eth_balance,
         primitives::{ToMoveAddress, ToMoveU256, B256, U256, U64},
         storage::{InMemoryState, State},

--- a/moved/src/move_execution/tests/utils.rs
+++ b/moved/src/move_execution/tests/utils.rs
@@ -66,7 +66,7 @@ impl TestContext {
     pub fn new() -> Self {
         let genesis_config = GenesisConfig::default();
         let mut state = InMemoryState::new();
-        init_state(&genesis_config, &mut state);
+        init_and_apply(&genesis_config, &mut state);
 
         Self {
             state,

--- a/moved/src/state_actor.rs
+++ b/moved/src/state_actor.rs
@@ -13,10 +13,9 @@ use {
         },
         genesis::config::GenesisConfig,
         move_execution::{
-            execute_transaction, quick_get_nonce,
+            execute_transaction,
             simulate::{call_transaction, simulate_transaction},
-            BaseTokenAccounts, CreateL1GasFee, L1GasFee,
-            L1GasFeeInput, LogsBloom,
+            BaseTokenAccounts, CreateL1GasFee, L1GasFee, L1GasFeeInput, LogsBloom,
         },
         primitives::{self, ToEthAddress, ToMoveAddress, ToSaturatedU64, B256, U256, U64},
         storage::State,
@@ -32,7 +31,10 @@ use {
     },
     alloy::{
         consensus::Receipt,
-        eips::{eip2718::Encodable2718, BlockNumberOrTag, BlockNumberOrTag::*},
+        eips::{
+            eip2718::Encodable2718,
+            BlockNumberOrTag::{self, *},
+        },
         primitives::{keccak256, Bloom},
         rlp::{Decodable, Encodable},
         rpc::types::{FeeHistory, TransactionReceipt as AlloyTxReceipt},

--- a/moved/src/state_actor.rs
+++ b/moved/src/state_actor.rs
@@ -613,7 +613,7 @@ mod test_doubles {
         move_core_types::account_address::AccountAddress,
     };
 
-    pub struct MockStateQueries(pub BlockHeight, pub AccountAddress);
+    pub struct MockStateQueries(pub AccountAddress, pub BlockHeight);
 
     impl StateQueries for MockStateQueries {
         type Storage = ();
@@ -624,8 +624,8 @@ mod test_doubles {
             account: AccountAddress,
             height: BlockHeight,
         ) -> Option<Balance> {
-            assert_eq!(height, self.0);
-            assert_eq!(account, self.1);
+            assert_eq!(account, self.0);
+            assert_eq!(height, self.1);
 
             Some(U256::from(5))
         }
@@ -636,8 +636,8 @@ mod test_doubles {
             account: AccountAddress,
             height: BlockHeight,
         ) -> Option<Nonce> {
-            assert_eq!(height, self.0);
-            assert_eq!(account, self.1);
+            assert_eq!(account, self.0);
+            assert_eq!(height, self.1);
 
             Some(3)
         }
@@ -911,7 +911,7 @@ mod tests {
         let address = primitives::Address::new(hex!("11223344556677889900ffeeaabbccddee111111"));
         let (state_actor, _) = create_state_actor_with_given_queries(
             head_height,
-            MockStateQueries(expected_height, address.to_move_address()),
+            MockStateQueries(address.to_move_address(), expected_height),
         );
         let (tx, rx) = oneshot::channel();
 
@@ -941,7 +941,7 @@ mod tests {
         let address = primitives::Address::new(hex!("44223344556677889900ffeeaabbccddee111111"));
         let (state_actor, _) = create_state_actor_with_given_queries(
             head_height,
-            MockStateQueries(expected_height, address.to_move_address()),
+            MockStateQueries(address.to_move_address(), expected_height),
         );
         let (tx, rx) = oneshot::channel();
 

--- a/moved/src/state_actor.rs
+++ b/moved/src/state_actor.rs
@@ -602,10 +602,6 @@ mod test_doubles {
     impl StateQueries for MockStateQueries {
         type Storage = ();
 
-        fn balance(&self, _account: AccountAddress) -> crate::move_execution::Balance {
-            unimplemented!()
-        }
-
         fn balance_at(
             &self,
             account: AccountAddress,
@@ -615,10 +611,6 @@ mod test_doubles {
             assert_eq!(account, self.1);
 
             U256::from(5)
-        }
-
-        fn nonce(&self, _account: AccountAddress) -> crate::move_execution::Nonce {
-            unimplemented!()
         }
 
         fn nonce_at(

--- a/moved/src/state_actor/queries.rs
+++ b/moved/src/state_actor/queries.rs
@@ -642,6 +642,13 @@ mod tests {
         let expected_nonce = 1u64;
 
         assert_eq!(actual_nonce, expected_nonce);
+
+        let actual_nonce = query
+            .nonce_at(state.db(), addr, 2)
+            .expect("Block height should exist");
+        let expected_nonce = 3u64;
+
+        assert_eq!(actual_nonce, expected_nonce);
     }
 
     #[test]

--- a/moved/src/state_actor/queries.rs
+++ b/moved/src/state_actor/queries.rs
@@ -76,7 +76,7 @@ impl StateMemory {
     /// Creates state memory with `genesis_changes` on `version` 0 tagged as block `height` 0.
     pub fn from_genesis(genesis_changes: ChangeSet) -> Self {
         Self {
-            mem: InMemoryVersionedState::from_iter(genesis_changes.into_versioned_kv(0)),
+            mem: InMemoryVersionedState::from_iter(genesis_changes.into_versioned_map(0)),
             tags: vec![0],
             version: 0,
         }
@@ -84,7 +84,7 @@ impl StateMemory {
 
     fn add(&mut self, changes: ChangeSet) {
         let version = self.next_version();
-        for (k, v) in changes.into_versioned_kv(version) {
+        for (k, v) in changes.into_versioned_map(version) {
             self.mem.historic_state.insert(k, v);
         }
     }
@@ -111,9 +111,9 @@ impl StateMemory {
     }
 }
 
-/// The `IntoVersionedKv` trait is defined by a single operation [`Self::into_versioned_kv`]. See
+/// The `IntoVersionedMap` trait is defined by a single operation [`Self::into_versioned_map`]. See
 /// its documentation for details.
-trait IntoVersionedKv {
+trait IntoVersionedMap {
     /// Converts a set of changes into an iterator of key-value pairs where:
     ///
     /// * *Key* is a pair of [`StateKey`] and [`Version`]. It is a fully qualified name of a module
@@ -127,14 +127,14 @@ trait IntoVersionedKv {
     /// associated with a list of operations on its modules and resources.
     ///
     /// The term "operation" is a ternary value of either addition, modification or deletion.
-    fn into_versioned_kv(
+    fn into_versioned_map(
         self,
         version: Version,
     ) -> impl Iterator<Item = ((StateKey, Version), Option<StateValue>)>;
 }
 
-impl IntoVersionedKv for ChangeSet {
-    fn into_versioned_kv(
+impl IntoVersionedMap for ChangeSet {
+    fn into_versioned_map(
         self,
         version: Version,
     ) -> impl Iterator<Item = ((StateKey, Version), Option<StateValue>)> {

--- a/moved/src/storage.rs
+++ b/moved/src/storage.rs
@@ -48,6 +48,8 @@ pub trait State {
         table_changes: TableChangeSet,
     ) -> Result<(), Self::Err>;
 
+    fn db(&self) -> &(impl TreeReader<StateKey> + Sync);
+
     /// Returns a reference to a [`MoveResolver`] that can resolve both resources and modules.
     fn resolver(&self) -> &(impl MoveResolver<Self::Err> + TableResolver);
 
@@ -100,6 +102,10 @@ impl State for InMemoryState {
         self.insert_change_set_into_merkle_trie(&changes);
         self.resolver.apply_extended(changes, table_changes)?;
         Ok(())
+    }
+
+    fn db(&self) -> &(impl TreeReader<StateKey> + Sync) {
+        &self.db
     }
 
     fn resolver(&self) -> &(impl MoveResolver<Self::Err> + TableResolver) {

--- a/moved/src/storage.rs
+++ b/moved/src/storage.rs
@@ -264,7 +264,8 @@ where
             shard_root_nodes[shard_id as usize] = shard_root_node;
         }
 
-        let (root_hash, root_batch) = self.put_top_levels_nodes(shard_root_nodes.to_vec(), version.checked_sub(1), version)?;
+        let (root_hash, root_batch) =
+            self.put_top_levels_nodes(shard_root_nodes.to_vec(), version.checked_sub(1), version)?;
         tree_update_batch.combine(root_batch);
         Ok((root_hash, tree_update_batch))
     }

--- a/moved/src/types/state.rs
+++ b/moved/src/types/state.rs
@@ -172,12 +172,12 @@ pub enum Query {
     BalanceByHeight {
         address: Address,
         height: BlockNumberOrTag,
-        response_channel: oneshot::Sender<U256>,
+        response_channel: oneshot::Sender<Option<U256>>,
     },
     NonceByHeight {
         address: Address,
         height: BlockNumberOrTag,
-        response_channel: oneshot::Sender<u64>,
+        response_channel: oneshot::Sender<Option<u64>>,
     },
     BlockByHash {
         hash: B256,

--- a/moved/src/types/state.rs
+++ b/moved/src/types/state.rs
@@ -169,14 +169,14 @@ pub enum Query {
     ChainId {
         response_channel: oneshot::Sender<u64>,
     },
-    GetBalance {
+    BalanceByHeight {
         address: Address,
-        block_number: BlockNumberOrTag,
+        height: BlockNumberOrTag,
         response_channel: oneshot::Sender<U256>,
     },
-    GetNonce {
+    NonceByHeight {
         address: Address,
-        block_number: BlockNumberOrTag,
+        height: BlockNumberOrTag,
         response_channel: oneshot::Sender<u64>,
     },
     BlockByHash {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -115,6 +115,7 @@ pub async fn run() {
         InMemoryBlockQueries,
         block_memory,
         state_query,
+        Box::new(|| Box::new(|state, changes| state.state_queries.add(changes))),
     );
 
     let http_state_channel = state_channel.clone();

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -115,7 +115,7 @@ pub async fn run() {
         InMemoryBlockQueries,
         block_memory,
         state_query,
-        Box::new(|| Box::new(|state, changes| state.state_queries.add(changes))),
+        moved::state_actor::StateActor::on_tx_batch_in_memory(),
     );
 
     let http_state_channel = state_channel.clone();

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -101,6 +101,7 @@ pub async fn run() {
         rx,
         state,
         head,
+        0,
         genesis_config,
         StatePayloadId,
         block_hash,


### PR DESCRIPTION
### Description
Implements historical lookup of balances and nonces from the blockchain state.

### Changes
- Add state queries for balance and nonce retrieval of any known block height.

### Testing
- Unit test of endpoint
- Unit test of state actor
- Unit test of state queries
