### PR TITLE
Feat(rpc): Implement eth_call by transaction simulation

### DIFF
--- a/engine-api/src/methods/call.rs
+++ b/engine-api/src/methods/call.rs
@@ -1,6 +1,10 @@
 use {
-    crate::{json_utils, json_utils::access_state_error, jsonrpc::JsonRpcError},
-    alloy::{eips::BlockNumberOrTag, hex, rpc::types::TransactionRequest},
+    crate::{
+        json_utils,
+        json_utils::{access_state_error, transaction_error},
+        jsonrpc::JsonRpcError,
+    },
+    alloy::{eips::BlockNumberOrTag, rpc::types::TransactionRequest},
     moved::types::state::{Query, StateMessage},
     tokio::sync::{mpsc, oneshot},
 };
@@ -12,8 +16,7 @@ pub async fn execute(
     let (transaction, block_number) = parse_params(request)?;
     let response = inner_execute(transaction, block_number, state_channel).await?;
 
-    Ok(serde_json::to_value(hex::encode_prefixed(response))
-        .expect("Must be able to JSON-serialize response"))
+    Ok(serde_json::to_value(response).expect("Must be able to JSON-serialize response"))
 }
 
 fn parse_params(
@@ -53,14 +56,21 @@ async fn inner_execute(
     .into();
     state_channel.send(msg).await.map_err(access_state_error)?;
     let response = rx.await.map_err(access_state_error)?;
-    Ok(response)
+    response.map_err(transaction_error)
 }
 
 #[cfg(test)]
 mod tests {
     use {
-        super::*, crate::methods::tests::create_state_actor, alloy::primitives::Address,
-        moved::primitives::U64, std::str::FromStr, test_case::test_case,
+        super::*,
+        crate::methods::tests::{create_state_actor, deploy_contract, deposit_eth},
+        alloy::{
+            hex::FromHex,
+            primitives::{Address, Bytes},
+        },
+        moved::primitives::U64,
+        std::str::FromStr,
+        test_case::test_case,
     };
 
     #[test_case("0x1")]
@@ -100,28 +110,63 @@ mod tests {
     #[test_case("latest")]
     #[test_case("pending")]
     #[tokio::test]
-    async fn test_execute(block: &str) {
+    async fn test_execute_call_entry_fn(block: &str) {
         let (state_actor, state_channel) = create_state_actor();
-
         let state_handle = state_actor.spawn();
+
+        // Add funds to the account to deploy the `counter` contract
+        deposit_eth("0x8fd379246834eac74b8419ffda202cf8051f7a03", &state_channel).await;
+        deploy_contract(Bytes::from_hex("01fd01a11ceb0b0600000009010002020204030614051a0e07283d0865200a8501050c8a01490dd3010200000001080000020001000003000200000400030000050403000105010101030002060c0301070307636f756e74657207436f756e7465720e636f756e7465725f657869737473096765745f636f756e7409696e6372656d656e74077075626c69736801690000000000000000000000008fd379246834eac74b8419ffda202cf8051f7a0300020106030001000003030b00290002010100010003050b002b00100014020201040100050b0b002a000f000c010a0114060100000000000000160b0115020301040003050b000b0112002d0002000000").unwrap(), &state_channel).await;
+
+        // Check if the count exists for an address, which returns false
         let request: serde_json::Value = serde_json::json!({
             "jsonrpc": "2.0",
             "method": "eth_call",
             "params": [
                 {
-                    "from": "0x0000000000000000000000000000000000000001",
-                    "to": null,
-                    "input": "0xa11ce0"
+                    "from": "0x8fd379246834eac74b8419ffda202cf8051f7a03",
+                    "to": "0x8fd379246834eac74b8419ffda202cf8051f7a03",
+                    "input": "0x020000000000000000000000008fd379246834eac74b8419ffda202cf8051f7a0307636f756e7465720e636f756e7465725f6578697374730001200000000000000000000000000000000000000000000000000000000000000b0b"
                 },
                 block,
             ],
             "id": 1
         });
 
-        let expected_response: serde_json::Value = serde_json::from_str(r#""0x""#).unwrap();
+        let expected_response = serde_json::json!([1, 1, 0, 0]);
         let response = execute(request, state_channel).await.unwrap();
 
         assert_eq!(response, expected_response);
+        state_handle.await.unwrap();
+    }
+
+    #[test_case("0x1")]
+    #[test_case("latest")]
+    #[test_case("pending")]
+    #[tokio::test]
+    async fn test_execute_call_script(block: &str) {
+        let (state_actor, state_channel) = create_state_actor();
+        let state_handle = state_actor.spawn();
+
+        // Add funds to the account to deploy the `counter` contract
+        deposit_eth("0x8fd379246834eac74b8419ffda202cf8051f7a03", &state_channel).await;
+        deploy_contract(Bytes::from_hex("01fd01a11ceb0b0600000009010002020204030614051a0e07283d0865200a8501050c8a01490dd3010200000001080000020001000003000200000400030000050403000105010101030002060c0301070307636f756e74657207436f756e7465720e636f756e7465725f657869737473096765745f636f756e7409696e6372656d656e74077075626c69736801690000000000000000000000008fd379246834eac74b8419ffda202cf8051f7a0300020106030001000003030b00290002010100010003050b002b00100014020201040100050b0b002a000f000c010a0114060100000000000000160b0115020301040003050b000b0112002d0002000000").unwrap(), &state_channel).await;
+
+        let request: serde_json::Value = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_call",
+            "params": [
+                {
+                    "from": "0x8fd379246834eac74b8419ffda202cf8051f7a03",
+                    "input": "00fb01a11ceb0b060000000501000403041405180c072436085a4000000101000203010001030002000104010400010501020002060c0301050001060c0103067369676e657207636f756e7465720a616464726573735f6f66077075626c697368096765745f636f756e7409696e6372656d656e7400000000000000000000000000000000000000000000000000000000000000010000000000000000000000008fd379246834eac74b8419ffda202cf8051f7a030000011b0a0011000c020b000a0111010a0211020a0121040c050e060000000000000000270a0211030b0211020b0106010000000000000016210418051a06010000000000000027020001010d00000000000000"
+                },
+                block,
+            ],
+            "id": 1
+        });
+        // Counter script call should succeed
+        execute(request, state_channel).await.unwrap();
+
         state_handle.await.unwrap();
     }
 }

--- a/moved/src/move_execution/evm_native/tests.rs
+++ b/moved/src/move_execution/evm_native/tests.rs
@@ -8,7 +8,7 @@ use {
         primitives::{ToEthAddress, ToMoveAddress, ToMoveU256},
         storage::{InMemoryState, State},
         tests::{ALT_EVM_ADDRESS, EVM_ADDRESS},
-        types::session_id::SessionId,
+        types::{session_id::SessionId, transactions::TransactionData},
     },
     alloy::{
         primitives::utils::parse_ether,
@@ -103,7 +103,7 @@ fn test_evm() {
     let (tx_hash, tx) = create_transaction(
         &mut ctx.signer,
         TxKind::Call(EVM_NATIVE_ADDRESS.to_eth_address()),
-        bcs::to_bytes(&entry_fn).unwrap(),
+        bcs::to_bytes(&TransactionData::EntryFunction(entry_fn)).unwrap(),
     );
 
     let transaction = TestTransaction::new(tx, tx_hash);
@@ -165,7 +165,7 @@ fn test_solidity_fixed_bytes() {
         let (tx_hash, tx) = create_transaction(
             &mut ctx.signer,
             TxKind::Call(EVM_ADDRESS),
-            bcs::to_bytes(&entry_fn).unwrap(),
+            bcs::to_bytes(&TransactionData::EntryFunction(entry_fn)).unwrap(),
         );
         execute_transaction(
             &tx,

--- a/moved/src/move_execution/mod.rs
+++ b/moved/src/move_execution/mod.rs
@@ -44,8 +44,9 @@ mod deposited;
 mod eth_token;
 mod evm_native;
 mod execute;
-pub(crate) mod gas;
+mod gas;
 mod nonces;
+pub(crate) mod simulate;
 mod tag_validation;
 
 #[cfg(test)]

--- a/moved/src/move_execution/simulate.rs
+++ b/moved/src/move_execution/simulate.rs
@@ -1,0 +1,99 @@
+use {
+    crate::{
+        block::HeaderForExecution,
+        genesis::config::GenesisConfig,
+        move_execution::{
+            create_move_vm, create_vm_session, execute_transaction, quick_get_nonce,
+            BaseTokenAccounts,
+        },
+        primitives::{ToMoveAddress, B256},
+        types::{
+            session_id::SessionId,
+            transactions::{
+                NormalizedEthTransaction, NormalizedExtendedTxEnvelope, ScriptOrModule,
+                TransactionData, TransactionExecutionOutcome,
+            },
+        },
+        Error::InvalidTransaction,
+        InvalidTransactionCause,
+    },
+    alloy::rpc::types::TransactionRequest,
+    move_binary_format::errors::PartialVMError,
+    move_core_types::resolver::MoveResolver,
+    move_table_extension::TableResolver,
+    move_vm_runtime::module_traversal::{TraversalContext, TraversalStorage},
+    move_vm_types::gas::UnmeteredGasMeter,
+    std::time::{SystemTime, UNIX_EPOCH},
+};
+
+pub fn simulate_transaction(
+    request: TransactionRequest,
+    state: &(impl MoveResolver<PartialVMError> + TableResolver),
+    genesis_config: &GenesisConfig,
+    base_token: &impl BaseTokenAccounts,
+) -> crate::Result<TransactionExecutionOutcome> {
+    let mut tx = NormalizedEthTransaction::from(request.clone());
+    if request.from.is_some() && request.nonce.is_none() {
+        tx.nonce = quick_get_nonce(&tx.signer.to_move_address(), state);
+    }
+    let tx = NormalizedExtendedTxEnvelope::Canonical(tx);
+
+    let block_header = HeaderForExecution {
+        number: 0,
+        timestamp: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Should get current time")
+            .as_secs(),
+        prev_randao: B256::random(),
+    };
+
+    execute_transaction(
+        &tx,
+        &B256::random(),
+        state,
+        genesis_config,
+        0,
+        base_token,
+        block_header,
+    )
+}
+
+pub fn call_transaction(
+    request: TransactionRequest,
+    state: &(impl MoveResolver<PartialVMError> + TableResolver),
+) -> crate::Result<Vec<u8>> {
+    let tx = NormalizedEthTransaction::from(request.clone());
+    let tx_data = TransactionData::parse_from(&tx)?;
+
+    let move_vm = create_move_vm()?;
+    let session_id = SessionId::default();
+    let mut session = create_vm_session(&move_vm, state, session_id);
+    let traversal_storage = TraversalStorage::new();
+    let mut traversal_context = TraversalContext::new(&traversal_storage);
+    let mut gas_meter = UnmeteredGasMeter;
+
+    match tx_data {
+        TransactionData::EntryFunction(entry_fn) => {
+            let outcome = session.execute_function_bypass_visibility(
+                entry_fn.module(),
+                entry_fn.function(),
+                entry_fn.ty_args().to_vec(),
+                entry_fn.args().to_vec(),
+                &mut gas_meter,
+                &mut traversal_context,
+            )?;
+            Ok(bcs::to_bytes(&outcome.return_values)?)
+        }
+        TransactionData::ScriptOrModule(ScriptOrModule::Script(script)) => {
+            crate::move_execution::execute::execute_script(
+                script,
+                &tx.signer.to_move_address(),
+                &mut session,
+                &mut traversal_context,
+                &mut gas_meter,
+            )?;
+            Ok(vec![])
+        }
+        _ => Err(InvalidTransaction(InvalidTransactionCause::UnsupportedType)),
+    }
+}

--- a/moved/src/move_execution/tests/framework.rs
+++ b/moved/src/move_execution/tests/framework.rs
@@ -32,9 +32,10 @@ fn test_execute_object_playground_contract() {
     let dest_arg = MoveValue::Address(move_address);
     ctx.execute(&module_id, "create_and_transfer", vec![&signer, &dest_arg]);
 
-    // The object address is deterministic based on the transaction
+    // The object address is deterministic based on the transaction. If the object address
+    // changes, the new one shows up is in the `create_and_transfer` execution outcome
     let object_address = AccountAddress::new(hex!(
-        "81383494fba7aa2410337bc4f16e3d0a196105b22d3317a56d6cbd613c061f5f"
+        "48043a7459c6464fa889f5e686e74636a73dfdc395b80bfbab15de1513f9a37e"
     ));
 
     // Calls with correct object address work

--- a/moved/src/move_execution/tests/mod.rs
+++ b/moved/src/move_execution/tests/mod.rs
@@ -9,7 +9,7 @@ use {
         primitives::{ToMoveAddress, ToMoveU256, B256, U256, U64},
         storage::{InMemoryState, State},
         tests::{signer::Signer, ALT_EVM_ADDRESS, ALT_PRIVATE_KEY, EVM_ADDRESS, PRIVATE_KEY},
-        types::transactions::{DepositedTx, ExtendedTxEnvelope, ScriptOrModule},
+        types::transactions::{DepositedTx, ExtendedTxEnvelope, ScriptOrModule, TransactionData},
     },
     alloy::{
         consensus::{transaction::TxEip1559, SignableTransaction, TxEnvelope},

--- a/moved/src/move_execution/tests/transaction.rs
+++ b/moved/src/move_execution/tests/transaction.rs
@@ -81,12 +81,12 @@ fn test_transaction_chain_id() {
     let module_id = ctx.deploy_contract("natives");
 
     // Use a transaction to call a function but pass the wrong chain id
-    let entry_fn = EntryFunction::new(
+    let entry_fn = TransactionData::EntryFunction(EntryFunction::new(
         module_id,
         Identifier::new("hashing").unwrap(),
         Vec::new(),
         vec![],
-    );
+    ));
     let mut tx = TxEip1559 {
         // Intentionally setting the wrong chain id
         chain_id: ctx.genesis_config.chain_id + 1,
@@ -115,12 +115,12 @@ fn test_out_of_gas() {
     let module_id = ctx.deploy_contract("natives");
 
     // Use a transaction to call a function but pass in too little gas
-    let entry_fn = EntryFunction::new(
+    let entry_fn = TransactionData::EntryFunction(EntryFunction::new(
         module_id,
         Identifier::new("hashing").unwrap(),
         Vec::new(),
         vec![],
-    );
+    ));
     let mut tx = TxEip1559 {
         chain_id: ctx.genesis_config.chain_id,
         nonce: ctx.signer.nonce,
@@ -131,9 +131,7 @@ fn test_out_of_gas() {
         to: TxKind::Call(EVM_ADDRESS),
         value: Default::default(),
         access_list: Default::default(),
-        input: bcs::to_bytes(&TransactionData::EntryFunction(entry_fn))
-            .unwrap()
-            .into(),
+        input: bcs::to_bytes(&entry_fn).unwrap().into(),
     };
     let signature = ctx.signer.inner.sign_transaction_sync(&mut tx).unwrap();
     let signed_tx = TxEnvelope::Eip1559(tx.into_signed(signature));

--- a/moved/src/move_execution/tests/transaction.rs
+++ b/moved/src/move_execution/tests/transaction.rs
@@ -67,7 +67,7 @@ fn test_transaction_incorrect_destination() {
     let (tx_hash, tx) = create_transaction(
         &mut ctx.signer,
         TxKind::Call(Default::default()), // Wrong address!
-        bcs::to_bytes(&entry_fn).unwrap(),
+        bcs::to_bytes(&TransactionData::EntryFunction(entry_fn)).unwrap(),
     );
 
     let transaction = TestTransaction::new(tx, tx_hash);
@@ -131,7 +131,9 @@ fn test_out_of_gas() {
         to: TxKind::Call(EVM_ADDRESS),
         value: Default::default(),
         access_list: Default::default(),
-        input: bcs::to_bytes(&entry_fn).unwrap().into(),
+        input: bcs::to_bytes(&TransactionData::EntryFunction(entry_fn))
+            .unwrap()
+            .into(),
     };
     let signature = ctx.signer.inner.sign_transaction_sync(&mut tx).unwrap();
     let signed_tx = TxEnvelope::Eip1559(tx.into_signed(signature));

--- a/moved/src/move_execution/tests/utils.rs
+++ b/moved/src/move_execution/tests/utils.rs
@@ -115,6 +115,7 @@ impl TestContext {
         args: Vec<TransactionArgument>,
     ) -> Vec<Log<LogData>> {
         let script_bytes = self.compile_script(script_name, local_deps, args);
+        println!("SCRIPT_BYTES: {:?}", hex::encode(&script_bytes));
         let (tx_hash, tx) = create_transaction(&mut self.signer, TxKind::Create, script_bytes);
         let transaction = TestTransaction::new(tx, tx_hash);
         let outcome = self.execute_tx(&transaction).unwrap();
@@ -397,7 +398,7 @@ pub fn create_test_tx(
     create_transaction(
         signer,
         TxKind::Call(EVM_ADDRESS),
-        bcs::to_bytes(&entry_fn).unwrap(),
+        bcs::to_bytes(&TransactionData::EntryFunction(entry_fn)).unwrap(),
     )
 }
 

--- a/moved/src/move_execution/tests/utils.rs
+++ b/moved/src/move_execution/tests/utils.rs
@@ -115,7 +115,6 @@ impl TestContext {
         args: Vec<TransactionArgument>,
     ) -> Vec<Log<LogData>> {
         let script_bytes = self.compile_script(script_name, local_deps, args);
-        println!("SCRIPT_BYTES: {:?}", hex::encode(&script_bytes));
         let (tx_hash, tx) = create_transaction(&mut self.signer, TxKind::Create, script_bytes);
         let transaction = TestTransaction::new(tx, tx_hash);
         let outcome = self.execute_tx(&transaction).unwrap();

--- a/moved/src/state_actor.rs
+++ b/moved/src/state_actor.rs
@@ -233,7 +233,7 @@ impl<
                 ..
             } => {
                 // TODO: Support transaction call from arbitrary blocks
-                let outcome = call_transaction(transaction, self.state.resolver());
+                let outcome = call_transaction(transaction, self.state.resolver(), &self.genesis_config, &self.base_token);
                 response_channel.send(outcome).ok()
             }
             Query::TransactionReceipt { tx_hash, response_channel } => {

--- a/moved/src/types/state.rs
+++ b/moved/src/types/state.rs
@@ -212,7 +212,7 @@ pub enum Query {
     Call {
         transaction: TransactionRequest,
         block_number: BlockNumberOrTag,
-        response_channel: oneshot::Sender<Vec<u8>>,
+        response_channel: oneshot::Sender<crate::Result<Vec<u8>>>,
     },
     TransactionReceipt {
         tx_hash: B256,


### PR DESCRIPTION
### Description
`eth_call` implementation by simulating an entry function or script transaction. Part of #47.

### Changes
- `call_transaction` method to execute entry fn or script input
- `deploy_contract` helper test method to set up `eth_call` test
- Tests for entry fn and script bytecode inputs

### Testing
✓ New tests for entry fn and script

### Notes
Refactored `simulate_transaction` into `simulate.rs` under `move_execution`.