### PR TITLE
Fix: Include withdrawals root in block header

### DIFF
--- a/engine-api/src/schema/engine.rs
+++ b/engine-api/src/schema/engine.rs
@@ -286,10 +286,10 @@ impl From<ExecutionPayload> for ExecutionPayloadV3 {
 impl From<WithdrawalV1> for Withdrawal {
     fn from(value: WithdrawalV1) -> Self {
         Self {
-            index: value.index,
-            validator_index: value.validator_index,
+            index: value.index.saturating_to(),
+            validator_index: value.validator_index.saturating_to(),
             address: value.address,
-            amount: value.amount,
+            amount: value.amount.saturating_to(),
         }
     }
 }
@@ -297,10 +297,10 @@ impl From<WithdrawalV1> for Withdrawal {
 impl From<Withdrawal> for WithdrawalV1 {
     fn from(value: Withdrawal) -> Self {
         Self {
-            index: value.index,
-            validator_index: value.validator_index,
+            index: U64::from(value.index),
+            validator_index: U64::from(value.validator_index),
             address: value.address,
-            amount: value.amount,
+            amount: U64::from(value.amount),
         }
     }
 }

--- a/moved/src/types/state.rs
+++ b/moved/src/types/state.rs
@@ -34,13 +34,7 @@ pub struct Payload {
     pub gas_limit: U64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct Withdrawal {
-    pub index: U64,
-    pub validator_index: U64,
-    pub address: Address,
-    pub amount: U64,
-}
+pub type Withdrawal = alloy::rpc::types::Withdrawal;
 
 pub type PayloadId = U64;
 
@@ -399,10 +393,10 @@ trait ToWithdrawal {
 impl ToWithdrawal for Withdrawal {
     fn to_withdrawal(&self) -> alloy::eips::eip4895::Withdrawal {
         alloy::eips::eip4895::Withdrawal {
-            index: self.index.into_limbs()[0],
-            validator_index: self.validator_index.into_limbs()[0],
+            index: self.index,
+            validator_index: self.validator_index,
             address: self.address,
-            amount: self.amount.into_limbs()[0],
+            amount: self.amount,
         }
     }
 }


### PR DESCRIPTION
### Description
Adds the `withdrawals_root` to the block header. This is required for `op-batcher` to work properly with `op-move`.

### Changes
- Use `alloy` to compute withdrawals root

### Testing
- Continued integration testing work

### Notes
I'm not sure if this implementation is totally right (the withdrawals might need a different serialization than the default for example), but it does work when the withdrawals array is empty, which is the only case we consider for now. We can continue iterating on this when we actually have withdrawals.