### PR TITLE
Feat(L2): Generic L2 contract request handler

### DIFF
--- a/moved/src/error.rs
+++ b/moved/src/error.rs
@@ -72,6 +72,8 @@ pub enum UserError {
     InvalidSignature(#[from] alloy::primitives::SignatureError),
     #[error("Error during EVM execution for L2 bridge {0:?}")]
     DepositFailure(Vec<u8>),
+    #[error("L2 contract call failure")]
+    L2ContractCallFailure,
 }
 
 /// The error caused by invalid transaction input parameter.

--- a/moved/src/move_execution/deposited.rs
+++ b/moved/src/move_execution/deposited.rs
@@ -6,6 +6,7 @@ use {
         move_execution::{
             create_move_vm, create_vm_session, eth_token, evm_native,
             gas::{new_gas_meter, total_gas_used},
+            ADDRESS_LAYOUT, U256_LAYOUT,
         },
         primitives::{ToMoveAddress, ToMoveU256, B256},
         types::{
@@ -18,14 +19,10 @@ use {
     move_binary_format::errors::PartialVMError,
     move_core_types::{
         account_address::AccountAddress, language_storage::ModuleId, resolver::MoveResolver,
-        value::MoveTypeLayout,
     },
     move_vm_runtime::module_traversal::{TraversalContext, TraversalStorage},
     move_vm_types::values::Value,
 };
-
-const ADDRESS_LAYOUT: MoveTypeLayout = MoveTypeLayout::Address;
-const U256_LAYOUT: MoveTypeLayout = MoveTypeLayout::U256;
 
 // Topic identifying the event
 // ETHBridgeFinalized(address indexed from, address indexed to, uint256 amount, bytes extraData)

--- a/moved/src/move_execution/eth_token.rs
+++ b/moved/src/move_execution/eth_token.rs
@@ -25,6 +25,7 @@ use {
 const TOKEN_ADMIN: AccountAddress = FRAMEWORK_ADDRESS;
 const TOKEN_MODULE_NAME: &IdentStr = ident_str!("eth_token");
 const MINT_FUNCTION_NAME: &IdentStr = ident_str!("mint");
+const BURN_FUNCTION_NAME: &IdentStr = ident_str!("burn");
 const GET_BALANCE_FUNCTION_NAME: &IdentStr = ident_str!("get_balance");
 const TRANSFER_FUNCTION_NAME: &IdentStr = ident_str!("transfer");
 
@@ -127,6 +128,35 @@ pub fn mint_eth<G: GasMeter>(
             println!("{e:?}");
             crate::Error::eth_token_invariant_violation(EthToken::MintAlwaysSucceeds)
         })?;
+
+    Ok(())
+}
+
+pub fn burn_eth<G: GasMeter>(
+    from: &AccountAddress,
+    amount: U256,
+    session: &mut Session,
+    traversal_context: &mut TraversalContext,
+    gas_meter: &mut G,
+) -> Result<(), crate::Error> {
+    let token_module_id = ModuleId::new(FRAMEWORK_ADDRESS, TOKEN_MODULE_NAME.into());
+    let admin_arg = bcs::to_bytes(&MoveValue::Signer(TOKEN_ADMIN)).expect("signer can serialize");
+    let from_arg = bcs::to_bytes(from).expect("address can serialize");
+    let amount_arg =
+        bcs::to_bytes(&MoveValue::U256(amount.to_move_u256())).expect("amount can serialize");
+
+    session.execute_entry_function(
+        &token_module_id,
+        BURN_FUNCTION_NAME,
+        Vec::new(),
+        vec![
+            admin_arg.as_slice(),
+            from_arg.as_slice(),
+            amount_arg.as_slice(),
+        ],
+        gas_meter,
+        traversal_context,
+    )?;
 
     Ok(())
 }

--- a/moved/src/move_execution/execute.rs
+++ b/moved/src/move_execution/execute.rs
@@ -1,6 +1,13 @@
 use {
     super::tag_validation::{validate_entry_type_tag, validate_entry_value},
-    crate::{error::Error, InvalidTransactionCause, ScriptTransaction},
+    crate::{
+        error::Error,
+        move_execution::{eth_token::burn_eth, evm_native, ADDRESS_LAYOUT, U256_LAYOUT},
+        primitives::{ToMoveU256, U256},
+        Error::User,
+        InvalidTransactionCause, ScriptTransaction, UserError,
+    },
+    alloy::primitives::{Log, LogData},
     aptos_types::transaction::{EntryFunction, Module, Script},
     move_binary_format::CompiledModule,
     move_core_types::{
@@ -113,6 +120,58 @@ pub(super) fn execute_script<G: GasMeter>(
         traversal_context,
     )?;
     Ok(())
+}
+
+pub(super) fn execute_l2_contract<G: GasMeter>(
+    signer: &AccountAddress,
+    contract: &AccountAddress,
+    value: U256,
+    data: Vec<u8>,
+    session: &mut Session,
+    traversal_context: &mut TraversalContext,
+    gas_meter: &mut G,
+) -> crate::Result<Vec<Log<LogData>>> {
+    // Take out the ETH value right away according to Ethereum spec
+    if value > U256::ZERO {
+        burn_eth(signer, value, session, traversal_context, gas_meter)?;
+    }
+
+    let module = ModuleId::new(
+        evm_native::EVM_NATIVE_ADDRESS,
+        evm_native::EVM_NATIVE_MODULE.into(),
+    );
+    let function_name = evm_native::EVM_CALL_FN_NAME;
+    // Unwraps in serialization are safe because the layouts match the types.
+    let args = vec![
+        Value::address(*signer)
+            .simple_serialize(&ADDRESS_LAYOUT)
+            .unwrap(),
+        Value::address(*contract)
+            .simple_serialize(&ADDRESS_LAYOUT)
+            .unwrap(),
+        Value::u256(value.to_move_u256())
+            .simple_serialize(&U256_LAYOUT)
+            .unwrap(),
+        Value::vector_u8(data)
+            .simple_serialize(&evm_native::CODE_LAYOUT)
+            .unwrap(),
+    ];
+    let outcome = session
+        .execute_function_bypass_visibility(
+            &module,
+            function_name,
+            Vec::new(),
+            args,
+            gas_meter,
+            traversal_context,
+        )
+        .map_err(|e| User(UserError::Vm(e)))?;
+
+    let evm_outcome = evm_native::extract_evm_result(outcome);
+    if !evm_outcome.is_success {
+        return Err(User(UserError::L2ContractCallFailure));
+    }
+    Ok(evm_outcome.logs)
 }
 
 // If `t` is wrapped in `Type::Reference` or `Type::MutableReference`,

--- a/moved/src/move_execution/mod.rs
+++ b/moved/src/move_execution/mod.rs
@@ -32,7 +32,11 @@ use {
     canonical::execute_canonical_transaction,
     deposited::execute_deposited_transaction,
     move_binary_format::errors::PartialVMError,
-    move_core_types::{language_storage::TypeTag, resolver::MoveResolver, value::MoveValue},
+    move_core_types::{
+        language_storage::TypeTag,
+        resolver::MoveResolver,
+        value::{MoveTypeLayout, MoveValue},
+    },
     move_vm_runtime::{
         move_vm::MoveVM, native_extensions::NativeContextExtensions, session::Session,
     },
@@ -51,6 +55,9 @@ mod tag_validation;
 
 #[cfg(test)]
 mod tests;
+
+const ADDRESS_LAYOUT: MoveTypeLayout = MoveTypeLayout::Address;
+const U256_LAYOUT: MoveTypeLayout = MoveTypeLayout::U256;
 
 pub fn create_move_vm() -> crate::Result<MoveVM> {
     let mut builder = SafeNativeBuilder::new(

--- a/moved/src/move_execution/tests/transfer.rs
+++ b/moved/src/move_execution/tests/transfer.rs
@@ -53,6 +53,24 @@ fn test_initiate_withdrawal() {
 }
 
 #[test]
+fn test_initiate_withdrawal_zero_balance() {
+    let mut ctx = TestContext::new();
+    let withdraw_amount = U256::from(1_000);
+    let l2_parser = address!("4200000000000000000000000000000000000016");
+
+    let (tx_hash, tx) = create_transaction_with_value(
+        &mut ctx.signer,
+        TxKind::Call(l2_parser),
+        Vec::new(),
+        U256::from(withdraw_amount),
+    );
+
+    let transaction = TestTransaction::new(tx, tx_hash);
+    let err = ctx.execute_tx(&transaction).unwrap_err();
+    assert!(err.to_string().contains("VMError with status ABORTED"));
+}
+
+#[test]
 fn test_withdrawal_tx() {
     let mut ctx = TestContext::new();
 


### PR DESCRIPTION
### Description
All the L2 contract requests go through this canonical transaction execution, including the withdrawal requests. This started as a way to initiate withdrawals, however it extended to handle every L2 request. Part of #98

### Changes
- Handle L2 call requests in canonical transaction execution
- Burn any payable ETH value and then execute the L2 contract through `evm` Move native extension
- Implement `burn_eth` method in `eth_token`
- Return the EVM logs as transaction outcome

### Testing
✓ Test to initiate a withdrawal request