### PR TITLE
Feat(rpc): eth_getProof implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6765,6 +6765,7 @@ dependencies = [
  "aptos-vm-types",
  "bcs 0.1.3",
  "better_any",
+ "borsh",
  "bytes",
  "hex",
  "jmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ aptos-native-interface = { git = "https://github.com/aptos-labs/aptos-core", tag
 aptos-storage-interface = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.14.0" }
 bcs = { git = "https://github.com/aptos-labs/bcs" }
 better_any = "0.1.1"
+borsh = { version = "1.5", features = ["derive"] }
 bytes = "1.6"
 clap = { version = "4.5", features = ["derive"] }
 convert_case = "0.6"

--- a/engine-api/src/jsonrpc.rs
+++ b/engine-api/src/jsonrpc.rs
@@ -1,5 +1,4 @@
 use {
-    crate::schema::BlockNumberOrTag,
     std::fmt,
     tokio::sync::{mpsc::error::SendError, oneshot::error::RecvError},
 };
@@ -32,7 +31,7 @@ impl JsonRpcError {
         Self::without_data(-1, format!("Failed to access state: {e:?}"))
     }
 
-    pub fn block_not_found(block_number: BlockNumberOrTag) -> Self {
+    pub fn block_not_found<T: fmt::Display>(block_number: T) -> Self {
         JsonRpcError::without_data(-32001, format!("Block not found: {block_number}"))
     }
 }

--- a/engine-api/src/method_name.rs
+++ b/engine-api/src/method_name.rs
@@ -19,6 +19,7 @@ pub enum MethodName {
     EstimateGas,
     Call,
     TransactionReceipt,
+    GetProof,
 }
 
 impl FromStr for MethodName {
@@ -43,6 +44,7 @@ impl FromStr for MethodName {
             "eth_estimateGas" => Self::EstimateGas,
             "eth_call" => Self::Call,
             "eth_getTransactionReceipt" => Self::TransactionReceipt,
+            "eth_getProof" => Self::GetProof,
             other => {
                 return Err(JsonRpcError::without_data(
                     -32601,

--- a/engine-api/src/methods/get_proof.rs
+++ b/engine-api/src/methods/get_proof.rs
@@ -1,0 +1,157 @@
+use {
+    crate::{
+        json_utils::{self, access_state_error},
+        jsonrpc::JsonRpcError,
+    },
+    alloy::{
+        eips::BlockNumberOrTag,
+        primitives::{Address, U256},
+    },
+    moved::types::{
+        queries::ProofResponse,
+        state::{Query, StateMessage},
+    },
+    tokio::sync::{mpsc, oneshot},
+};
+
+pub async fn execute(
+    request: serde_json::Value,
+    state_channel: mpsc::Sender<StateMessage>,
+) -> Result<serde_json::Value, JsonRpcError> {
+    let (address, storage_slots, block_number) = parse_params(request)?;
+    let response = inner_execute(address, storage_slots, block_number, state_channel).await?;
+
+    // Format the balance as a hex string
+    Ok(serde_json::to_value(response).expect("Must be able to JSON-serialize response"))
+}
+
+fn parse_params(
+    request: serde_json::Value,
+) -> Result<(Address, Vec<U256>, BlockNumberOrTag), JsonRpcError> {
+    let params = json_utils::get_params_list(&request);
+    match params {
+        [] | [_] => Err(JsonRpcError {
+            code: -32602,
+            data: request,
+            message: "Not enough params".into(),
+        }),
+        [a, b] => {
+            let address: Address = json_utils::deserialize(a)?;
+            let storage_slots = json_utils::deserialize(b)?;
+            Ok((address, storage_slots, BlockNumberOrTag::Latest))
+        }
+        [a, b, c] => {
+            let address: Address = json_utils::deserialize(a)?;
+            let storage_slots = json_utils::deserialize(b)?;
+            let block_number: BlockNumberOrTag = json_utils::deserialize(c)?;
+            Ok((address, storage_slots, block_number))
+        }
+        _ => Err(JsonRpcError {
+            code: -32602,
+            data: request,
+            message: "Too many params".into(),
+        }),
+    }
+}
+
+async fn inner_execute(
+    address: Address,
+    storage_slots: Vec<U256>,
+    height: BlockNumberOrTag,
+    state_channel: mpsc::Sender<StateMessage>,
+) -> Result<ProofResponse, JsonRpcError> {
+    let (tx, rx) = oneshot::channel();
+    let msg = Query::GetProof {
+        address,
+        storage_slots,
+        height,
+        response_channel: tx,
+    }
+    .into();
+    state_channel.send(msg).await.map_err(access_state_error)?;
+    let response = rx.await?.ok_or(JsonRpcError::block_not_found(height))?;
+
+    Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::methods::tests::create_state_actor,
+        alloy::{hex, primitives::address},
+        moved::primitives::U64,
+        std::str::FromStr,
+        test_case::test_case,
+    };
+
+    #[test_case("0x1")]
+    #[test_case("latest")]
+    #[test_case("pending")]
+    fn test_parse_params_with_block_number(block: &str) {
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_getProof",
+            "params": [
+                "0x0000000000000000000000000000000000000001",
+                [],
+                block,
+            ],
+            "id": 1
+        });
+
+        let (address, storage_slots, block_number) = parse_params(request).unwrap();
+        assert_eq!(
+            address,
+            Address::from_str("0x0000000000000000000000000000000000000001").unwrap()
+        );
+        assert_eq!(storage_slots, Vec::new());
+        match block {
+            "latest" => assert_eq!(block_number, BlockNumberOrTag::Latest),
+            "pending" => assert_eq!(block_number, BlockNumberOrTag::Pending),
+            _ => assert_eq!(
+                block_number,
+                BlockNumberOrTag::Number(U64::from_str(block).unwrap().into_limbs()[0])
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute() {
+        let (state_actor, state_channel) = create_state_actor();
+
+        let state_handle = state_actor.spawn();
+        let request: serde_json::Value = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_getProof",
+            "params": [
+                "0x4200000000000000000000000000000000000016",
+                [],
+                "latest",
+            ],
+            "id": 1
+        });
+
+        let response: ProofResponse =
+            serde_json::from_value(execute(request, state_channel).await.unwrap()).unwrap();
+
+        assert_eq!(
+            response.address,
+            address!("4200000000000000000000000000000000000016")
+        );
+        assert_eq!(response.balance, U256::ZERO);
+        assert_eq!(response.nonce, 0);
+        assert_eq!(
+            response.code_hash,
+            hex!("fa8c9db6c6cab7108dea276f4cd09d575674eb0852c0fa3187e59e98ef977998")
+        );
+        assert_eq!(response.storage_proof, Vec::new());
+
+        for bytes in response.account_proof {
+            let list: Vec<alloy::rlp::Bytes> = alloy::rlp::decode_exact(bytes).unwrap();
+            assert_eq!(list.len(), 3);
+        }
+
+        state_handle.await.unwrap();
+    }
+}

--- a/engine-api/src/methods/mod.rs
+++ b/engine-api/src/methods/mod.rs
@@ -9,6 +9,7 @@ pub mod get_block_by_hash;
 pub mod get_block_by_number;
 pub mod get_nonce;
 pub mod get_payload;
+pub mod get_proof;
 pub mod get_transaction_receipt;
 pub mod new_payload;
 pub mod send_raw_transaction;

--- a/engine-api/src/request.rs
+++ b/engine-api/src/request.rs
@@ -57,6 +57,7 @@ async fn inner_handle_request(
         EstimateGas => estimate_gas::execute(request, state_channel).await,
         Call => call::execute(request, state_channel).await,
         TransactionReceipt => get_transaction_receipt::execute(request, state_channel).await,
+        GetProof => get_proof::execute(request, state_channel).await,
         ForkChoiceUpdatedV2 => todo!(),
         GetPayloadV2 => todo!(),
         NewPayloadV2 => todo!(),

--- a/moved/Cargo.toml
+++ b/moved/Cargo.toml
@@ -21,6 +21,7 @@ aptos-native-interface.workspace = true
 aptos-storage-interface.workspace = true
 bcs.workspace = true
 better_any.workspace = true
+borsh.workspace = true
 bytes.workspace = true
 hex.workspace = true
 jmt.workspace = true

--- a/moved/src/move_execution/evm_native/mod.rs
+++ b/moved/src/move_execution/evm_native/mod.rs
@@ -1,5 +1,5 @@
 pub use self::{
-    native_evm_context::NativeEVMContext,
+    native_evm_context::{NativeEVMContext, ResolverBackedDB},
     native_impl::{append_evm_natives, EVM_CALL_FN_NAME},
     state_changes::{extract_evm_changes, genesis_state_changes},
     type_utils::extract_evm_result,
@@ -21,7 +21,7 @@ mod native_evm_context;
 mod native_impl;
 mod solidity_abi;
 mod state_changes;
-mod type_utils;
+pub mod type_utils;
 
 #[cfg(test)]
 mod tests;
@@ -45,7 +45,7 @@ pub static CODE_LAYOUT: LazyLock<MoveTypeLayout> =
 /// that is used in `revm`. It saves space if the same bytecode is deployed more than once
 /// because we still only store the whole bytecode one time and simply duplicate the same hash
 /// across all the contracts using that bytecode.
-static ACCOUNT_INFO_LAYOUT: LazyLock<MoveTypeLayout> = LazyLock::new(|| {
+pub static ACCOUNT_INFO_LAYOUT: LazyLock<MoveTypeLayout> = LazyLock::new(|| {
     MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![
         MoveTypeLayout::U256,                                 // balance
         MoveTypeLayout::U64,                                  // nonce

--- a/moved/src/move_execution/evm_native/native_evm_context.rs
+++ b/moved/src/move_execution/evm_native/native_evm_context.rs
@@ -34,7 +34,7 @@ impl<'a> NativeEVMContext<'a> {
         state: &'a impl MoveResolver<PartialVMError>,
         block_header: HeaderForExecution,
     ) -> Self {
-        let inner_db = ResolverBackedDB { resolver: state };
+        let inner_db = ResolverBackedDB::new(state);
         let db = CacheDB::new(inner_db);
         Self {
             resolver: state,
@@ -47,6 +47,12 @@ impl<'a> NativeEVMContext<'a> {
 
 pub struct ResolverBackedDB<'a> {
     resolver: &'a dyn MoveResolver<PartialVMError>,
+}
+
+impl<'a> ResolverBackedDB<'a> {
+    pub fn new(resolver: &'a impl MoveResolver<PartialVMError>) -> Self {
+        Self { resolver }
+    }
 }
 
 impl<'a> DatabaseRef for ResolverBackedDB<'a> {

--- a/moved/src/move_execution/mod.rs
+++ b/moved/src/move_execution/mod.rs
@@ -49,7 +49,7 @@ use {
 mod canonical;
 mod deposited;
 mod eth_token;
-mod evm_native;
+pub mod evm_native;
 mod execute;
 mod gas;
 mod nonces;

--- a/moved/src/state_actor.rs
+++ b/moved/src/state_actor.rs
@@ -274,6 +274,16 @@ impl<
             Query::TransactionReceipt { tx_hash, response_channel } => {
                 response_channel.send(self.query_transaction_receipt(tx_hash)).ok()
             }
+            Query::GetProof { address, storage_slots, height, response_channel } => {
+                response_channel.send(
+                    self.state_queries.get_proof(
+                        self.state.db(),
+                        address.to_move_address(),
+                        &storage_slots,
+                        self.resolve_height(height)
+                    )
+                ).ok()
+            }
         };
     }
 
@@ -660,6 +670,16 @@ mod test_doubles {
             assert_eq!(height, self.1);
 
             Some(3)
+        }
+
+        fn get_proof(
+            &self,
+            _db: &(impl TreeReader + Sync),
+            _account: AccountAddress,
+            _storage_slots: &[U256],
+            _height: BlockHeight,
+        ) -> Option<crate::types::queries::ProofResponse> {
+            None
         }
     }
 }

--- a/moved/src/types/mod.rs
+++ b/moved/src/types/mod.rs
@@ -1,3 +1,4 @@
+pub mod queries;
 pub mod session_id;
 pub mod state;
 pub mod transactions;

--- a/moved/src/types/queries.rs
+++ b/moved/src/types/queries.rs
@@ -1,0 +1,162 @@
+use {
+    alloy::{
+        primitives::Bytes,
+        rlp::BufMut,
+        rpc::types::{EIP1186AccountProofResponse, EIP1186StorageProof},
+    },
+    borsh::{BorshDeserialize, BorshSerialize},
+    jmt::{
+        proof::{SparseMerkleProof, INTERNAL_DOMAIN_SEPARATOR, LEAF_DOMAIN_SEPARATOR},
+        KeyHash, ValueHash,
+    },
+    sha3::Keccak256,
+};
+
+pub type ProofResponse = EIP1186AccountProofResponse;
+pub type StorageProof = EIP1186StorageProof;
+
+/// Similar to `jmt::SparseMerkleProof`, but with public fields so that the
+/// proof can be transformed to suit our needs.
+#[derive(Debug, PartialEq, Eq, Clone, BorshDeserialize, BorshSerialize)]
+pub struct JmtProof {
+    leaf: Option<JmtLeaf>,
+    siblings: Vec<JmtNode>,
+}
+
+impl<'a> From<&'a SparseMerkleProof<Keccak256>> for JmtProof {
+    fn from(value: &'a SparseMerkleProof<Keccak256>) -> Self {
+        // We have to do this conversion via borsh serialization because
+        // SparseMerkleProof has private fields with no getters.
+        let encoded = borsh::to_vec(value).expect("Proof must serialize");
+        borsh::from_slice(&encoded).expect("JmtProof and SparseMerkleProof have the same layout")
+    }
+}
+
+impl<'a> From<&'a JmtProof> for SparseMerkleProof<Keccak256> {
+    fn from(value: &'a JmtProof) -> Self {
+        // We have to do this conversion via borsh serialization because
+        // SparseMerkleProof has private fields and no constructor.
+        let encoded = borsh::to_vec(value).expect("Proof must serialize");
+        borsh::from_slice(&encoded).expect("JmtProof and SparseMerkleProof have the same layout")
+    }
+}
+
+impl JmtProof {
+    // This function creates a list of RLP-encoded nodes in the proof. Thus it is
+    // compatible with the format needed in EIP-1186 Merkle proofs. It is intentional
+    // that each node is encoded as a 3-element list. This encoding ensures it cannot
+    // be confused with a normal Ethereum Merkle proof because MPT nodes are either length
+    // 17 (branch nodes consisting of 16 siblings, together with an optional value) or
+    // length 2 (value nodes or extension nodes).
+    pub fn encode_for_response(&self) -> Vec<Bytes> {
+        let mut result = Vec::with_capacity(1 + self.siblings.len());
+
+        let mut leaf_encoding = Vec::new();
+        self.leaf
+            .as_ref()
+            .map(|leaf| leaf.rlp_encode(&mut leaf_encoding))
+            .unwrap_or_else(|| {
+                alloy_rlp::encode_list::<&[u8], &[u8]>(
+                    &[LEAF_DOMAIN_SEPARATOR, &[], &[]],
+                    &mut leaf_encoding,
+                )
+            });
+        result.push(leaf_encoding.into());
+
+        for sibling in &self.siblings {
+            let mut out = Vec::new();
+            sibling.rlp_encode(&mut out);
+            result.push(out.into());
+        }
+
+        result
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, BorshDeserialize, BorshSerialize)]
+pub enum JmtNode {
+    Null,
+    Internal(JmtInternalNode),
+    Leaf(JmtLeaf),
+}
+
+impl JmtNode {
+    pub fn rlp_encode(&self, out: &mut impl BufMut) {
+        match self {
+            Self::Internal(node) => node.rlp_encode(out),
+            Self::Leaf(node) => node.rlp_encode(out),
+            Self::Null => alloy_rlp::encode_list::<&[u8], &[u8]>(&[b"NULL", &[], &[]], out),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, BorshDeserialize, BorshSerialize)]
+pub struct JmtLeaf {
+    pub key_hash: KeyHash,
+    pub value_hash: ValueHash,
+}
+
+impl JmtLeaf {
+    pub fn rlp_encode(&self, out: &mut impl BufMut) {
+        alloy_rlp::encode_list::<&[u8], &[u8]>(
+            &[
+                LEAF_DOMAIN_SEPARATOR,
+                self.key_hash.0.as_slice(),
+                self.value_hash.0.as_slice(),
+            ],
+            out,
+        );
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, BorshDeserialize, BorshSerialize)]
+pub struct JmtInternalNode {
+    pub left: [u8; 32],
+    pub right: [u8; 32],
+}
+
+impl JmtInternalNode {
+    pub fn rlp_encode(&self, out: &mut impl BufMut) {
+        alloy_rlp::encode_list::<&[u8], &[u8]>(
+            &[
+                INTERNAL_DOMAIN_SEPARATOR,
+                self.left.as_slice(),
+                self.right.as_slice(),
+            ],
+            out,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            move_execution::evm_native::{type_utils::account_info_struct_tag, EVM_NATIVE_ADDRESS},
+            primitives::KeyHashable,
+        },
+        aptos_types::state_store::state_key::StateKey,
+        jmt::{mock::MockTreeStore, JellyfishMerkleTree},
+    };
+
+    #[test]
+    fn test_jmt_proof_roundtrip() {
+        let store = MockTreeStore::default();
+        let struct_tag = account_info_struct_tag(&Default::default());
+        let key = StateKey::resource(&EVM_NATIVE_ADDRESS, &struct_tag).unwrap();
+        let version = 0;
+        let value_set = vec![(key.key_hash(), None)];
+        let trie = JellyfishMerkleTree::<_, Keccak256>::new(&store);
+        let (_, update) = trie.put_value_set(value_set, version).unwrap();
+        store.write_tree_update_batch(update).unwrap();
+
+        let trie = JellyfishMerkleTree::<_, Keccak256>::new(&store);
+        let (_, proof) = trie.get_with_proof(key.key_hash(), version).unwrap();
+
+        let converted: JmtProof = (&proof).into();
+        let round_trip: SparseMerkleProof<Keccak256> = (&converted).into();
+
+        assert_eq!(proof, round_trip);
+    }
+}

--- a/moved/src/types/state.rs
+++ b/moved/src/types/state.rs
@@ -13,7 +13,7 @@ use {
     },
     alloy::{
         consensus::transaction::TxEnvelope,
-        eips::{eip2718::Encodable2718, BlockNumberOrTag},
+        eips::{eip2718::Encodable2718, BlockId, BlockNumberOrTag},
         primitives::Bloom,
         rpc::types::{BlockTransactions, FeeHistory, TransactionRequest},
     },
@@ -216,7 +216,7 @@ pub enum Query {
     GetProof {
         address: Address,
         storage_slots: Vec<U256>,
-        height: BlockNumberOrTag,
+        height: BlockId,
         response_channel: oneshot::Sender<Option<ProofResponse>>,
     },
 }

--- a/moved/src/types/state.rs
+++ b/moved/src/types/state.rs
@@ -4,6 +4,7 @@
 //! accepts.
 
 use {
+    super::queries::ProofResponse,
     crate::{
         block::{ExtendedBlock, Header},
         primitives::{Address, Bytes, ToU64, B2048, B256, U256, U64},
@@ -211,6 +212,12 @@ pub enum Query {
     TransactionReceipt {
         tx_hash: B256,
         response_channel: oneshot::Sender<Option<TransactionReceipt>>,
+    },
+    GetProof {
+        address: Address,
+        storage_slots: Vec<U256>,
+        height: BlockNumberOrTag,
+        response_channel: oneshot::Sender<Option<ProofResponse>>,
     },
 }
 

--- a/moved/src/types/transactions.rs
+++ b/moved/src/types/transactions.rs
@@ -22,8 +22,8 @@ use {
 };
 
 const DEPOSITED_TYPE_BYTE: u8 = 0x7e;
-const L2_LOWEST_ADDRESS: Address = address!("4200000000000000000000000000000000000000");
-const L2_HIGHEST_ADDRESS: Address = address!("42000000000000000000000000000000000000ff");
+pub const L2_LOWEST_ADDRESS: Address = address!("4200000000000000000000000000000000000000");
+pub const L2_HIGHEST_ADDRESS: Address = address!("42000000000000000000000000000000000000ff");
 
 /// OP-stack special transactions defined in
 /// https://specs.optimism.io/protocol/deposits.html#the-deposited-transaction-type


### PR DESCRIPTION
### Description
Adds an implementation of `eth_getProof` to our RPC. The proofs returned are _not_ Ethereum MPT proofs, rather they are JMT proofs because we use a different Merkle tree implementation.

### Changes
- `eth_getProof` rpc method
- New method on `StateQueries` trait for the `eth_getProof` method

### Testing
- Basic sanity test in `get_proof.rs`
- Integration/devnet testing

### Notes
I needed to redefine some types from the `jmt` library because they have private fields that I need access to when constructing the output for `eth_getProof`.