### PR TITLE
test(storage): Test that there is no collision between different column families

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6908,6 +6908,7 @@ name = "moved-storage"
 version = "0.1.0"
 dependencies = [
  "eth_trie",
+ "hex-literal",
  "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.14.0)",
  "move-core-types 0.0.4 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.14.0)",
  "move-table-extension",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ eth_trie = "0.5.0"
 flate2 = "1"
 handlebars = "6.2"
 hex = "0.4"
+hex-literal = "0.4"
 hyper = "0.14"
 jsonwebtoken = { version = "9", default-features = false }
 move-binary-format = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.14.0" }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -11,3 +11,6 @@ move-core-types.workspace = true
 move-table-extension.workspace = true
 moved.workspace = true
 rocksdb.workspace = true
+
+[dev-dependencies]
+hex-literal.workspace = true

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,4 +1,7 @@
 mod state;
 mod trie;
 
-pub use {state::RocksDbState, trie::RocksEthTrieDb};
+pub use {
+    state::RocksDbState,
+    trie::{RocksEthTrieDb, COLUMN_FAMILIES, COLUMN_FAMILY, ROOT_COLUMN_FAMILY, ROOT_KEY},
+};

--- a/storage/src/trie.rs
+++ b/storage/src/trie.rs
@@ -6,6 +6,7 @@ use {
 
 pub const COLUMN_FAMILY: &str = "trie";
 pub const ROOT_COLUMN_FAMILY: &str = "trie_root";
+pub const COLUMN_FAMILIES: [&str; 2] = [COLUMN_FAMILY, ROOT_COLUMN_FAMILY];
 pub const ROOT_KEY: &str = "trie_root";
 
 pub struct RocksEthTrieDb<'db> {

--- a/storage/tests/collision.rs
+++ b/storage/tests/collision.rs
@@ -1,0 +1,40 @@
+use {
+    eth_trie::DB,
+    hex_literal::hex,
+    moved::primitives::B256,
+    moved_storage::{RocksEthTrieDb, ROOT_KEY},
+};
+
+mod common;
+
+#[test]
+fn test_column_families_do_not_collide() {
+    let rocks = common::create_db();
+    let db = RocksEthTrieDb::new(&rocks);
+
+    let random_32_bytes = B256::new(hex!(
+        "50596cee391a497683672d9396379f56cd8e96476b844557933f48039c483a81"
+    ));
+
+    db.put_root(random_32_bytes).unwrap();
+
+    // We assume that `put_root` uses `ROOT_KEY` to store the state root under the hood
+    // If the keys are not separated by column families, then this overwrites the state root
+    let random_value = hex!("feef");
+
+    db.insert(ROOT_KEY.as_bytes(), random_value.as_slice().to_vec())
+        .unwrap();
+
+    let expected_root = random_32_bytes;
+    let actual_root = db.root().unwrap().expect("Root should exist in database");
+
+    assert_eq!(actual_root, expected_root);
+
+    let expected_value = random_value;
+    let actual_value = db
+        .get(ROOT_KEY.as_bytes())
+        .unwrap()
+        .expect("Key should exist in database");
+
+    assert_eq!(actual_value, expected_value);
+}

--- a/storage/tests/common.rs
+++ b/storage/tests/common.rs
@@ -1,0 +1,19 @@
+use {moved_storage::COLUMN_FAMILIES, rocksdb::Options};
+
+pub fn create_db() -> rocksdb::DB {
+    let path = concat!(
+        concat!(env!("CARGO_TARGET_TMPDIR"), "/"),
+        env!("CARGO_CRATE_NAME")
+    );
+
+    if std::fs::exists(path).unwrap() {
+        std::fs::remove_dir_all(path)
+            .expect("Removing non-empty database directory should succeed");
+    }
+
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.create_missing_column_families(true);
+
+    rocksdb::DB::open_cf(&options, path, COLUMN_FAMILIES).expect("Database should open in tmpdir")
+}


### PR DESCRIPTION
### Description
Introduces integration tests into the `storage` crate.

### Changes
- Initialize directory for integration tests in `storage` trait
- Declare `common` module with code for creating empty database for testing
- Add test that interacts with file system using `rocksdb` that simulates the situation where the same key used for storing *state root* is used through the `DB` trait of the `eth_trie` crate and test that nothing was overwritten.

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt