### PR TITLE
feat(storage): Implement block repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6907,6 +6907,7 @@ dependencies = [
 name = "moved-storage"
 version = "0.1.0"
 dependencies = [
+ "bcs 0.1.3",
  "eth_trie",
  "hex-literal",
  "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.14.0)",

--- a/moved/src/block/root.rs
+++ b/moved/src/block/root.rs
@@ -33,7 +33,7 @@ pub trait BlockRepository: Debug {
 
 pub type Header = alloy::consensus::Header;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct ExtendedBlock {
     /// The block hash is the output of keccak-256 algorithm with RLP encoded block header as input.
     pub hash: B256,
@@ -62,7 +62,7 @@ impl ExtendedBlock {
 }
 
 /// TODO: Add withdrawals
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct Block {
     pub header: Header,
     pub transactions: Vec<OpTxEnvelope>,

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+bcs.workspace = true
 eth_trie.workspace = true
 move-binary-format.workspace = true
 move-core-types.workspace = true

--- a/storage/src/all.rs
+++ b/storage/src/all.rs
@@ -1,0 +1,20 @@
+use crate::{
+    block::BLOCK_COLUMN_FAMILY,
+    trie::{ROOT_COLUMN_FAMILY, TRIE_COLUMN_FAMILY},
+};
+
+pub const COLUMN_FAMILIES: [&str; 3] =
+    [TRIE_COLUMN_FAMILY, ROOT_COLUMN_FAMILY, BLOCK_COLUMN_FAMILY];
+
+#[cfg(test)]
+mod tests {
+    use {super::*, std::collections::HashSet};
+
+    #[test]
+    fn test_column_families_have_unique_names() {
+        let expected_unique_len = COLUMN_FAMILIES.len();
+        let actual_unique_len = HashSet::from(COLUMN_FAMILIES).len();
+
+        assert_eq!(actual_unique_len, expected_unique_len);
+    }
+}

--- a/storage/src/block.rs
+++ b/storage/src/block.rs
@@ -1,0 +1,35 @@
+use {
+    moved::{
+        block::{BlockRepository, ExtendedBlock},
+        primitives::B256,
+    },
+    rocksdb::{AsColumnFamilyRef, DB as RocksDb},
+};
+
+pub const BLOCK_COLUMN_FAMILY: &str = "block";
+
+#[derive(Debug)]
+pub struct RocksDbBlockRepository;
+
+impl RocksDbBlockRepository {
+    pub fn cf(db: &RocksDb) -> impl AsColumnFamilyRef + use<'_> {
+        db.cf_handle(BLOCK_COLUMN_FAMILY)
+            .expect("Column family should exist")
+    }
+}
+
+impl BlockRepository for RocksDbBlockRepository {
+    type Storage = RocksDb;
+
+    fn add(&mut self, storage: &mut Self::Storage, block: ExtendedBlock) {
+        let cf = Self::cf(storage);
+        let bytes = bcs::to_bytes(&block).unwrap();
+        storage.put_cf(&cf, block.hash, bytes).unwrap()
+    }
+
+    fn by_hash(&self, storage: &Self::Storage, hash: B256) -> Option<ExtendedBlock> {
+        let cf = Self::cf(storage);
+        let bytes = storage.get_cf(&cf, hash).unwrap()?;
+        bcs::from_bytes(bytes.as_slice()).ok()
+    }
+}

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,7 +1,11 @@
+mod all;
+mod block;
 mod state;
 mod trie;
 
 pub use {
+    all::COLUMN_FAMILIES,
+    block::RocksDbBlockRepository,
     state::RocksDbState,
-    trie::{RocksEthTrieDb, COLUMN_FAMILIES, COLUMN_FAMILY, ROOT_COLUMN_FAMILY, ROOT_KEY},
+    trie::{RocksEthTrieDb, ROOT_KEY},
 };

--- a/storage/src/trie.rs
+++ b/storage/src/trie.rs
@@ -4,9 +4,8 @@ use {
     rocksdb::{AsColumnFamilyRef, DB as RocksDb},
 };
 
-pub const COLUMN_FAMILY: &str = "trie";
+pub const TRIE_COLUMN_FAMILY: &str = "trie";
 pub const ROOT_COLUMN_FAMILY: &str = "trie_root";
-pub const COLUMN_FAMILIES: [&str; 2] = [COLUMN_FAMILY, ROOT_COLUMN_FAMILY];
 pub const ROOT_KEY: &str = "trie_root";
 
 pub struct RocksEthTrieDb<'db> {
@@ -31,7 +30,7 @@ impl<'db> RocksEthTrieDb<'db> {
 
     fn cf(&self) -> &impl AsColumnFamilyRef {
         self.db
-            .cf_handle(COLUMN_FAMILY)
+            .cf_handle(TRIE_COLUMN_FAMILY)
             .expect("Column family should exist")
     }
 


### PR DESCRIPTION
### Description
Implements storing blocks inside `rocksdb`.

### Changes
- Added `BlockRepository` implementation backed by `rocksdb`
- Added new column family for blocks into `rocksdb` so that they have separate isolated namespace to avoid collision with keys for other purposes
- Added test for column family name uniqueness

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt