### PR TITLE
refactor: Resolve `clippy::too_many_args` warning for transaction execution

### DIFF
--- a/moved/src/move_execution/tests/transaction.rs
+++ b/moved/src/move_execution/tests/transaction.rs
@@ -1,4 +1,4 @@
-use super::*;
+use {super::*, crate::types::transactions::NormalizedExtendedTxEnvelope};
 
 #[test]
 fn test_move_event_converts_to_eth_log_successfully() {

--- a/moved/src/move_execution/tests/transfer.rs
+++ b/moved/src/move_execution/tests/transfer.rs
@@ -1,4 +1,4 @@
-use super::*;
+use {super::*, crate::types::transactions::NormalizedExtendedTxEnvelope};
 
 /// Deposits can be made to the L2.
 #[test]

--- a/moved/src/types/transactions.rs
+++ b/moved/src/types/transactions.rs
@@ -201,6 +201,14 @@ impl TryFrom<ExtendedTxEnvelope> for NormalizedExtendedTxEnvelope {
 }
 
 impl NormalizedExtendedTxEnvelope {
+    pub fn into_canonical(self) -> Option<NormalizedEthTransaction> {
+        if let Self::Canonical(tx) = self {
+            Some(tx)
+        } else {
+            None
+        }
+    }
+
     pub fn tip_per_gas(&self, base_fee: U256) -> U256 {
         match self {
             Self::DepositedTx(..) => U256::ZERO,


### PR DESCRIPTION
### Description
Changes the design of our transaction execution entry points by making them use only a single argument.

### Changes
- Introduce the concept of an input struct for executing transactions
- Use the input structs for deposit and for canonical transaction execution
- Update all usages
- Clear `#[allow(clippy::too_many_args)]` on the affected places

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt