### PR TITLE
refactor: Resolve `clippy::too_many_args` warning for transaction verification

### DIFF
--- a/moved/src/move_execution/canonical.rs
+++ b/moved/src/move_execution/canonical.rs
@@ -32,63 +32,69 @@ use {
     },
 };
 
-#[allow(clippy::too_many_arguments)]
-pub(super) fn verify_transaction(
-    tx: &NormalizedEthTransaction,
-    session: &mut Session,
-    traversal_context: &mut TraversalContext,
-    gas_meter: &mut StandardGasMeter<StandardGasAlgebra>,
-    genesis_config: &GenesisConfig,
-    l1_cost: u64,
-    l2_cost: u64,
-    base_token: &impl BaseTokenAccounts,
+pub struct CanonicalVerificationInput<'input, 'r, 'l, B> {
+    pub tx: &'input NormalizedEthTransaction,
+    pub session: &'input mut Session<'r, 'l>,
+    pub traversal_context: &'input mut TraversalContext<'input>,
+    pub gas_meter: &'input mut StandardGasMeter<StandardGasAlgebra>,
+    pub genesis_config: &'input GenesisConfig,
+    pub l1_cost: u64,
+    pub l2_cost: u64,
+    pub base_token: &'input B,
+}
+
+pub(super) fn verify_transaction<B: BaseTokenAccounts>(
+    input: &mut CanonicalVerificationInput<B>,
 ) -> crate::Result<()> {
-    if let Some(chain_id) = tx.chain_id {
-        if chain_id != genesis_config.chain_id {
+    if let Some(chain_id) = input.tx.chain_id {
+        if chain_id != input.genesis_config.chain_id {
             return Err(InvalidTransactionCause::IncorrectChainId.into());
         }
     }
 
-    let sender_move_address = tx.signer.to_move_address();
+    let sender_move_address = input.tx.signer.to_move_address();
 
     // Charge gas for the transaction itself.
     // Immediately exit if there is not enough.
-    let txn_size = (tx.data.len() as u64).into();
-    let charge_gas = gas_meter
+    let txn_size = (input.tx.data.len() as u64).into();
+    let charge_gas = input
+        .gas_meter
         .charge_intrinsic_gas_for_transaction(txn_size)
-        .and_then(|_| gas_meter.charge_io_gas_for_transaction(txn_size));
+        .and_then(|_| input.gas_meter.charge_io_gas_for_transaction(txn_size));
     if charge_gas.is_err() {
         return Err(InvalidTransaction(
             InvalidTransactionCause::InsufficientIntrinsicGas,
         ));
     }
 
-    base_token
+    input
+        .base_token
         .charge_gas_cost(
             &sender_move_address,
-            l1_cost,
-            session,
-            traversal_context,
-            gas_meter,
+            input.l1_cost,
+            input.session,
+            input.traversal_context,
+            input.gas_meter,
         )
         .map_err(|_| InvalidTransaction(InvalidTransactionCause::FailedToPayL1Fee))?;
 
-    base_token
+    input
+        .base_token
         .charge_gas_cost(
             &sender_move_address,
-            l2_cost,
-            session,
-            traversal_context,
-            gas_meter,
+            input.l2_cost,
+            input.session,
+            input.traversal_context,
+            input.gas_meter,
         )
         .map_err(|_| InvalidTransaction(InvalidTransactionCause::FailedToPayL2Fee))?;
 
     check_nonce(
-        tx.nonce,
+        input.tx.nonce,
         &sender_move_address,
-        session,
-        traversal_context,
-        gas_meter,
+        input.session,
+        input.traversal_context,
+        input.gas_meter,
     )?;
 
     Ok(())
@@ -126,35 +132,40 @@ pub(super) fn execute_canonical_transaction<
 
     // TODO: use free gas meter for things that shouldn't fail due to
     // insufficient gas limit, impose a lower bound on the latter
-    verify_transaction(
-        input.tx,
-        &mut session,
-        &mut traversal_context,
-        &mut gas_meter,
-        input.genesis_config,
-        input.l1_cost,
+    let mut verify_input = CanonicalVerificationInput {
+        tx: input.tx,
+        session: &mut session,
+        traversal_context: &mut traversal_context,
+        gas_meter: &mut gas_meter,
+        genesis_config: input.genesis_config,
+        l1_cost: input.l1_cost,
         l2_cost,
-        input.base_token,
-    )?;
+        base_token: input.base_token,
+    };
+    verify_transaction(&mut verify_input)?;
 
     let vm_outcome = match tx_data {
         TransactionData::EntryFunction(entry_fn) => execute_entry_function(
             entry_fn,
             &sender_move_address,
-            &mut session,
-            &mut traversal_context,
-            &mut gas_meter,
+            verify_input.session,
+            verify_input.traversal_context,
+            verify_input.gas_meter,
         ),
         TransactionData::ScriptOrModule(ScriptOrModule::Script(script)) => execute_script(
             script,
             &sender_move_address,
-            &mut session,
-            &mut traversal_context,
-            &mut gas_meter,
+            verify_input.session,
+            verify_input.traversal_context,
+            verify_input.gas_meter,
         ),
         TransactionData::ScriptOrModule(ScriptOrModule::Module(module)) => {
-            let module_id =
-                deploy_module(module, sender_move_address, &mut session, &mut gas_meter);
+            let module_id = deploy_module(
+                module,
+                sender_move_address,
+                verify_input.session,
+                verify_input.gas_meter,
+            );
             module_id.map(|id| {
                 deployment = Some((sender_move_address, id));
             })
@@ -168,9 +179,12 @@ pub(super) fn execute_canonical_transaction<
                 amount,
             };
 
-            input
-                .base_token
-                .transfer(args, &mut session, &mut traversal_context, &mut gas_meter)
+            input.base_token.transfer(
+                args,
+                verify_input.session,
+                verify_input.traversal_context,
+                verify_input.gas_meter,
+            )
         }
         TransactionData::L2Contract(contract) => {
             evm_logs = execute_l2_contract(
@@ -178,15 +192,15 @@ pub(super) fn execute_canonical_transaction<
                 &contract.to_move_address(),
                 input.tx.value,
                 input.tx.data.to_vec(),
-                &mut session,
-                &mut traversal_context,
-                &mut gas_meter,
+                verify_input.session,
+                verify_input.traversal_context,
+                verify_input.gas_meter,
             )?;
             Ok(())
         }
     };
 
-    let gas_used = total_gas_used(&gas_meter, input.genesis_config);
+    let gas_used = total_gas_used(verify_input.gas_meter, input.genesis_config);
     let used_l2_input = L2GasFeeInput::new(gas_used, input.l2_input.effective_gas_price);
     let used_l2_cost = input.l2_fee.l2_fee(used_l2_input).to_saturated_u64();
 
@@ -196,8 +210,8 @@ pub(super) fn execute_canonical_transaction<
         .refund_gas_cost(
             &sender_move_address,
             l2_cost.saturating_sub(used_l2_cost),
-            &mut session,
-            &mut traversal_context,
+            verify_input.session,
+            verify_input.traversal_context,
         )
         .map_err(|_| {
             crate::Error::InvariantViolation(InvariantViolation::EthToken(

--- a/moved/src/move_execution/mod.rs
+++ b/moved/src/move_execution/mod.rs
@@ -116,11 +116,13 @@ where
     vm.new_session_with_extensions(state, native_extensions)
 }
 
+#[derive(Debug)]
 pub enum TransactionExecutionInput<'input, S, F, B> {
     Deposit(DepositExecutionInput<'input, S>),
     Canonical(CanonicalExecutionInput<'input, S, F, B>),
 }
 
+#[derive(Debug)]
 pub struct DepositExecutionInput<'input, S> {
     pub tx: &'input DepositedTx,
     pub tx_hash: &'input B256,
@@ -137,6 +139,7 @@ impl<'input, S, F, B> From<DepositExecutionInput<'input, S>>
     }
 }
 
+#[derive(Debug)]
 pub struct CanonicalExecutionInput<'input, S, F, B> {
     pub tx: &'input NormalizedEthTransaction,
     pub tx_hash: &'input B256,


### PR DESCRIPTION
### Description
Changes the design of our transaction verification function by making it use only a single argument.

### Changes
- Introduce the concept of an input struct for verification of transactions
- Use the input structs for canonical transaction verification
- Update all usages
- Clear `#[allow(clippy::too_many_args)]` on the affected places

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt