### PR TITLE
Feat(server): Support cross origin CORS calls

### DIFF
--- a/engine-api/src/methods/estimate_gas.rs
+++ b/engine-api/src/methods/estimate_gas.rs
@@ -31,6 +31,10 @@ fn parse_params(
             data: request,
             message: "Not enough params".into(),
         }),
+        [a] => {
+            let transaction: TransactionRequest = json_utils::deserialize(a)?;
+            Ok((transaction, BlockNumberOrTag::Latest))
+        }
         [a, b] => {
             let transaction: TransactionRequest = json_utils::deserialize(a)?;
             let block_number: BlockNumberOrTag = json_utils::deserialize(b)?;
@@ -71,6 +75,19 @@ mod tests {
         std::str::FromStr,
         test_case::test_case,
     };
+
+    #[test]
+    fn test_parse_params_empty_block_number() {
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_estimateGas",
+            "params": [{}],
+            "id": 1
+        });
+
+        let (_, block_number) = parse_params(request.clone()).unwrap();
+        assert_eq!(block_number, BlockNumberOrTag::Latest);
+    }
 
     #[test_case("0x1")]
     #[test_case("latest")]

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -103,7 +103,8 @@ pub async fn run() {
         .and_then(|state_channel, path, query, method, headers, body| {
             // TODO: Limit engine API access to only authenticated endpoint
             mirror(state_channel, path, query, method, headers, body, "9545")
-        });
+        })
+        .with(warp::cors().allow_any_origin());
 
     let auth_state_channel = state_channel;
     let auth_server_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 8551));
@@ -113,7 +114,8 @@ pub async fn run() {
         .and(validate_jwt())
         .and_then(|state_channel, path, query, method, headers, body, _| {
             mirror(state_channel, path, query, method, headers, body, "9551")
-        });
+        })
+        .with(warp::cors().allow_any_origin());
 
     let (_, _, state_result) = tokio::join!(
         warp::serve(http_route).run(http_server_addr),


### PR DESCRIPTION
### Description
Browsers require CORS support when making calls to the server.
Viem client calls `eth_estimateGas` without the block number assuming the latest.

### Changes
- Receive calls from anywhere with CORS
- Accept estimate gas calls without the block number parameter

### Testing
✓ Unit tests, clippy and format checks all pass