### PR TITLE
refactor(api): Generalize JSON-RPC params parsing

### DIFF
--- a/api/src/json_utils.rs
+++ b/api/src/json_utils.rs
@@ -34,3 +34,47 @@ pub fn access_state_error<E: fmt::Debug>(e: E) -> JsonRpcError {
 pub fn transaction_error<E: fmt::Debug>(e: E) -> JsonRpcError {
     JsonRpcError::without_data(3, format!("Execution reverted: {e:?}"))
 }
+
+pub fn parse_params_0(request: serde_json::Value) -> Result<(), JsonRpcError> {
+    let params = get_params_list(&request);
+    match params {
+        [] => Ok(()),
+        _ => Err(JsonRpcError::parse_error(request, "Too many params")),
+    }
+}
+
+pub fn parse_params_1<T: DeserializeOwned>(request: serde_json::Value) -> Result<T, JsonRpcError> {
+    let params = get_params_list(&request);
+    match params {
+        [] => Err(JsonRpcError::parse_error(request, "Not enough params")),
+        [x] => Ok(deserialize(x)?),
+        _ => Err(JsonRpcError::parse_error(request, "Too many params")),
+    }
+}
+
+pub fn parse_params_2<T1, T2>(request: serde_json::Value) -> Result<(T1, T2), JsonRpcError>
+where
+    T1: DeserializeOwned,
+    T2: DeserializeOwned,
+{
+    let params = get_params_list(&request);
+    match params {
+        [] | [_] => Err(JsonRpcError::parse_error(request, "Not enough params")),
+        [a, b] => Ok((deserialize(a)?, deserialize(b)?)),
+        _ => Err(JsonRpcError::parse_error(request, "Too many params")),
+    }
+}
+
+pub fn parse_params_3<T1, T2, T3>(request: serde_json::Value) -> Result<(T1, T2, T3), JsonRpcError>
+where
+    T1: DeserializeOwned,
+    T2: DeserializeOwned,
+    T3: DeserializeOwned,
+{
+    let params = get_params_list(&request);
+    match params {
+        [] | [_] | [_, _] => Err(JsonRpcError::parse_error(request, "Not enough params")),
+        [a, b, c] => Ok((deserialize(a)?, deserialize(b)?, deserialize(c)?)),
+        _ => Err(JsonRpcError::parse_error(request, "Too many params")),
+    }
+}

--- a/api/src/methods/get_block_by_hash.rs
+++ b/api/src/methods/get_block_by_hash.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        json_utils::{self, access_state_error},
+        json_utils::{access_state_error, parse_params_2},
         jsonrpc::JsonRpcError,
         schema::GetBlockResponse,
     },
@@ -13,7 +13,7 @@ pub async fn execute(
     request: serde_json::Value,
     state_channel: mpsc::Sender<StateMessage>,
 ) -> Result<serde_json::Value, JsonRpcError> {
-    let (block_hash, include_transactions) = parse_params(request)?;
+    let (block_hash, include_transactions) = parse_params_2(request)?;
     let response = inner_execute(block_hash, include_transactions, state_channel).await?;
     Ok(serde_json::to_value(response).expect("Must be able to JSON-serialize response"))
 }
@@ -34,19 +34,6 @@ async fn inner_execute(
     let maybe_response = rx.await.map_err(access_state_error)?;
 
     Ok(maybe_response.map(GetBlockResponse::from))
-}
-
-fn parse_params(request: serde_json::Value) -> Result<(B256, bool), JsonRpcError> {
-    let params = json_utils::get_params_list(&request);
-    match params {
-        [] | [_] => Err(JsonRpcError::parse_error(request, "Not enough params")),
-        [x, y] => {
-            let block_hash: B256 = json_utils::deserialize(x)?;
-            let include_transactions: bool = json_utils::deserialize(y)?;
-            Ok((block_hash, include_transactions))
-        }
-        _ => Err(JsonRpcError::parse_error(request, "Too many params")),
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Description
The endpoint implementation contains parameter parsing logic, that contains a large portion of duplicated code.

In this PR we use generic return types to generalize and remove these duplicated parsing functions.

Targets only cases where the argument count is exact with no further logic.

### Changes
- Remove duplicate custom parsing logic and generalize it into a generic version

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt