### PR TITLE
build(server): Rename target binary `moved_server` => `op-move`

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -4,6 +4,10 @@ description = "Moved execution HTTP server (using warp)"
 version = "0.1.0"
 edition = "2021"
 
+[[bin]]
+path = "src/main.rs"
+name = "op-move"
+
 [dependencies]
 anyhow.workspace = true
 aptos-types.workspace = true


### PR DESCRIPTION
### Description
In case this is wanted, this PR changes the name of the output binary to `op-move` which should align nicely with the rest of the op stack.

When building for default target with release profile, the produced binary executable will be `./target/release/op-move`

### Changes
- Rename target binary `moved_server` => `op-move`

### Testing
```
cargo run --bin op-move
```