### PR TITLE
feat: Add transaction reading and writing

### DIFF
--- a/api/src/methods/get_payload.rs
+++ b/api/src/methods/get_payload.rs
@@ -47,9 +47,10 @@ mod tests {
         alloy::primitives::hex,
         moved::{
             block::{
-                Block, BlockMemory, BlockRepository, Eip1559GasFee, InMemoryBlockQueries,
+                Block, BlockRepository, Eip1559GasFee, InMemoryBlockQueries,
                 InMemoryBlockRepository,
             },
+            in_memory::SharedMemory,
             state_actor::InMemoryStateQueries,
             transaction::InMemoryTransactionRepository,
             types::state::Command,
@@ -93,9 +94,9 @@ mod tests {
         ));
         let genesis_block = Block::default().with_hash(head_hash).with_value(U256::ZERO);
 
-        let mut block_memory = BlockMemory::new();
+        let mut memory = SharedMemory::new();
         let mut repository = InMemoryBlockRepository::new();
-        repository.add(&mut block_memory, genesis_block);
+        repository.add(&mut memory, genesis_block);
 
         let mut state = InMemoryState::new();
         let (changes, table_changes) = moved_genesis_image::load();
@@ -116,7 +117,7 @@ mod tests {
             U256::ZERO,
             (),
             InMemoryBlockQueries,
-            block_memory,
+            memory,
             InMemoryStateQueries::from_genesis(initial_state_root),
             InMemoryTransactionRepository::new(),
             moved::state_actor::StateActor::on_tx_noop(),

--- a/api/src/methods/get_payload.rs
+++ b/api/src/methods/get_payload.rs
@@ -51,6 +51,7 @@ mod tests {
                 InMemoryBlockRepository,
             },
             state_actor::InMemoryStateQueries,
+            transaction::InMemoryTransactionRepository,
             types::state::Command,
         },
         moved_genesis::config::GenesisConfig,
@@ -117,6 +118,7 @@ mod tests {
             InMemoryBlockQueries,
             block_memory,
             InMemoryStateQueries::from_genesis(initial_state_root),
+            InMemoryTransactionRepository::new(),
             moved::state_actor::StateActor::on_tx_noop(),
             moved::state_actor::StateActor::on_tx_batch_noop(),
         );

--- a/api/src/methods/get_payload.rs
+++ b/api/src/methods/get_payload.rs
@@ -52,7 +52,7 @@ mod tests {
             },
             in_memory::SharedMemory,
             state_actor::InMemoryStateQueries,
-            transaction::InMemoryTransactionRepository,
+            transaction::{InMemoryTransactionQueries, InMemoryTransactionRepository},
             types::state::Command,
         },
         moved_genesis::config::GenesisConfig,
@@ -120,6 +120,7 @@ mod tests {
             memory,
             InMemoryStateQueries::from_genesis(initial_state_root),
             InMemoryTransactionRepository::new(),
+            InMemoryTransactionQueries::new(),
             moved::state_actor::StateActor::on_tx_noop(),
             moved::state_actor::StateActor::on_tx_batch_noop(),
         );

--- a/api/src/methods/get_transaction_by_hash.rs
+++ b/api/src/methods/get_transaction_by_hash.rs
@@ -40,7 +40,13 @@ async fn inner_execute(
 mod tests {
     use {
         super::*,
-        crate::methods::{send_raw_transaction, tests::create_state_actor},
+        crate::{
+            methods::{
+                forkchoice_updated, get_payload, send_raw_transaction, tests::create_state_actor,
+            },
+            schema::{ForkchoiceUpdatedResponseV1, GetPayloadResponseV3},
+        },
+        serde_json::json,
         std::iter,
     };
 
@@ -49,12 +55,41 @@ mod tests {
         let (state, state_channel) = create_state_actor();
         let state_handle = state.spawn();
 
+        // 1. Send transaction
         let tx_hash = send_raw_transaction::execute(
             send_raw_transaction::tests::example_request(),
             state_channel.clone(),
         )
         .await
         .unwrap();
+
+        // 2. Trigger block production
+        let forkchoice_response: ForkchoiceUpdatedResponseV1 = serde_json::from_value(
+            forkchoice_updated::execute_v3(
+                forkchoice_updated::tests::example_request(),
+                state_channel.clone(),
+            )
+            .await
+            .unwrap(),
+        )
+        .unwrap();
+        let request = serde_json::Value::Object(
+            iter::once((
+                "params".to_string(),
+                serde_json::Value::Array(vec![serde_json::to_value(
+                    forkchoice_response.payload_id.unwrap(),
+                )
+                .unwrap()]),
+            ))
+            .collect(),
+        );
+        let payload_response: GetPayloadResponseV3 = serde_json::from_value(
+            get_payload::execute_v3(request, state_channel.clone())
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        let _block_hash = payload_response.execution_payload.block_hash;
 
         let request = serde_json::Value::Object(
             iter::once((
@@ -63,10 +98,31 @@ mod tests {
             ))
             .collect(),
         );
-        let tx: serde_json::Value =
+        let actual_response: serde_json::Value =
             serde_json::from_value(execute(request, state_channel).await.unwrap()).unwrap();
+        let expected_response = json!({
+            "type": "0x2",
+            "chainId": "0x194",
+            "nonce": "0x0",
+            "gas": "0xffffffffffffffff",
+            "maxFeePerGas": "0x0",
+            "maxPriorityFeePerGas": "0x0",
+            "to": "0x8fd379246834eac74b8419ffda202cf8051f7a03",
+            "value": "0x3d",
+            "accessList": [],
+            "input": "0x",
+            "r": "0x78c716fef14bfcb7c2c9ff4abeb741529874fe7046ac042871f9d8490db55f5c",
+            "s": "0x1fd5186e08990692d54912b476496f12c48bd7cc540a92d211dde232133ed17",
+            "yParity": "0x0",
+            "v": "0x0",
+            "hash": "0x3545efb3ce7a22353c346c98771640131b81baa64eb03113b20ad2bef5c0ec53",
+            "blockHash": null,
+            "blockNumber": null,
+            "transactionIndex": null,
+            "from": "0x0000000000000000000000000000000000000000"
+        });
 
-        assert_eq!(tx, serde_json::Value::Null);
+        assert_eq!(actual_response, expected_response);
 
         state_handle.await.unwrap();
     }

--- a/api/src/methods/get_transaction_by_hash.rs
+++ b/api/src/methods/get_transaction_by_hash.rs
@@ -89,7 +89,7 @@ mod tests {
                 .unwrap(),
         )
         .unwrap();
-        let _block_hash = payload_response.execution_payload.block_hash;
+        let block_hash = payload_response.execution_payload.block_hash;
 
         let request = serde_json::Value::Object(
             iter::once((
@@ -116,10 +116,11 @@ mod tests {
             "yParity": "0x0",
             "v": "0x0",
             "hash": "0x3545efb3ce7a22353c346c98771640131b81baa64eb03113b20ad2bef5c0ec53",
-            "blockHash": null,
-            "blockNumber": null,
-            "transactionIndex": null,
-            "from": "0x0000000000000000000000000000000000000000"
+            "blockHash": block_hash,
+            "blockNumber": "0x1",
+            "transactionIndex": "0x2",
+            "from": "0x88f9b82462f6c4bf4a0fb15e5c3971559a316e7f",
+            "gasPrice": "0x0"
         });
 
         assert_eq!(actual_response, expected_response);

--- a/api/src/methods/mod.rs
+++ b/api/src/methods/mod.rs
@@ -40,7 +40,10 @@ pub mod tests {
             state_actor::{
                 InMemoryStateQueries, MockStateQueries, NewPayloadId, StateActor, StateQueries,
             },
-            transaction::{InMemoryTransactionRepository, TransactionRepository},
+            transaction::{
+                InMemoryTransactionQueries, InMemoryTransactionRepository, TransactionQueries,
+                TransactionRepository,
+            },
             types::{
                 state::{Command, Payload, StateMessage},
                 transactions::{DepositedTx, ExtendedTxEnvelope},
@@ -93,6 +96,7 @@ pub mod tests {
             memory,
             InMemoryStateQueries::from_genesis(initial_state_root),
             InMemoryTransactionRepository::new(),
+            InMemoryTransactionQueries::new(),
             StateActor::on_tx_noop(),
             StateActor::on_tx_batch_noop(),
         );
@@ -177,6 +181,7 @@ pub mod tests {
             (),
             impl StateQueries,
             impl TransactionRepository<Storage = ()>,
+            impl TransactionQueries<Storage = ()>,
         >,
         Sender<StateMessage>,
     ) {
@@ -199,6 +204,7 @@ pub mod tests {
             (),
             (),
             MockStateQueries(address, height),
+            (),
             (),
             StateActor::on_tx_noop(),
             StateActor::on_tx_batch_noop(),

--- a/api/src/methods/mod.rs
+++ b/api/src/methods/mod.rs
@@ -39,6 +39,7 @@ pub mod tests {
             state_actor::{
                 InMemoryStateQueries, MockStateQueries, NewPayloadId, StateActor, StateQueries,
             },
+            transaction::{InMemoryTransactionRepository, TransactionRepository},
             types::{
                 state::{Command, Payload, StateMessage},
                 transactions::{DepositedTx, ExtendedTxEnvelope},
@@ -90,6 +91,7 @@ pub mod tests {
             InMemoryBlockQueries,
             block_memory,
             InMemoryStateQueries::from_genesis(initial_state_root),
+            InMemoryTransactionRepository::new(),
             StateActor::on_tx_noop(),
             StateActor::on_tx_batch_noop(),
         );
@@ -173,6 +175,7 @@ pub mod tests {
             impl BlockQueries<Storage = ()>,
             (),
             impl StateQueries,
+            impl TransactionRepository,
         >,
         Sender<StateMessage>,
     ) {
@@ -195,6 +198,7 @@ pub mod tests {
             (),
             (),
             MockStateQueries(address, height),
+            InMemoryTransactionRepository::new(),
             StateActor::on_tx_noop(),
             StateActor::on_tx_batch_noop(),
         );

--- a/api/src/methods/mod.rs
+++ b/api/src/methods/mod.rs
@@ -30,9 +30,10 @@ pub mod tests {
         move_core_types::account_address::AccountAddress,
         moved::{
             block::{
-                BaseGasFee, Block, BlockHash, BlockMemory, BlockQueries, BlockRepository,
-                Eip1559GasFee, InMemoryBlockQueries, InMemoryBlockRepository, MovedBlockHash,
+                BaseGasFee, Block, BlockHash, BlockQueries, BlockRepository, Eip1559GasFee,
+                InMemoryBlockQueries, InMemoryBlockRepository, MovedBlockHash,
             },
+            in_memory::SharedMemory,
             move_execution::{
                 BaseTokenAccounts, CreateL1GasFee, CreateL2GasFee, MovedBaseTokenAccounts,
             },
@@ -66,9 +67,9 @@ pub mod tests {
         ));
         let genesis_block = Block::default().with_hash(head_hash).with_value(U256::ZERO);
 
-        let mut block_memory = BlockMemory::new();
+        let mut memory = SharedMemory::new();
         let mut repository = InMemoryBlockRepository::new();
-        repository.add(&mut block_memory, genesis_block);
+        repository.add(&mut memory, genesis_block);
 
         let mut state = InMemoryState::new();
         let (changes, table_changes) = moved_genesis_image::load();
@@ -89,7 +90,7 @@ pub mod tests {
             U256::ZERO,
             MovedBaseTokenAccounts::new(AccountAddress::ONE),
             InMemoryBlockQueries,
-            block_memory,
+            memory,
             InMemoryStateQueries::from_genesis(initial_state_root),
             InMemoryTransactionRepository::new(),
             StateActor::on_tx_noop(),
@@ -175,7 +176,7 @@ pub mod tests {
             impl BlockQueries<Storage = ()>,
             (),
             impl StateQueries,
-            impl TransactionRepository,
+            impl TransactionRepository<Storage = ()>,
         >,
         Sender<StateMessage>,
     ) {
@@ -198,7 +199,7 @@ pub mod tests {
             (),
             (),
             MockStateQueries(address, height),
-            InMemoryTransactionRepository::new(),
+            (),
             StateActor::on_tx_noop(),
             StateActor::on_tx_batch_noop(),
         );

--- a/api/src/methods/new_payload.rs
+++ b/api/src/methods/new_payload.rs
@@ -165,9 +165,10 @@ mod tests {
         alloy::primitives::hex,
         moved::{
             block::{
-                Block, BlockMemory, BlockRepository, Eip1559GasFee, InMemoryBlockQueries,
+                Block, BlockRepository, Eip1559GasFee, InMemoryBlockQueries,
                 InMemoryBlockRepository,
             },
+            in_memory::SharedMemory,
             state_actor::InMemoryStateQueries,
             transaction::InMemoryTransactionRepository,
         },
@@ -255,9 +256,9 @@ mod tests {
         ));
         let genesis_block = Block::default().with_hash(head_hash).with_value(U256::ZERO);
 
-        let mut block_memory = BlockMemory::new();
+        let mut memory = SharedMemory::new();
         let mut repository = InMemoryBlockRepository::new();
-        repository.add(&mut block_memory, genesis_block);
+        repository.add(&mut memory, genesis_block);
 
         let mut state = InMemoryState::new();
         let (changes, table_changes) = moved_genesis_image::load();
@@ -280,7 +281,7 @@ mod tests {
             U256::ZERO,
             (),
             InMemoryBlockQueries,
-            block_memory,
+            memory,
             InMemoryStateQueries::from_genesis(initial_state_root),
             InMemoryTransactionRepository::new(),
             moved::state_actor::StateActor::on_tx_noop(),

--- a/api/src/methods/new_payload.rs
+++ b/api/src/methods/new_payload.rs
@@ -170,7 +170,7 @@ mod tests {
             },
             in_memory::SharedMemory,
             state_actor::InMemoryStateQueries,
-            transaction::InMemoryTransactionRepository,
+            transaction::{InMemoryTransactionQueries, InMemoryTransactionRepository},
         },
         moved_genesis::config::GenesisConfig,
         moved_shared::primitives::{Address, Bytes, B2048, U256, U64},
@@ -284,6 +284,7 @@ mod tests {
             memory,
             InMemoryStateQueries::from_genesis(initial_state_root),
             InMemoryTransactionRepository::new(),
+            InMemoryTransactionQueries::new(),
             moved::state_actor::StateActor::on_tx_noop(),
             moved::state_actor::StateActor::on_tx_batch_noop(),
         );

--- a/api/src/methods/new_payload.rs
+++ b/api/src/methods/new_payload.rs
@@ -169,6 +169,7 @@ mod tests {
                 InMemoryBlockRepository,
             },
             state_actor::InMemoryStateQueries,
+            transaction::InMemoryTransactionRepository,
         },
         moved_genesis::config::GenesisConfig,
         moved_shared::primitives::{Address, Bytes, B2048, U256, U64},
@@ -281,6 +282,7 @@ mod tests {
             InMemoryBlockQueries,
             block_memory,
             InMemoryStateQueries::from_genesis(initial_state_root),
+            InMemoryTransactionRepository::new(),
             moved::state_actor::StateActor::on_tx_noop(),
             moved::state_actor::StateActor::on_tx_batch_noop(),
         );

--- a/api/src/schema/eth.rs
+++ b/api/src/schema/eth.rs
@@ -1,7 +1,7 @@
 pub use alloy::eips::BlockNumberOrTag;
 
 use {
-    moved::types::state::{BlockResponse, RpcBlock, RpcTx, TransactionResponse},
+    moved::types::state::{BlockResponse, RpcBlock, RpcTransaction, TransactionResponse},
     serde::{Deserialize, Serialize},
 };
 
@@ -15,10 +15,10 @@ impl From<BlockResponse> for GetBlockResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct GetTransactionResponse(pub RpcTx);
+pub struct GetTransactionResponse(pub RpcTransaction);
 
 impl From<TransactionResponse> for GetTransactionResponse {
     fn from(value: TransactionResponse) -> Self {
-        Self(value.0)
+        Self(value)
     }
 }

--- a/moved/src/in_memory.rs
+++ b/moved/src/in_memory.rs
@@ -1,0 +1,13 @@
+use crate::{block::BlockMemory, transaction::TransactionMemory};
+
+#[derive(Debug, Default)]
+pub struct SharedMemory {
+    pub block_memory: BlockMemory,
+    pub transaction_memory: TransactionMemory,
+}
+
+impl SharedMemory {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/moved/src/lib.rs
+++ b/moved/src/lib.rs
@@ -2,6 +2,7 @@ pub use error::*;
 
 pub mod block;
 pub mod error;
+pub mod in_memory;
 pub mod move_execution;
 pub mod state_actor;
 pub mod transaction;

--- a/moved/src/lib.rs
+++ b/moved/src/lib.rs
@@ -4,6 +4,7 @@ pub mod block;
 pub mod error;
 pub mod move_execution;
 pub mod state_actor;
+pub mod transaction;
 pub mod types;
 
 #[cfg(test)]

--- a/moved/src/state_actor.rs
+++ b/moved/src/state_actor.rs
@@ -1,4 +1,3 @@
-use alloy::consensus::Transaction;
 pub use {
     payload::{NewPayloadId, NewPayloadIdInput, StatePayloadId},
     queries::{
@@ -15,9 +14,10 @@ use {
         move_execution::{
             execute_transaction,
             simulate::{call_transaction, simulate_transaction},
-            BaseTokenAccounts, CreateL1GasFee, CreateL2GasFee, L1GasFee, L1GasFeeInput,
-            L2GasFeeInput, LogsBloom,
+            BaseTokenAccounts, CanonicalExecutionInput, CreateL1GasFee, CreateL2GasFee,
+            DepositExecutionInput, L1GasFee, L1GasFeeInput, L2GasFeeInput, LogsBloom,
         },
+        transaction::{ExtendedTransaction, TransactionQueries, TransactionRepository},
         types::{
             queries::ProofResponse,
             state::{
@@ -30,7 +30,7 @@ use {
         Error::{InvalidTransaction, InvariantViolation, User},
     },
     alloy::{
-        consensus::Receipt,
+        consensus::{Receipt, Transaction},
         eips::{
             eip2718::Encodable2718,
             BlockId,
@@ -712,12 +712,6 @@ impl<
     }
 }
 
-use crate::{
-    move_execution::{CanonicalExecutionInput, DepositExecutionInput},
-    transaction::{ExtendedTransaction, TransactionRepository},
-};
-
-use crate::transaction::TransactionQueries;
 #[cfg(any(feature = "test-doubles", test))]
 pub use test_doubles::*;
 

--- a/moved/src/transaction/in_memory.rs
+++ b/moved/src/transaction/in_memory.rs
@@ -1,0 +1,65 @@
+use {
+    crate::{
+        transaction::{Transaction, TransactionQueries, TransactionRepository},
+        types::state::TransactionResponse,
+    },
+    alloy::eips::eip2718::Encodable2718,
+    moved_shared::primitives::B256,
+    std::convert::Infallible,
+};
+
+#[derive(Debug)]
+pub struct TransactionMemory {
+    txs: std::collections::HashMap<B256, Transaction>,
+}
+
+impl TransactionMemory {
+    pub fn add(&mut self, tx: Transaction) {
+        self.txs.insert(tx.0.trie_hash(), tx);
+    }
+
+    pub fn by_hash(&self, hash: B256) -> Option<Transaction> {
+        self.txs.get(&hash).cloned()
+    }
+}
+
+#[derive(Debug)]
+pub struct InMemoryTransactionRepository;
+
+impl Default for InMemoryTransactionRepository {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InMemoryTransactionRepository {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[derive(Debug)]
+pub struct InMemoryTransactionQueries;
+
+impl TransactionRepository for InMemoryTransactionRepository {
+    type Err = Infallible;
+    type Storage = TransactionMemory;
+
+    fn add(&mut self, storage: &mut Self::Storage, tx: Transaction) -> Result<(), Self::Err> {
+        storage.add(tx);
+        Ok(())
+    }
+}
+
+impl TransactionQueries for InMemoryTransactionQueries {
+    type Err = Infallible;
+    type Storage = TransactionMemory;
+
+    fn by_hash(
+        &self,
+        storage: &Self::Storage,
+        hash: B256,
+    ) -> Result<Option<TransactionResponse>, Self::Err> {
+        Ok(storage.by_hash(hash).map(TransactionResponse::from))
+    }
+}

--- a/moved/src/transaction/in_memory.rs
+++ b/moved/src/transaction/in_memory.rs
@@ -1,17 +1,16 @@
 use {
     crate::{
         in_memory::SharedMemory,
-        transaction::{Transaction, TransactionQueries, TransactionRepository},
+        transaction::{ExtendedTransaction, TransactionQueries, TransactionRepository},
         types::state::TransactionResponse,
     },
-    alloy::eips::eip2718::Encodable2718,
     moved_shared::primitives::B256,
     std::{collections::HashMap, convert::Infallible},
 };
 
 #[derive(Debug, Default)]
 pub struct TransactionMemory {
-    txs: HashMap<B256, Transaction>,
+    mem: HashMap<B256, ExtendedTransaction>,
 }
 
 impl TransactionMemory {
@@ -19,17 +18,16 @@ impl TransactionMemory {
         Self::default()
     }
 
-    pub fn add(&mut self, tx: Transaction) {
-        self.txs.insert(tx.0.trie_hash(), tx);
+    pub fn add(&mut self, tx: ExtendedTransaction) {
+        self.mem.insert(tx.hash(), tx);
     }
 
-    pub fn extend(&mut self, tx: impl IntoIterator<Item = Transaction>) {
-        self.txs
-            .extend(tx.into_iter().map(|tx| (tx.0.trie_hash(), tx)));
+    pub fn extend(&mut self, tx: impl IntoIterator<Item = ExtendedTransaction>) {
+        self.mem.extend(tx.into_iter().map(|tx| (tx.hash(), tx)));
     }
 
-    pub fn by_hash(&self, hash: B256) -> Option<Transaction> {
-        self.txs.get(&hash).cloned()
+    pub fn by_hash(&self, hash: B256) -> Option<ExtendedTransaction> {
+        self.mem.get(&hash).cloned()
     }
 }
 
@@ -58,7 +56,7 @@ impl TransactionRepository for InMemoryTransactionRepository {
     fn add(
         &mut self,
         storage: &mut Self::Storage,
-        transaction: Transaction,
+        transaction: ExtendedTransaction,
     ) -> Result<(), Self::Err> {
         storage.transaction_memory.add(transaction);
         Ok(())
@@ -67,7 +65,7 @@ impl TransactionRepository for InMemoryTransactionRepository {
     fn extend(
         &mut self,
         storage: &mut Self::Storage,
-        transactions: impl IntoIterator<Item = Transaction>,
+        transactions: impl IntoIterator<Item = ExtendedTransaction>,
     ) -> Result<(), Self::Err> {
         storage.transaction_memory.extend(transactions);
         Ok(())
@@ -111,14 +109,14 @@ mod test_doubles {
         type Err = Infallible;
         type Storage = ();
 
-        fn add(&mut self, _: &mut Self::Storage, _: Transaction) -> Result<(), Self::Err> {
+        fn add(&mut self, _: &mut Self::Storage, _: ExtendedTransaction) -> Result<(), Self::Err> {
             Ok(())
         }
 
         fn extend(
             &mut self,
             _: &mut Self::Storage,
-            _: impl IntoIterator<Item = Transaction>,
+            _: impl IntoIterator<Item = ExtendedTransaction>,
         ) -> Result<(), Self::Err> {
             Ok(())
         }

--- a/moved/src/transaction/in_memory.rs
+++ b/moved/src/transaction/in_memory.rs
@@ -1,21 +1,31 @@
 use {
     crate::{
+        in_memory::SharedMemory,
         transaction::{Transaction, TransactionQueries, TransactionRepository},
         types::state::TransactionResponse,
     },
     alloy::eips::eip2718::Encodable2718,
     moved_shared::primitives::B256,
-    std::convert::Infallible,
+    std::{collections::HashMap, convert::Infallible},
 };
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct TransactionMemory {
-    txs: std::collections::HashMap<B256, Transaction>,
+    txs: HashMap<B256, Transaction>,
 }
 
 impl TransactionMemory {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     pub fn add(&mut self, tx: Transaction) {
         self.txs.insert(tx.0.trie_hash(), tx);
+    }
+
+    pub fn extend(&mut self, tx: impl IntoIterator<Item = Transaction>) {
+        self.txs
+            .extend(tx.into_iter().map(|tx| (tx.0.trie_hash(), tx)));
     }
 
     pub fn by_hash(&self, hash: B256) -> Option<Transaction> {
@@ -43,23 +53,74 @@ pub struct InMemoryTransactionQueries;
 
 impl TransactionRepository for InMemoryTransactionRepository {
     type Err = Infallible;
-    type Storage = TransactionMemory;
+    type Storage = SharedMemory;
 
-    fn add(&mut self, storage: &mut Self::Storage, tx: Transaction) -> Result<(), Self::Err> {
-        storage.add(tx);
+    fn add(
+        &mut self,
+        storage: &mut Self::Storage,
+        transaction: Transaction,
+    ) -> Result<(), Self::Err> {
+        storage.transaction_memory.add(transaction);
+        Ok(())
+    }
+
+    fn extend(
+        &mut self,
+        storage: &mut Self::Storage,
+        transactions: impl IntoIterator<Item = Transaction>,
+    ) -> Result<(), Self::Err> {
+        storage.transaction_memory.extend(transactions);
         Ok(())
     }
 }
 
 impl TransactionQueries for InMemoryTransactionQueries {
     type Err = Infallible;
-    type Storage = TransactionMemory;
+    type Storage = SharedMemory;
 
     fn by_hash(
         &self,
         storage: &Self::Storage,
         hash: B256,
     ) -> Result<Option<TransactionResponse>, Self::Err> {
-        Ok(storage.by_hash(hash).map(TransactionResponse::from))
+        Ok(storage
+            .transaction_memory
+            .by_hash(hash)
+            .map(TransactionResponse::from))
+    }
+}
+
+#[cfg(any(feature = "test-doubles", test))]
+mod test_doubles {
+    use super::*;
+
+    impl TransactionQueries for () {
+        type Err = Infallible;
+        type Storage = ();
+
+        fn by_hash(
+            &self,
+            _: &Self::Storage,
+            _: B256,
+        ) -> Result<Option<TransactionResponse>, Self::Err> {
+            Ok(None)
+        }
+    }
+
+    impl TransactionRepository for () {
+        type Err = Infallible;
+        type Storage = ();
+
+        fn add(&mut self, _: &mut Self::Storage, _: Transaction) -> Result<(), Self::Err> {
+            Ok(())
+        }
+
+        fn extend(
+            &mut self,
+            _: &mut Self::Storage,
+            _: impl IntoIterator<Item = Transaction>,
+        ) -> Result<(), Self::Err> {
+            Ok(())
+        }
     }
 }

--- a/moved/src/transaction/in_memory.rs
+++ b/moved/src/transaction/in_memory.rs
@@ -33,14 +33,8 @@ impl TransactionMemory {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct InMemoryTransactionRepository;
-
-impl Default for InMemoryTransactionRepository {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 impl InMemoryTransactionRepository {
     pub fn new() -> Self {
@@ -48,8 +42,14 @@ impl InMemoryTransactionRepository {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct InMemoryTransactionQueries;
+
+impl InMemoryTransactionQueries {
+    pub fn new() -> Self {
+        Self
+    }
+}
 
 impl TransactionRepository for InMemoryTransactionRepository {
     type Err = Infallible;

--- a/moved/src/transaction/in_memory.rs
+++ b/moved/src/transaction/in_memory.rs
@@ -10,7 +10,7 @@ use {
 
 #[derive(Debug, Default)]
 pub struct TransactionMemory {
-    mem: HashMap<B256, ExtendedTransaction>,
+    transactions: HashMap<B256, ExtendedTransaction>,
 }
 
 impl TransactionMemory {
@@ -18,16 +18,13 @@ impl TransactionMemory {
         Self::default()
     }
 
-    pub fn add(&mut self, tx: ExtendedTransaction) {
-        self.mem.insert(tx.hash(), tx);
-    }
-
     pub fn extend(&mut self, tx: impl IntoIterator<Item = ExtendedTransaction>) {
-        self.mem.extend(tx.into_iter().map(|tx| (tx.hash(), tx)));
+        self.transactions
+            .extend(tx.into_iter().map(|tx| (tx.hash(), tx)));
     }
 
     pub fn by_hash(&self, hash: B256) -> Option<ExtendedTransaction> {
-        self.mem.get(&hash).cloned()
+        self.transactions.get(&hash).cloned()
     }
 }
 
@@ -52,15 +49,6 @@ impl InMemoryTransactionQueries {
 impl TransactionRepository for InMemoryTransactionRepository {
     type Err = Infallible;
     type Storage = SharedMemory;
-
-    fn add(
-        &mut self,
-        storage: &mut Self::Storage,
-        transaction: ExtendedTransaction,
-    ) -> Result<(), Self::Err> {
-        storage.transaction_memory.add(transaction);
-        Ok(())
-    }
 
     fn extend(
         &mut self,
@@ -108,10 +96,6 @@ mod test_doubles {
     impl TransactionRepository for () {
         type Err = Infallible;
         type Storage = ();
-
-        fn add(&mut self, _: &mut Self::Storage, _: ExtendedTransaction) -> Result<(), Self::Err> {
-            Ok(())
-        }
 
         fn extend(
             &mut self,

--- a/moved/src/transaction/mod.rs
+++ b/moved/src/transaction/mod.rs
@@ -1,7 +1,7 @@
 pub use {
     in_memory::{InMemoryTransactionQueries, InMemoryTransactionRepository, TransactionMemory},
     read::TransactionQueries,
-    write::{Transaction, TransactionRepository},
+    write::{ExtendedTransaction, TransactionRepository},
 };
 
 mod in_memory;

--- a/moved/src/transaction/mod.rs
+++ b/moved/src/transaction/mod.rs
@@ -1,0 +1,9 @@
+pub use {
+    in_memory::{InMemoryTransactionQueries, InMemoryTransactionRepository, TransactionMemory},
+    read::TransactionQueries,
+    write::{Transaction, TransactionRepository},
+};
+
+mod in_memory;
+mod read;
+mod write;

--- a/moved/src/transaction/read.rs
+++ b/moved/src/transaction/read.rs
@@ -1,0 +1,12 @@
+use {crate::types::state::TransactionResponse, moved_shared::primitives::B256, std::fmt::Debug};
+
+pub trait TransactionQueries {
+    type Err: Debug;
+    type Storage;
+
+    fn by_hash(
+        &self,
+        storage: &Self::Storage,
+        hash: B256,
+    ) -> Result<Option<TransactionResponse>, Self::Err>;
+}

--- a/moved/src/transaction/write.rs
+++ b/moved/src/transaction/write.rs
@@ -1,11 +1,40 @@
-use {op_alloy::consensus::OpTxEnvelope, std::fmt::Debug};
+use {
+    alloy::eips::eip2718::Encodable2718, moved_shared::primitives::B256,
+    op_alloy::consensus::OpTxEnvelope, std::fmt::Debug,
+};
 
 #[derive(Debug, Clone)]
-pub struct Transaction(pub OpTxEnvelope);
+pub struct ExtendedTransaction {
+    pub effective_gas_price: u128,
+    pub inner: OpTxEnvelope,
+    pub block_number: u64,
+    pub block_hash: B256,
+    pub transaction_index: u64,
+}
 
-impl Transaction {
-    pub fn new(inner: OpTxEnvelope) -> Self {
-        Self(inner)
+impl ExtendedTransaction {
+    pub fn new(
+        effective_gas_price: u128,
+        inner: OpTxEnvelope,
+        block_number: u64,
+        block_hash: B256,
+        transaction_index: u64,
+    ) -> Self {
+        Self {
+            effective_gas_price,
+            inner,
+            block_number,
+            block_hash,
+            transaction_index,
+        }
+    }
+
+    pub fn inner(&self) -> &OpTxEnvelope {
+        &self.inner
+    }
+
+    pub fn hash(&self) -> B256 {
+        self.inner.trie_hash()
     }
 }
 
@@ -16,12 +45,12 @@ pub trait TransactionRepository {
     fn add(
         &mut self,
         storage: &mut Self::Storage,
-        transaction: Transaction,
+        transaction: ExtendedTransaction,
     ) -> Result<(), Self::Err>;
 
     fn extend(
         &mut self,
         storage: &mut Self::Storage,
-        transactions: impl IntoIterator<Item = Transaction>,
+        transactions: impl IntoIterator<Item = ExtendedTransaction>,
     ) -> Result<(), Self::Err>;
 }

--- a/moved/src/transaction/write.rs
+++ b/moved/src/transaction/write.rs
@@ -42,12 +42,6 @@ pub trait TransactionRepository {
     type Err: Debug;
     type Storage;
 
-    fn add(
-        &mut self,
-        storage: &mut Self::Storage,
-        transaction: ExtendedTransaction,
-    ) -> Result<(), Self::Err>;
-
     fn extend(
         &mut self,
         storage: &mut Self::Storage,

--- a/moved/src/transaction/write.rs
+++ b/moved/src/transaction/write.rs
@@ -1,0 +1,11 @@
+use {op_alloy::consensus::OpTxEnvelope, std::fmt::Debug};
+
+#[derive(Debug, Clone)]
+pub struct Transaction(pub OpTxEnvelope);
+
+pub trait TransactionRepository {
+    type Err: Debug;
+    type Storage;
+
+    fn add(&mut self, storage: &mut Self::Storage, tx: Transaction) -> Result<(), Self::Err>;
+}

--- a/moved/src/transaction/write.rs
+++ b/moved/src/transaction/write.rs
@@ -3,9 +3,25 @@ use {op_alloy::consensus::OpTxEnvelope, std::fmt::Debug};
 #[derive(Debug, Clone)]
 pub struct Transaction(pub OpTxEnvelope);
 
+impl Transaction {
+    pub fn new(inner: OpTxEnvelope) -> Self {
+        Self(inner)
+    }
+}
+
 pub trait TransactionRepository {
     type Err: Debug;
     type Storage;
 
-    fn add(&mut self, storage: &mut Self::Storage, tx: Transaction) -> Result<(), Self::Err>;
+    fn add(
+        &mut self,
+        storage: &mut Self::Storage,
+        transaction: Transaction,
+    ) -> Result<(), Self::Err>;
+
+    fn extend(
+        &mut self,
+        storage: &mut Self::Storage,
+        transactions: impl IntoIterator<Item = Transaction>,
+    ) -> Result<(), Self::Err>;
 }

--- a/moved/src/types/state.rs
+++ b/moved/src/types/state.rs
@@ -8,6 +8,7 @@ use {
     crate::{
         block::{ExtendedBlock, Header},
         state_actor::NewPayloadIdInput,
+        transaction::Transaction,
         types::transactions::NormalizedExtendedTxEnvelope,
     },
     alloy::{
@@ -377,6 +378,76 @@ fn compute_from(tx: &OpTxEnvelope) -> Result<Address, alloy::primitives::Signatu
 
 #[derive(Debug)]
 pub struct TransactionResponse(pub op_alloy::rpc_types::Transaction);
+
+impl TransactionResponse {
+    pub fn canonical(
+        inner: OpTxEnvelope,
+        block_hash: B256,
+        block_number: u64,
+        transaction_index: u64,
+        effective_gas_price: u128,
+        from: Address,
+    ) -> Self {
+        Self(op_alloy::rpc_types::Transaction {
+            inner: alloy::rpc::types::eth::Transaction {
+                inner,
+                block_hash: Some(block_hash),
+                block_number: Some(block_number),
+                transaction_index: Some(transaction_index),
+                effective_gas_price: Some(effective_gas_price),
+                from,
+            },
+            deposit_nonce: None,
+            deposit_receipt_version: None,
+        })
+    }
+
+    pub fn deposit(
+        inner: OpTxEnvelope,
+        block_hash: B256,
+        block_number: u64,
+        transaction_index: u64,
+        effective_gas_price: u128,
+        from: Address,
+        deposit_nonce: u64,
+        deposit_receipt_version: u64,
+    ) -> Self {
+        Self(op_alloy::rpc_types::Transaction {
+            inner: alloy::rpc::types::eth::Transaction {
+                inner,
+                block_hash: Some(block_hash),
+                block_number: Some(block_number),
+                transaction_index: Some(transaction_index),
+                effective_gas_price: Some(effective_gas_price),
+                from,
+            },
+            deposit_nonce: Some(deposit_nonce),
+            deposit_receipt_version: Some(deposit_receipt_version),
+        })
+    }
+}
+
+impl From<Transaction> for TransactionResponse {
+    fn from(value: Transaction) -> Self {
+        let (deposit_nonce, deposit_receipt_version) = get_deposit_nonce(&value.0)
+            .map(|nonce| (Some(nonce.nonce), Some(nonce.version)))
+            .unwrap_or((None, None));
+
+        Self(op_alloy::rpc_types::Transaction {
+            inner: alloy::rpc::types::eth::Transaction {
+                inner: value.0,
+                // TODO: Solve missing fields
+                block_hash: None,
+                block_number: None,
+                transaction_index: None,
+                effective_gas_price: None,
+                from: Default::default(),
+            },
+            deposit_nonce,
+            deposit_receipt_version,
+        })
+    }
+}
 
 pub type TransactionReceipt = op_alloy::rpc_types::OpTransactionReceipt;
 

--- a/moved/src/types/state.rs
+++ b/moved/src/types/state.rs
@@ -233,7 +233,7 @@ impl From<Query> for StateMessage {
 }
 
 pub type RpcBlock = alloy::rpc::types::Block<op_alloy::rpc_types::Transaction>;
-pub type RpcTx = op_alloy::rpc_types::Transaction;
+pub type RpcTransaction = op_alloy::rpc_types::Transaction;
 
 #[derive(Debug)]
 pub struct BlockResponse(pub RpcBlock);
@@ -376,8 +376,7 @@ fn compute_from(tx: &OpTxEnvelope) -> Result<Address, alloy::primitives::Signatu
     }
 }
 
-#[derive(Debug)]
-pub struct TransactionResponse(pub op_alloy::rpc_types::Transaction);
+pub type TransactionResponse = op_alloy::rpc_types::Transaction;
 
 impl From<ExtendedTransaction> for TransactionResponse {
     fn from(value: ExtendedTransaction) -> Self {
@@ -385,7 +384,7 @@ impl From<ExtendedTransaction> for TransactionResponse {
             .map(|nonce| (Some(nonce.nonce), Some(nonce.version)))
             .unwrap_or((None, None));
 
-        Self(op_alloy::rpc_types::Transaction {
+        Self {
             inner: alloy::rpc::types::eth::Transaction {
                 from: compute_from(value.inner())
                     .expect("Block transactions should contain valid signature"),
@@ -397,7 +396,7 @@ impl From<ExtendedTransaction> for TransactionResponse {
             },
             deposit_nonce,
             deposit_receipt_version,
-        })
+        }
     }
 }
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -11,7 +11,7 @@ use {
         in_memory::SharedMemory,
         move_execution::{CreateEcotoneL1GasFee, CreateMovedL2GasFee, MovedBaseTokenAccounts},
         state_actor::{InMemoryStateQueries, StateActor, StatePayloadId},
-        transaction::InMemoryTransactionRepository,
+        transaction::{InMemoryTransactionQueries, InMemoryTransactionRepository},
         types::state::{Command, StateMessage},
     },
     moved_genesis::config::GenesisConfig,
@@ -56,6 +56,7 @@ pub type ProductionStateActor = StateActor<
     SharedMemory,
     InMemoryStateQueries,
     InMemoryTransactionRepository,
+    InMemoryTransactionQueries,
 >;
 
 #[derive(Parser)]
@@ -157,6 +158,7 @@ pub fn initialize_state_actor(
     let base_token = MovedBaseTokenAccounts::new(genesis_config.treasury);
 
     let transaction_repository = InMemoryTransactionRepository::new();
+    let transaction_queries = InMemoryTransactionQueries::new();
 
     StateActor::new(
         rx,
@@ -178,6 +180,7 @@ pub fn initialize_state_actor(
         memory,
         state_query,
         transaction_repository,
+        transaction_queries,
         moved::state_actor::StateActor::on_tx_in_memory(),
         moved::state_actor::StateActor::on_tx_batch_in_memory(),
     )

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -10,6 +10,7 @@ use {
         },
         move_execution::{CreateEcotoneL1GasFee, CreateMovedL2GasFee, MovedBaseTokenAccounts},
         state_actor::{InMemoryStateQueries, StateActor, StatePayloadId},
+        transaction::InMemoryTransactionRepository,
         types::state::{Command, StateMessage},
     },
     moved_genesis::config::GenesisConfig,
@@ -53,6 +54,7 @@ pub type ProductionStateActor = StateActor<
     InMemoryBlockQueries,
     BlockMemory,
     InMemoryStateQueries,
+    InMemoryTransactionRepository,
 >;
 
 #[derive(Parser)]
@@ -152,6 +154,9 @@ pub fn initialize_state_actor(
     moved_genesis::apply(genesis_changes, table_changes, &genesis_config, &mut state);
 
     let base_token = MovedBaseTokenAccounts::new(genesis_config.treasury);
+
+    let transaction_repository = InMemoryTransactionRepository::new();
+
     StateActor::new(
         rx,
         state,
@@ -171,6 +176,7 @@ pub fn initialize_state_actor(
         InMemoryBlockQueries,
         block_memory,
         state_query,
+        transaction_repository,
         moved::state_actor::StateActor::on_tx_in_memory(),
         moved::state_actor::StateActor::on_tx_batch_in_memory(),
     )

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -5,9 +5,10 @@ use {
     jsonwebtoken::{DecodingKey, Validation},
     moved::{
         block::{
-            Block, BlockHash, BlockMemory, BlockRepository, Eip1559GasFee, ExtendedBlock, Header,
+            Block, BlockHash, BlockRepository, Eip1559GasFee, ExtendedBlock, Header,
             InMemoryBlockQueries, InMemoryBlockRepository, MovedBlockHash,
         },
+        in_memory::SharedMemory,
         move_execution::{CreateEcotoneL1GasFee, CreateMovedL2GasFee, MovedBaseTokenAccounts},
         state_actor::{InMemoryStateQueries, StateActor, StatePayloadId},
         transaction::InMemoryTransactionRepository,
@@ -52,7 +53,7 @@ pub type ProductionStateActor = StateActor<
     CreateMovedL2GasFee,
     MovedBaseTokenAccounts,
     InMemoryBlockQueries,
-    BlockMemory,
+    SharedMemory,
     InMemoryStateQueries,
     InMemoryTransactionRepository,
 >;
@@ -134,10 +135,10 @@ pub fn initialize_state_actor(
     let block_hash = MovedBlockHash;
     let genesis_block = create_genesis_block(&block_hash, &genesis_config);
 
-    let mut block_memory = BlockMemory::new();
+    let mut memory = SharedMemory::new();
     let mut repository = InMemoryBlockRepository::new();
     let head = genesis_block.hash;
-    repository.add(&mut block_memory, genesis_block);
+    repository.add(&mut memory, genesis_block);
 
     let mut state = InMemoryState::new();
     let (genesis_changes, table_changes) = {
@@ -174,7 +175,7 @@ pub fn initialize_state_actor(
         CreateMovedL2GasFee,
         base_token,
         InMemoryBlockQueries,
-        block_memory,
+        memory,
         state_query,
         transaction_repository,
         moved::state_actor::StateActor::on_tx_in_memory(),


### PR DESCRIPTION
### Description
* Adds append-only repository and query for fetching by hash.
* Allows for querying transactions using API.
* Includes in-memory implementation.

### Changes
- Add write and read model for transactions
- Add in-memory implementations
- Include the model in `StateActor`
- Return proper responses in `api` endpoint
- Fill-in all missing fields

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt

### Notes
In this version, the transactions are stored twice. Once in their own memory space and once as a part of blocks.

This can be mitigated, but doing so would increase the amount of changes in this high priority PR as well as time to finish and review it.

Therefore we can conclude that it's better to target it as a separate issue.