### PR TITLE
Fix: Ignore engaging EVM for zero amounts

### DIFF
--- a/api/src/methods/estimate_gas.rs
+++ b/api/src/methods/estimate_gas.rs
@@ -145,7 +145,7 @@ mod tests {
             "id": 1
         });
 
-        let expected_response: serde_json::Value = serde_json::from_str(r#""0x2ee0""#).unwrap();
+        let expected_response: serde_json::Value = serde_json::from_str(r#""0xbb8""#).unwrap();
         let response = execute(request, state_channel).await.unwrap();
 
         assert_eq!(response, expected_response);

--- a/moved/src/move_execution/eth_token.rs
+++ b/moved/src/move_execution/eth_token.rs
@@ -130,6 +130,9 @@ pub fn mint_eth<G: GasMeter>(
     traversal_context: &mut TraversalContext,
     gas_meter: &mut G,
 ) -> Result<(), crate::Error> {
+    if amount.is_zero() {
+        return Ok(());
+    }
     let token_module_id = ModuleId::new(FRAMEWORK_ADDRESS, TOKEN_MODULE_NAME.into());
     let admin_arg = bcs::to_bytes(&MoveValue::Signer(TOKEN_ADMIN)).expect("signer can serialize");
     let to_arg = bcs::to_bytes(to).expect("address can serialize");
@@ -164,6 +167,9 @@ pub fn burn_eth<G: GasMeter>(
     traversal_context: &mut TraversalContext,
     gas_meter: &mut G,
 ) -> Result<(), crate::Error> {
+    if amount.is_zero() {
+        return Ok(());
+    }
     let token_module_id = ModuleId::new(FRAMEWORK_ADDRESS, TOKEN_MODULE_NAME.into());
     let admin_arg = bcs::to_bytes(&MoveValue::Signer(TOKEN_ADMIN)).expect("signer can serialize");
     let from_arg = bcs::to_bytes(from).expect("address can serialize");
@@ -192,6 +198,9 @@ pub fn transfer_eth<G: GasMeter>(
     traversal_context: &mut TraversalContext,
     gas_meter: &mut G,
 ) -> Result<(), crate::Error> {
+    if args.amount.is_zero() {
+        return Ok(());
+    }
     let token_module_id = ModuleId::new(FRAMEWORK_ADDRESS, TOKEN_MODULE_NAME.into());
     let admin_arg = bcs::to_bytes(&MoveValue::Signer(TOKEN_ADMIN)).expect("signer can serialize");
     let from_arg = bcs::to_bytes(args.from).expect("from address can serialize");


### PR DESCRIPTION
### Description
Calling ETH transfers for zero amounts is not necessary. This becomes a problem for simulation, since sometimes the `from` address is missing and causes the fungible store to fail because the default `from` address is assumed `0x0` and a fungible store for `0x0` doesn't exist.

### Changes
- Bail and return `Ok` fast if the amount is zero for moving ETH around
- Estimate gas test returns less gas since the EVM is not engaged, causing less gas usage

### Testing
✓ Existing tests pass