### PR TITLE
feat(storage): Implement transaction reading and writing using `rocksdb`

### DIFF
--- a/moved/src/transaction/write.rs
+++ b/moved/src/transaction/write.rs
@@ -3,13 +3,13 @@ use {
     op_alloy::consensus::OpTxEnvelope, std::fmt::Debug,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ExtendedTransaction {
-    pub effective_gas_price: u128,
     pub inner: OpTxEnvelope,
     pub block_number: u64,
     pub block_hash: B256,
     pub transaction_index: u64,
+    pub effective_gas_price: u128,
 }
 
 impl ExtendedTransaction {

--- a/storage/src/all.rs
+++ b/storage/src/all.rs
@@ -1,13 +1,15 @@
 use crate::{
     block::{BLOCK_COLUMN_FAMILY, HEIGHT_COLUMN_FAMILY},
+    transaction::TRANSACTION_COLUMN_FAMILY,
     trie::{ROOT_COLUMN_FAMILY, TRIE_COLUMN_FAMILY},
 };
 
-pub const COLUMN_FAMILIES: [&str; 4] = [
+pub const COLUMN_FAMILIES: [&str; 5] = [
     HEIGHT_COLUMN_FAMILY,
     TRIE_COLUMN_FAMILY,
     ROOT_COLUMN_FAMILY,
     BLOCK_COLUMN_FAMILY,
+    TRANSACTION_COLUMN_FAMILY,
 ];
 
 #[cfg(test)]

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -2,6 +2,7 @@ mod all;
 mod block;
 mod generic;
 mod state;
+mod transaction;
 mod trie;
 
 pub use {

--- a/storage/src/transaction.rs
+++ b/storage/src/transaction.rs
@@ -1,0 +1,59 @@
+use {
+    moved::{
+        transaction::{ExtendedTransaction, TransactionQueries, TransactionRepository},
+        types::state::TransactionResponse,
+    },
+    moved_shared::primitives::B256,
+    rocksdb::{AsColumnFamilyRef, WriteBatchWithTransaction, DB as RocksDb},
+};
+
+pub const TRANSACTION_COLUMN_FAMILY: &str = "transaction";
+
+#[derive(Debug)]
+pub struct RocksDbTransactionRepository;
+
+impl TransactionRepository for RocksDbTransactionRepository {
+    type Err = rocksdb::Error;
+    type Storage = RocksDb;
+
+    fn extend(
+        &mut self,
+        db: &mut Self::Storage,
+        transactions: impl IntoIterator<Item = ExtendedTransaction>,
+    ) -> Result<(), Self::Err> {
+        let cf = transaction_cf(db);
+        let mut batch = WriteBatchWithTransaction::<false>::default();
+
+        for transaction in transactions {
+            let bytes = bcs::to_bytes(&transaction).unwrap();
+            batch.put_cf(&cf, transaction.hash(), bytes);
+        }
+
+        db.write(batch)
+    }
+}
+
+#[derive(Debug)]
+pub struct RocksDbTransactionQueries;
+
+impl TransactionQueries for RocksDbTransactionQueries {
+    type Err = rocksdb::Error;
+    type Storage = RocksDb;
+
+    fn by_hash(
+        &self,
+        db: &Self::Storage,
+        hash: B256,
+    ) -> Result<Option<TransactionResponse>, Self::Err> {
+        let cf = transaction_cf(db);
+
+        Ok(db
+            .get_cf(&cf, hash)?
+            .and_then(|v| bcs::from_bytes(v.as_slice()).ok()))
+    }
+}
+
+fn transaction_cf(db: &RocksDb) -> impl AsColumnFamilyRef + use<'_> {
+    db.cf_handle(TRANSACTION_COLUMN_FAMILY)
+        .expect("Column family should exist")
+}


### PR DESCRIPTION
### Description
Adds support for transaction read and write model via `rocksdb`.

### Changes
<!-- Key changes -->
- Implements transaction read and write model using `rocksdb`
- Extends `rocksdb` with new column family for transactions

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt