### PR TITLE
feat: Add `effective_gas_price` into transactions inside block responses

### DIFF
--- a/moved/src/block/in_memory.rs
+++ b/moved/src/block/in_memory.rs
@@ -103,9 +103,11 @@ impl BlockQueries for InMemoryBlockQueries {
         include_transactions: bool,
     ) -> Result<Option<BlockResponse>, Self::Err> {
         Ok(if include_transactions {
-            mem.block_memory
-                .by_hash(hash)
-                .map(BlockResponse::from_block_with_transactions)
+            mem.block_memory.by_hash(hash).map(|block| {
+                let transactions = mem.transaction_memory.by_hashes(block.transaction_hashes());
+
+                BlockResponse::from_block_with_transactions(block, transactions)
+            })
         } else {
             mem.block_memory
                 .by_hash(hash)
@@ -120,9 +122,11 @@ impl BlockQueries for InMemoryBlockQueries {
         include_transactions: bool,
     ) -> Result<Option<BlockResponse>, Self::Err> {
         Ok(if include_transactions {
-            mem.block_memory
-                .by_height(height)
-                .map(BlockResponse::from_block_with_transactions)
+            mem.block_memory.by_height(height).map(|block| {
+                let transactions = mem.transaction_memory.by_hashes(block.transaction_hashes());
+
+                BlockResponse::from_block_with_transactions(block, transactions)
+            })
         } else {
             mem.block_memory
                 .by_height(height)

--- a/moved/src/block/root.rs
+++ b/moved/src/block/root.rs
@@ -1,5 +1,6 @@
 use {
     crate::types::state::BlockResponse,
+    alloy::eips::eip2718::Encodable2718,
     moved_shared::primitives::{B256, U256},
     op_alloy::consensus::OpTxEnvelope,
     std::fmt::Debug,
@@ -58,6 +59,10 @@ impl ExtendedBlock {
     pub fn with_value(mut self, value: U256) -> Self {
         self.value = value;
         self
+    }
+
+    pub fn transaction_hashes(&self) -> impl Iterator<Item = B256> + use<'_> {
+        self.block.transactions.iter().map(|tx| tx.trie_hash())
     }
 }
 

--- a/moved/src/transaction/in_memory.rs
+++ b/moved/src/transaction/in_memory.rs
@@ -26,6 +26,13 @@ impl TransactionMemory {
     pub fn by_hash(&self, hash: B256) -> Option<ExtendedTransaction> {
         self.transactions.get(&hash).cloned()
     }
+
+    pub fn by_hashes(&self, hashes: impl IntoIterator<Item = B256>) -> Vec<ExtendedTransaction> {
+        hashes
+            .into_iter()
+            .filter_map(|hash| self.by_hash(hash))
+            .collect()
+    }
 }
 
 #[derive(Debug, Default)]

--- a/moved/src/transaction/write.rs
+++ b/moved/src/transaction/write.rs
@@ -1,6 +1,8 @@
 use {
-    alloy::eips::eip2718::Encodable2718, moved_shared::primitives::B256,
-    op_alloy::consensus::OpTxEnvelope, std::fmt::Debug,
+    alloy::eips::eip2718::Encodable2718,
+    moved_shared::primitives::{B256, U256},
+    op_alloy::consensus::{OpTxEnvelope, TxDeposit},
+    std::fmt::Debug,
 };
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -29,6 +31,19 @@ impl ExtendedTransaction {
         }
     }
 
+    pub fn from(
+        &self,
+    ) -> Result<moved_shared::primitives::Address, alloy::primitives::SignatureError> {
+        match self.inner() {
+            OpTxEnvelope::Legacy(tx) => tx.recover_signer(),
+            OpTxEnvelope::Eip1559(tx) => tx.recover_signer(),
+            OpTxEnvelope::Eip2930(tx) => tx.recover_signer(),
+            OpTxEnvelope::Eip7702(tx) => tx.recover_signer(),
+            OpTxEnvelope::Deposit(tx) => Ok(tx.from),
+            _ => unreachable!("Tx type not supported"),
+        }
+    }
+
     pub fn inner(&self) -> &OpTxEnvelope {
         &self.inner
     }
@@ -36,6 +51,56 @@ impl ExtendedTransaction {
     pub fn hash(&self) -> B256 {
         self.inner.trie_hash()
     }
+
+    pub fn deposit_nonce(&self) -> Option<VersionedNonce> {
+        if let OpTxEnvelope::Deposit(tx) = self.inner() {
+            inner_get_deposit_nonce(tx)
+        } else {
+            None
+        }
+    }
+}
+
+/// Nonce and version for messages of `CrossDomainMessenger` L2 contract.
+pub struct VersionedNonce {
+    pub version: u64,
+    pub nonce: u64,
+}
+
+fn inner_get_deposit_nonce(tx: &TxDeposit) -> Option<VersionedNonce> {
+    use alloy::sol_types::SolType;
+
+    // Function selector for `relayMessage`.
+    // See optimism/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
+    const RELAY_MESSAGE_SELECTOR: [u8; 4] = [0xd7, 0x64, 0xad, 0x0b];
+
+    // The upper 16 bits are for the version, the rest are for the nonce.
+    const NONCE_MASK: U256 = U256::from_be_bytes(alloy::hex!(
+        "0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    ));
+
+    alloy::sol! {
+        struct RelayMessageArgs {
+            uint256 nonce;
+            address sender;
+            address target;
+            uint256 value;
+            uint256 min_gas_limit;
+            bytes message;
+        }
+    }
+
+    if !tx.input.starts_with(&RELAY_MESSAGE_SELECTOR) {
+        return None;
+    }
+
+    let args = RelayMessageArgs::abi_decode_params(&tx.input[4..], true).ok()?;
+
+    // See optimism/packages/contracts-bedrock/src/libraries/Encoding.sol
+    let encoded_versioned_nonce = args.nonce;
+    let version = encoded_versioned_nonce.checked_shr(240)?.saturating_to();
+    let nonce = (encoded_versioned_nonce & NONCE_MASK).saturating_to();
+    Some(VersionedNonce { version, nonce })
 }
 
 pub trait TransactionRepository {
@@ -47,4 +112,22 @@ pub trait TransactionRepository {
         storage: &mut Self::Storage,
         transactions: impl IntoIterator<Item = ExtendedTransaction>,
     ) -> Result<(), Self::Err>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_deposit_nonce_from_encoded_input() {
+        const INPUT: [u8; 420] = alloy::hex!("d764ad0b0001000000000000000000000000000000000000000000000000000000000002000000000000000000000000c8088d0362bb4ac757ca77e211c30503d39cef4800000000000000000000000042000000000000000000000000000000000000100000000000000000000000000000000000000000000000056bc75e2d631000000000000000000000000000000000000000000000000000000000000000030d4000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000a41635f5fd000000000000000000000000c152ff76a513e15be1be43d102a881f076e707b3000000000000000000000000c152ff76a513e15be1be43d102a881f076e707b30000000000000000000000000000000000000000000000056bc75e2d631000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+
+        let tx = TxDeposit {
+            input: INPUT.into(),
+            ..Default::default()
+        };
+        let VersionedNonce { version, nonce } = inner_get_deposit_nonce(&tx).unwrap();
+        assert_eq!(nonce, 2);
+        assert_eq!(version, 1);
+    }
 }

--- a/storage/src/transaction.rs
+++ b/storage/src/transaction.rs
@@ -53,7 +53,7 @@ impl TransactionQueries for RocksDbTransactionQueries {
     }
 }
 
-fn transaction_cf(db: &RocksDb) -> impl AsColumnFamilyRef + use<'_> {
+pub(crate) fn transaction_cf(db: &RocksDb) -> impl AsColumnFamilyRef + use<'_> {
     db.cf_handle(TRANSACTION_COLUMN_FAMILY)
         .expect("Column family should exist")
 }


### PR DESCRIPTION
### Description
Fills-in missing gas price in transactions that are a part of block responses.

The recently added transaction response contains the `effective_gas_price` so this PR unifies this code path.

It is a step closer to removing transactions from blocks altogether and only use their own dedicated storage.

### Changes
- Unify code paths for pure transaction responses and transaction responses inside blocks

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt