### PR TITLE
refactor: Change `TransactionWithReceipt` into `ExtendedReceipt`

### DIFF
--- a/moved/src/receipt/mod.rs
+++ b/moved/src/receipt/mod.rs
@@ -1,7 +1,7 @@
 pub use {
     in_memory::{InMemoryReceiptQueries, InMemoryReceiptRepository, ReceiptMemory},
     read::{ReceiptQueries, TransactionReceipt},
-    write::{ReceiptRepository, TransactionWithReceipt},
+    write::{ExtendedReceipt, ReceiptRepository},
 };
 
 mod in_memory;

--- a/moved/src/receipt/read.rs
+++ b/moved/src/receipt/read.rs
@@ -1,18 +1,14 @@
-use {crate::block::BlockQueries, moved_shared::primitives::B256, std::fmt::Debug};
+use {moved_shared::primitives::B256, std::fmt::Debug};
 
 pub trait ReceiptQueries {
     type Err: Debug;
     type Storage;
 
-    fn by_transaction_hash<B: BlockQueries>(
+    fn by_transaction_hash(
         &self,
         storage: &Self::Storage,
-        block_queries: &B,
-        block_storage: &B::Storage,
         transaction_hash: B256,
-    ) -> Result<Option<TransactionReceipt>, Self::Err>
-    where
-        Self::Err: From<B::Err>;
+    ) -> Result<Option<TransactionReceipt>, Self::Err>;
 }
 
 pub type TransactionReceipt = op_alloy::rpc_types::OpTransactionReceipt;

--- a/moved/src/receipt/write.rs
+++ b/moved/src/receipt/write.rs
@@ -1,10 +1,6 @@
 use {
-    crate::types::transactions::NormalizedExtendedTxEnvelope,
     moved_shared::primitives::{Address, B256, U256},
-    op_alloy::{
-        consensus::{OpReceiptEnvelope, OpTxEnvelope},
-        rpc_types::L1BlockInfo,
-    },
+    op_alloy::{consensus::OpReceiptEnvelope, rpc_types::L1BlockInfo},
     std::fmt::Debug,
 };
 
@@ -14,20 +10,19 @@ pub trait ReceiptRepository {
 
     fn contains(&self, storage: &Self::Storage, transaction_hash: B256) -> Result<bool, Self::Err>;
 
-    fn add(
+    fn extend(
         &self,
         storage: &mut Self::Storage,
-        receipt: TransactionWithReceipt,
-        block_hash: B256,
+        receipts: impl IntoIterator<Item = ExtendedReceipt>,
     ) -> Result<(), Self::Err>;
 }
 
-#[derive(Debug, Clone)]
-pub struct TransactionWithReceipt {
-    pub tx_hash: B256,
-    pub tx: OpTxEnvelope,
-    pub tx_index: u64,
-    pub normalized_tx: NormalizedExtendedTxEnvelope,
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ExtendedReceipt {
+    pub transaction_hash: B256,
+    pub transaction_index: u64,
+    pub to: Option<Address>,
+    pub from: Address,
     pub receipt: OpReceiptEnvelope,
     pub l1_block_info: Option<L1BlockInfo>,
     pub gas_used: u64,
@@ -46,4 +41,14 @@ pub struct TransactionWithReceipt {
     ///
     /// This allows computing the log index for each log in this transaction.
     pub logs_offset: u64,
+    pub block_hash: B256,
+    pub block_number: u64,
+    pub block_timestamp: u64,
+}
+
+impl ExtendedReceipt {
+    pub fn with_block_hash(mut self, block_hash: B256) -> Self {
+        self.block_hash = block_hash;
+        self
+    }
 }


### PR DESCRIPTION
### Description
Cuts out dependency on block to construct receipt response. Also removes transaction from receipt and instead keeps only needed information.

The result of this is that the receipts are more cleanly isolated.

This is a ground work to make receipts serializable.

### Changes
* Rename `TransactionWithReceipt` to `ExtendedReceipt`
* Remove dependency on block
* Remove transaction

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt