### PR TITLE
feat(server): Integrate dependencies that use `rocksdb` as a backing storage engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6921,7 +6921,6 @@ dependencies = [
 name = "moved-storage"
 version = "0.1.0"
 dependencies = [
- "bcs 0.1.3",
  "eth_trie",
  "hex-literal",
  "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.14.0)",
@@ -6931,6 +6930,8 @@ dependencies = [
  "moved-shared",
  "moved-state",
  "rocksdb",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2196,7 +2196,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2 1.0.92",
@@ -5445,7 +5445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6870,6 +6870,7 @@ dependencies = [
  "hex",
  "hyper 0.14.31",
  "jsonwebtoken 9.3.0",
+ "lazy_static",
  "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.14.0)",
  "move-core-types 0.0.4 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.14.0)",
  "moved",
@@ -6879,6 +6880,7 @@ dependencies = [
  "moved-genesis-image",
  "moved-shared",
  "moved-state",
+ "moved-storage",
  "once_cell",
  "openssl",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6922,6 +6922,7 @@ name = "moved-storage"
 version = "0.1.0"
 dependencies = [
  "alloy",
+ "bytes",
  "eth_trie",
  "hex-literal",
  "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.14.0)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6921,6 +6921,7 @@ dependencies = [
 name = "moved-storage"
 version = "0.1.0"
 dependencies = [
+ "alloy",
  "eth_trie",
  "hex-literal",
  "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.14.0)",
@@ -6929,6 +6930,7 @@ dependencies = [
  "moved",
  "moved-shared",
  "moved-state",
+ "op-alloy",
  "rocksdb",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ hex = "0.4"
 hex-literal = "0.4"
 hyper = "0.14"
 jsonwebtoken = { version = "9", default-features = false }
+lazy_static = "1.5"
 move-binary-format = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.14.0" }
 move-compiler = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.14.0" }
 move-core-types = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.14.0" }

--- a/api/src/methods/get_payload.rs
+++ b/api/src/methods/get_payload.rs
@@ -97,7 +97,7 @@ mod tests {
 
         let mut memory = SharedMemory::new();
         let mut repository = InMemoryBlockRepository::new();
-        repository.add(&mut memory, genesis_block);
+        repository.add(&mut memory, genesis_block).unwrap();
 
         let mut state = InMemoryState::new();
         let (changes, table_changes) = moved_genesis_image::load();

--- a/api/src/methods/mod.rs
+++ b/api/src/methods/mod.rs
@@ -78,7 +78,7 @@ pub mod tests {
 
         let mut memory = SharedMemory::new();
         let mut repository = InMemoryBlockRepository::new();
-        repository.add(&mut memory, genesis_block);
+        repository.add(&mut memory, genesis_block).unwrap();
 
         let mut state = InMemoryState::new();
         let (changes, table_changes) = moved_genesis_image::load();

--- a/api/src/methods/new_payload.rs
+++ b/api/src/methods/new_payload.rs
@@ -259,7 +259,7 @@ mod tests {
 
         let mut memory = SharedMemory::new();
         let mut repository = InMemoryBlockRepository::new();
-        repository.add(&mut memory, genesis_block);
+        repository.add(&mut memory, genesis_block).unwrap();
 
         let mut state = InMemoryState::new();
         let (changes, table_changes) = moved_genesis_image::load();

--- a/genesis-image/build.rs
+++ b/genesis-image/build.rs
@@ -1,5 +1,4 @@
 use {
-    move_binary_format::errors::PartialVMError,
     move_core_types::effects::ChangeSet,
     move_table_extension::TableChangeSet,
     moved_genesis::{
@@ -21,7 +20,7 @@ fn main() {
 pub fn save(
     vm: &impl CreateMoveVm,
     config: &GenesisConfig,
-    state: &impl State<Err = PartialVMError>,
+    state: &impl State,
 ) -> (ChangeSet, TableChangeSet) {
     let path = std::env::var("OUT_DIR").unwrap() + "/genesis.bin";
     let (changes, tables) = build(vm, config, state);

--- a/genesis/src/framework.rs
+++ b/genesis/src/framework.rs
@@ -2,7 +2,7 @@ use {
     alloy::primitives::address,
     aptos_framework::ReleaseBundle,
     aptos_table_natives::{NativeTableContext, TableChange, TableChangeSet},
-    move_binary_format::errors::{Location, PartialVMError, VMError},
+    move_binary_format::errors::{Location, VMError},
     move_core_types::{
         account_address::AccountAddress,
         effects::{ChangeSet, Op},
@@ -89,7 +89,7 @@ pub fn load_sui_framework_snapshot() -> &'static BTreeMap<ObjectID, SystemPackag
 /// Initializes the blockchain state with Aptos and Sui frameworks.
 pub fn init_state(
     vm: &impl CreateMoveVm,
-    state: &impl State<Err = PartialVMError>,
+    state: &impl State,
 ) -> (ChangeSet, move_table_extension::TableChangeSet) {
     let (change_set, table_change_set) =
         deploy_framework(vm, state).expect("All bundle modules should be valid");
@@ -131,7 +131,7 @@ pub trait CreateMoveVm {
 
 fn deploy_framework(
     vm: &impl CreateMoveVm,
-    state: &impl State<Err = PartialVMError>,
+    state: &impl State,
 ) -> Result<(ChangeSet, TableChangeSet), VMError> {
     let vm = vm.create_move_vm()?;
     let mut extensions = NativeContextExtensions::default();

--- a/genesis/src/l2_contracts.rs
+++ b/genesis/src/l2_contracts.rs
@@ -1,8 +1,5 @@
-use {
-    alloy::genesis::Genesis, move_binary_format::errors::PartialVMError,
-    move_core_types::effects::ChangeSet, moved_state::State,
-};
+use {alloy::genesis::Genesis, move_core_types::effects::ChangeSet, moved_state::State};
 
-pub fn init_state(genesis: Genesis, state: &impl State<Err = PartialVMError>) -> ChangeSet {
+pub fn init_state(genesis: Genesis, state: &impl State) -> ChangeSet {
     moved_evm_ext::genesis_state_changes(genesis, state.resolver())
 }

--- a/genesis/src/lib.rs
+++ b/genesis/src/lib.rs
@@ -8,8 +8,8 @@ pub use {
 };
 
 use {
-    self::config::GenesisConfig, move_binary_format::errors::PartialVMError,
-    move_core_types::effects::ChangeSet, move_table_extension::TableChangeSet, moved_state::State,
+    self::config::GenesisConfig, move_core_types::effects::ChangeSet,
+    move_table_extension::TableChangeSet, moved_state::State,
 };
 
 pub mod config;
@@ -21,7 +21,7 @@ mod vm;
 pub fn build(
     vm: &impl CreateMoveVm,
     config: &GenesisConfig,
-    state: &impl State<Err = PartialVMError>,
+    state: &impl State,
 ) -> (ChangeSet, TableChangeSet) {
     // Read L2 contract data
     let l2_genesis_file = std::fs::File::open(&config.l2_contract_genesis)
@@ -52,7 +52,7 @@ pub fn apply(
     changes: ChangeSet,
     table_changes: TableChangeSet,
     config: &GenesisConfig,
-    state: &mut impl State<Err = PartialVMError>,
+    state: &mut impl State,
 ) {
     state
         .apply_with_tables(changes, table_changes)
@@ -68,11 +68,7 @@ pub fn apply(
     );
 }
 
-pub fn build_and_apply(
-    vm: &impl CreateMoveVm,
-    config: &GenesisConfig,
-    state: &mut impl State<Err = PartialVMError>,
-) {
+pub fn build_and_apply(vm: &impl CreateMoveVm, config: &GenesisConfig, state: &mut impl State) {
     let (changes, table_changes) = build(vm, config, state);
     apply(changes, table_changes, config, state);
 }

--- a/moved/src/block/in_memory.rs
+++ b/moved/src/block/in_memory.rs
@@ -77,14 +77,16 @@ impl InMemoryBlockRepository {
 }
 
 impl BlockRepository for InMemoryBlockRepository {
+    type Err = Infallible;
     type Storage = SharedMemory;
 
-    fn add(&mut self, mem: &mut Self::Storage, block: ExtendedBlock) {
-        mem.block_memory.add(block)
+    fn add(&mut self, mem: &mut Self::Storage, block: ExtendedBlock) -> Result<(), Self::Err> {
+        mem.block_memory.add(block);
+        Ok(())
     }
 
-    fn by_hash(&self, mem: &Self::Storage, hash: B256) -> Option<ExtendedBlock> {
-        mem.block_memory.by_hash(hash)
+    fn by_hash(&self, mem: &Self::Storage, hash: B256) -> Result<Option<ExtendedBlock>, Self::Err> {
+        Ok(mem.block_memory.by_hash(hash))
     }
 }
 
@@ -163,12 +165,15 @@ mod test_doubles {
     }
 
     impl BlockRepository for () {
+        type Err = ();
         type Storage = ();
 
-        fn add(&mut self, _storage: &mut Self::Storage, _block: ExtendedBlock) {}
+        fn add(&mut self, _: &mut Self::Storage, _: ExtendedBlock) -> Result<(), Self::Err> {
+            Ok(())
+        }
 
-        fn by_hash(&self, _storage: &Self::Storage, _hash: B256) -> Option<ExtendedBlock> {
-            None
+        fn by_hash(&self, _: &Self::Storage, _: B256) -> Result<Option<ExtendedBlock>, Self::Err> {
+            Ok(None)
         }
     }
 }

--- a/moved/src/block/root.rs
+++ b/moved/src/block/root.rs
@@ -8,7 +8,8 @@ use {
 
 pub trait BlockQueries: Debug {
     /// The associated error type for the backing storage access operation.
-    type Err;
+    type Err: Debug;
+    /// The backing storage access handle type.
     type Storage;
 
     fn by_hash(
@@ -27,9 +28,18 @@ pub trait BlockQueries: Debug {
 }
 
 pub trait BlockRepository: Debug {
+    /// The associated error type for the backing storage access operation.
+    type Err: Debug;
+    /// The backing storage access handle type.
     type Storage;
-    fn add(&mut self, storage: &mut Self::Storage, block: ExtendedBlock);
-    fn by_hash(&self, storage: &Self::Storage, hash: B256) -> Option<ExtendedBlock>;
+
+    fn add(&mut self, storage: &mut Self::Storage, block: ExtendedBlock) -> Result<(), Self::Err>;
+
+    fn by_hash(
+        &self,
+        storage: &Self::Storage,
+        hash: B256,
+    ) -> Result<Option<ExtendedBlock>, Self::Err>;
 }
 
 pub type Header = alloy::consensus::Header;

--- a/moved/src/receipt/in_memory.rs
+++ b/moved/src/receipt/in_memory.rs
@@ -2,8 +2,7 @@ use {
     crate::receipt::{
         write::ReceiptRepository, ExtendedReceipt, ReceiptQueries, TransactionReceipt,
     },
-    alloy::rpc::types::TransactionReceipt as AlloyTxReceipt,
-    moved_shared::{primitives, primitives::B256},
+    moved_shared::primitives::B256,
     std::{collections::HashMap, convert::Infallible},
 };
 
@@ -66,49 +65,10 @@ impl ReceiptQueries for InMemoryReceiptQueries {
         storage: &Self::Storage,
         transaction_hash: B256,
     ) -> Result<Option<TransactionReceipt>, Self::Err> {
-        let Some(rx) = storage.by_transaction_hash(transaction_hash) else {
-            return Ok(None);
-        };
-        let contract_address = rx.contract_address;
-        let logs = rx
-            .receipt
-            .logs()
-            .iter()
-            .enumerate()
-            .map(|(internal_index, log)| alloy::rpc::types::Log {
-                inner: log.clone(),
-                block_hash: Some(rx.block_hash),
-                block_number: Some(rx.block_number),
-                block_timestamp: Some(rx.block_timestamp),
-                transaction_hash: Some(transaction_hash),
-                transaction_index: Some(rx.transaction_index),
-                log_index: Some(rx.logs_offset + (internal_index as u64)),
-                removed: false,
-            })
-            .collect();
-        let receipt = primitives::with_rpc_logs(&rx.receipt, logs);
-        let result = TransactionReceipt {
-            inner: AlloyTxReceipt {
-                inner: receipt,
-                transaction_hash,
-                transaction_index: Some(rx.transaction_index),
-                block_hash: Some(rx.block_hash),
-                block_number: Some(rx.block_number),
-                gas_used: rx.gas_used as u128,
-                // TODO: make all gas prices bounded by u128?
-                effective_gas_price: rx.l2_gas_price.saturating_to(),
-                // Always None because we do not support eip-4844 transactions
-                blob_gas_used: None,
-                blob_gas_price: None,
-                from: rx.from,
-                to: rx.to,
-                contract_address,
-                // EIP-7702 not yet supported
-                authorization_list: None,
-            },
-            l1_block_info: rx.l1_block_info.unwrap_or_default(),
-        };
-        Ok(Some(result))
+        Ok(storage
+            .by_transaction_hash(transaction_hash)
+            .cloned()
+            .map(TransactionReceipt::from))
     }
 }
 

--- a/moved/src/receipt/read.rs
+++ b/moved/src/receipt/read.rs
@@ -1,4 +1,9 @@
-use {moved_shared::primitives::B256, std::fmt::Debug};
+use {
+    crate::receipt::ExtendedReceipt,
+    alloy::rpc::types::TransactionReceipt as AlloyTxReceipt,
+    moved_shared::{primitives, primitives::B256},
+    std::fmt::Debug,
+};
 
 pub trait ReceiptQueries {
     type Err: Debug;
@@ -12,3 +17,48 @@ pub trait ReceiptQueries {
 }
 
 pub type TransactionReceipt = op_alloy::rpc_types::OpTransactionReceipt;
+
+impl From<ExtendedReceipt> for TransactionReceipt {
+    fn from(rx: ExtendedReceipt) -> Self {
+        let contract_address = rx.contract_address;
+        let logs = rx
+            .receipt
+            .logs()
+            .iter()
+            .enumerate()
+            .map(|(internal_index, log)| alloy::rpc::types::Log {
+                inner: log.clone(),
+                block_hash: Some(rx.block_hash),
+                block_number: Some(rx.block_number),
+                block_timestamp: Some(rx.block_timestamp),
+                transaction_hash: Some(rx.transaction_hash),
+                transaction_index: Some(rx.transaction_index),
+                log_index: Some(rx.logs_offset + (internal_index as u64)),
+                removed: false,
+            })
+            .collect();
+        let receipt = primitives::with_rpc_logs(&rx.receipt, logs);
+
+        Self {
+            inner: AlloyTxReceipt {
+                inner: receipt,
+                transaction_hash: rx.transaction_hash,
+                transaction_index: Some(rx.transaction_index),
+                block_hash: Some(rx.block_hash),
+                block_number: Some(rx.block_number),
+                gas_used: rx.gas_used as u128,
+                // TODO: make all gas prices bounded by u128?
+                effective_gas_price: rx.l2_gas_price.saturating_to(),
+                // Always None because we do not support eip-4844 transactions
+                blob_gas_used: None,
+                blob_gas_price: None,
+                from: rx.from,
+                to: rx.to,
+                contract_address,
+                // EIP-7702 not yet supported
+                authorization_list: None,
+            },
+            l1_block_info: rx.l1_block_info.unwrap_or_default(),
+        }
+    }
+}

--- a/moved/src/state_actor.rs
+++ b/moved/src/state_actor.rs
@@ -2,7 +2,7 @@ use {alloy::primitives::TxKind, op_alloy::consensus::OpTxEnvelope};
 pub use {
     payload::{NewPayloadId, NewPayloadIdInput, StatePayloadId},
     queries::{
-        Balance, BlockHeight, HistoricResolver, InMemoryStateQueries, Nonce, StateMemory,
+        Balance, BlockHeight, EthTrieResolver, InMemoryStateQueries, Nonce, StateMemory,
         StateQueries, Version,
     },
 };
@@ -41,7 +41,6 @@ use {
         rlp::{Decodable, Encodable},
         rpc::types::FeeHistory,
     },
-    move_binary_format::errors::PartialVMError,
     move_core_types::effects::ChangeSet,
     moved_evm_ext::HeaderForExecution,
     moved_genesis::config::GenesisConfig,
@@ -113,7 +112,7 @@ pub struct StateActor<S, P, H, R, G, L1G, L2G, B, Q, M, SQ, T, TQ, N, RR, RQ> {
 }
 
 impl<
-        S: State<Err = PartialVMError> + Send + Sync + 'static,
+        S: State + Send + Sync + 'static,
         P: NewPayloadId + Send + Sync + 'static,
         H: BlockHash + Send + Sync + 'static,
         R: BlockRepository<Storage = M> + Send + Sync + 'static,
@@ -144,7 +143,7 @@ impl<
 }
 
 impl<
-        S: State<Err = PartialVMError>,
+        S: State,
         P: NewPayloadId,
         H: BlockHash,
         R: BlockRepository<Storage = M>,
@@ -661,7 +660,7 @@ impl<
 }
 
 impl<
-        S: State<Err = PartialVMError>,
+        S: State,
         P: NewPayloadId,
         H: BlockHash,
         R: BlockRepository,
@@ -862,7 +861,7 @@ mod tests {
         state_queries: SQ,
     ) -> (
         StateActor<
-            impl State<Err = PartialVMError>,
+            impl State,
             impl NewPayloadId,
             impl BlockHash,
             impl BlockRepository<Storage = SharedMemory>,
@@ -924,11 +923,7 @@ mod tests {
         (state, state_channel)
     }
 
-    fn mint_eth(
-        state: &impl State<Err = PartialVMError>,
-        addr: AccountAddress,
-        amount: U256,
-    ) -> ChangeSet {
+    fn mint_eth(state: &impl State, addr: AccountAddress, amount: U256) -> ChangeSet {
         let move_vm = create_move_vm().unwrap();
         let mut session = create_vm_session(&move_vm, state.resolver(), SessionId::default());
         let traversal_storage = TraversalStorage::new();
@@ -952,7 +947,7 @@ mod tests {
         initial_balance: U256,
     ) -> (
         StateActor<
-            impl State<Err = PartialVMError>,
+            impl State,
             impl NewPayloadId,
             impl BlockHash,
             impl BlockRepository<Storage = SharedMemory>,

--- a/moved/src/state_actor.rs
+++ b/moved/src/state_actor.rs
@@ -130,8 +130,6 @@ impl<
         RR: ReceiptRepository<Storage = N> + Send + Sync + 'static,
         RQ: ReceiptQueries<Storage = N> + Send + Sync + 'static,
     > StateActor<S, P, H, R, G, L1G, L2G, B, Q, M, SQ, T, TQ, N, RR, RQ>
-where
-    RQ::Err: From<Q::Err>,
 {
     pub fn spawn(mut self) -> JoinHandle<()> {
         tokio::spawn(async move {
@@ -163,8 +161,6 @@ impl<
         RR: ReceiptRepository<Storage = N>,
         RQ: ReceiptQueries<Storage = N>,
     > StateActor<S, P, H, R, G, L1G, L2G, B, Q, M, SQ, T, TQ, N, RR, RQ>
-where
-    RQ::Err: From<Q::Err>,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -707,8 +703,6 @@ mod test_doubles {
     pub struct MockStateQueries(pub AccountAddress, pub BlockHeight);
 
     impl StateQueries for MockStateQueries {
-        type Storage = ();
-
         fn balance_at(
             &self,
             _db: Arc<impl DB>,

--- a/moved/src/state_actor.rs
+++ b/moved/src/state_actor.rs
@@ -246,14 +246,14 @@ impl<
                 response_channel,
                 include_transactions,
             } => response_channel
-                .send(self.block_queries.by_hash(&self.storage, hash, include_transactions).ok().flatten())
+                .send(self.block_queries.by_hash(&self.storage, hash, include_transactions).unwrap())
                 .ok(),
             Query::BlockByHeight {
                 height,
                 response_channel,
                 include_transactions,
             } => response_channel
-                .send(self.block_queries.by_height(&self.storage, self.resolve_height(height), include_transactions).ok().flatten())
+                .send(self.block_queries.by_height(&self.storage, self.resolve_height(height), include_transactions).unwrap())
                 .ok(),
             Query::BlockNumber {
                 response_channel,
@@ -348,7 +348,9 @@ impl<
                 let id = self.payload_id.new_payload_id(input);
                 response_channel.send(id).ok();
                 let block = self.create_block(payload_attributes);
-                self.block_repository.add(&mut self.storage, block.clone());
+                self.block_repository
+                    .add(&mut self.storage, block.clone())
+                    .unwrap();
                 let block_number = block.block.header.number;
                 let block_hash = block.hash;
                 let base_fee = block.block.header.base_fee_per_gas;
@@ -412,7 +414,7 @@ impl<
             }
             Command::GenesisUpdate { block } => {
                 self.head = block.hash;
-                self.block_repository.add(&mut self.storage, block);
+                self.block_repository.add(&mut self.storage, block).unwrap();
             }
         }
     }
@@ -441,6 +443,7 @@ impl<
         let parent = self
             .block_repository
             .by_hash(&self.storage, self.head)
+            .unwrap()
             .expect("Parent block should exist");
         let base_fee = self.gas_fee.base_fee_per_gas(
             parent.block.header.gas_limit,
@@ -888,7 +891,7 @@ mod tests {
 
         let mut memory = SharedMemory::new();
         let mut repository = InMemoryBlockRepository::new();
-        repository.add(&mut memory, genesis_block);
+        repository.add(&mut memory, genesis_block).unwrap();
 
         let mut state = InMemoryState::new();
         let (changes, tables) = moved_genesis_image::load();
@@ -979,7 +982,7 @@ mod tests {
 
         let mut memory = SharedMemory::new();
         let mut repository = InMemoryBlockRepository::new();
-        repository.add(&mut memory, genesis_block);
+        repository.add(&mut memory, genesis_block).unwrap();
 
         let mut state = InMemoryState::new();
         let (genesis_changes, table_changes) = moved_genesis_image::load();

--- a/moved/src/state_actor/queries.rs
+++ b/moved/src/state_actor/queries.rs
@@ -51,9 +51,6 @@ pub type Version = u64;
 ///   denomination at given block height.
 /// * [`Self::nonce_at`] - To fetch the nonce value set for an account at given block height.
 pub trait StateQueries {
-    /// The associated storage type for querying the blockchain state.
-    type Storage;
-
     /// Queries the blockchain state version corresponding with block `height` for the amount of
     /// base token associated with `account`.
     fn balance_at(
@@ -135,8 +132,6 @@ impl InMemoryStateQueries {
 }
 
 impl StateQueries for InMemoryStateQueries {
-    type Storage = StateMemory;
-
     fn balance_at(
         &self,
         db: Arc<impl DB>,

--- a/moved/src/transaction/write.rs
+++ b/moved/src/transaction/write.rs
@@ -5,7 +5,7 @@ use {
     std::fmt::Debug,
 };
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ExtendedTransaction {
     pub inner: OpTxEnvelope,
     pub block_number: u64,

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -4,9 +4,9 @@ description = "Moved execution HTTP server (using warp)"
 version = "0.1.0"
 edition = "2021"
 
-[[bin]]
-path = "src/main.rs"
-name = "op-move"
+[features]
+default = []
+storage = ["moved-storage"]
 
 [dependencies]
 anyhow.workspace = true
@@ -17,12 +17,16 @@ flate2.workspace = true
 hex.workspace = true
 hyper.workspace = true
 jsonwebtoken.workspace = true
+lazy_static.workspace = true
+move-binary-format.workspace = true
 move-core-types.workspace = true
 moved.workspace = true
-moved-genesis.workspace = true
 moved-api.workspace = true
+moved-genesis.workspace = true
 moved-shared.workspace = true
 moved-state.workspace = true
+moved-storage.optional = true
+moved-storage.workspace = true
 once_cell.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -38,3 +42,7 @@ move-binary-format.workspace = true
 moved-evm-ext.workspace = true
 moved-genesis-image.workspace = true
 openssl.workspace = true
+
+[[bin]]
+path = "src/main.rs"
+name = "op-move"

--- a/server/src/dependency.rs
+++ b/server/src/dependency.rs
@@ -8,6 +8,7 @@ use {
     },
     moved_genesis::config::GenesisConfig,
     moved_state::State,
+    std::sync::Arc,
 };
 
 #[cfg(feature = "storage")]
@@ -56,7 +57,14 @@ pub fn block_repository() -> impl BlockRepository<Storage = SharedStorage> + Sen
 }
 
 pub fn state() -> impl State<Err = PartialVMError> + Send + Sync + 'static {
-    moved_state::InMemoryState::new()
+    #[cfg(feature = "storage")]
+    {
+        moved_storage::RocksDbState::new(Arc::new(moved_storage::RocksEthTrieDb::new(db())))
+    }
+    #[cfg(not(feature = "storage"))]
+    {
+        moved_state::InMemoryState::new()
+    }
 }
 
 pub fn state_query(genesis_config: &GenesisConfig) -> StateQueries {

--- a/server/src/dependency.rs
+++ b/server/src/dependency.rs
@@ -8,7 +8,6 @@ use {
     },
     moved_genesis::config::GenesisConfig,
     moved_state::State,
-    std::sync::Arc,
 };
 
 #[cfg(feature = "storage")]
@@ -59,7 +58,9 @@ pub fn block_repository() -> impl BlockRepository<Storage = SharedStorage> + Sen
 pub fn state() -> impl State<Err = PartialVMError> + Send + Sync + 'static {
     #[cfg(feature = "storage")]
     {
-        moved_storage::RocksDbState::new(Arc::new(moved_storage::RocksEthTrieDb::new(db())))
+        moved_storage::RocksDbState::new(std::sync::Arc::new(moved_storage::RocksEthTrieDb::new(
+            db(),
+        )))
     }
     #[cfg(not(feature = "storage"))]
     {

--- a/server/src/dependency.rs
+++ b/server/src/dependency.rs
@@ -1,0 +1,169 @@
+use {
+    move_binary_format::errors::PartialVMError,
+    moved::{
+        block::{BlockHash, BlockQueries, BlockRepository, MovedBlockHash},
+        move_execution::{BaseTokenAccounts, MovedBaseTokenAccounts},
+        receipt::{ReceiptQueries, ReceiptRepository},
+        transaction::{TransactionQueries, TransactionRepository},
+    },
+    moved_genesis::config::GenesisConfig,
+    moved_state::State,
+};
+
+#[cfg(feature = "storage")]
+pub type SharedStorage = &'static moved_storage::RocksDb;
+#[cfg(not(feature = "storage"))]
+pub type SharedStorage = moved::in_memory::SharedMemory;
+#[cfg(feature = "storage")]
+pub type ReceiptStorage = &'static moved_storage::RocksDb;
+#[cfg(not(feature = "storage"))]
+pub type ReceiptStorage = moved::receipt::ReceiptMemory;
+#[cfg(feature = "storage")]
+pub type StateQueries = moved::state_actor::InMemoryStateQueries;
+#[cfg(not(feature = "storage"))]
+pub type StateQueries = moved::state_actor::InMemoryStateQueries;
+
+pub fn block_hash() -> impl BlockHash + Send + Sync + 'static {
+    MovedBlockHash
+}
+
+pub fn base_token(
+    genesis_config: &GenesisConfig,
+) -> impl BaseTokenAccounts + Send + Sync + 'static {
+    MovedBaseTokenAccounts::new(genesis_config.treasury)
+}
+
+pub fn memory() -> SharedStorage {
+    #[cfg(feature = "storage")]
+    {
+        db()
+    }
+    #[cfg(not(feature = "storage"))]
+    {
+        moved::in_memory::SharedMemory::new()
+    }
+}
+
+pub fn block_repository() -> impl BlockRepository<Storage = SharedStorage> + Send + Sync + 'static {
+    #[cfg(feature = "storage")]
+    {
+        moved_storage::block::RocksDbBlockRepository
+    }
+    #[cfg(not(feature = "storage"))]
+    {
+        moved::block::InMemoryBlockRepository::new()
+    }
+}
+
+pub fn state() -> impl State<Err = PartialVMError> + Send + Sync + 'static {
+    moved_state::InMemoryState::new()
+}
+
+pub fn state_query(genesis_config: &GenesisConfig) -> StateQueries {
+    #[cfg(feature = "storage")]
+    {
+        moved::state_actor::InMemoryStateQueries::from_genesis(genesis_config.initial_state_root)
+    }
+    #[cfg(not(feature = "storage"))]
+    {
+        moved::state_actor::InMemoryStateQueries::from_genesis(genesis_config.initial_state_root)
+    }
+}
+
+pub fn transaction_repository(
+) -> impl TransactionRepository<Storage = SharedStorage> + Send + Sync + 'static {
+    #[cfg(feature = "storage")]
+    {
+        moved_storage::transaction::RocksDbTransactionRepository
+    }
+    #[cfg(not(feature = "storage"))]
+    {
+        moved::transaction::InMemoryTransactionRepository::new()
+    }
+}
+
+pub fn transaction_queries(
+) -> impl TransactionQueries<Storage = SharedStorage> + Send + Sync + 'static {
+    #[cfg(feature = "storage")]
+    {
+        moved_storage::transaction::RocksDbTransactionQueries
+    }
+    #[cfg(not(feature = "storage"))]
+    {
+        moved::transaction::InMemoryTransactionQueries::new()
+    }
+}
+
+pub fn receipt_repository(
+) -> impl ReceiptRepository<Storage = ReceiptStorage> + Send + Sync + 'static {
+    #[cfg(feature = "storage")]
+    {
+        moved_storage::receipt::RocksDbReceiptRepository
+    }
+    #[cfg(not(feature = "storage"))]
+    {
+        moved::receipt::InMemoryReceiptRepository::new()
+    }
+}
+
+pub fn receipt_queries() -> impl ReceiptQueries<Storage = ReceiptStorage> + Send + Sync + 'static {
+    #[cfg(feature = "storage")]
+    {
+        moved_storage::receipt::RocksDbReceiptQueries
+    }
+    #[cfg(not(feature = "storage"))]
+    {
+        moved::receipt::InMemoryReceiptQueries::new()
+    }
+}
+
+pub fn receipt_memory() -> ReceiptStorage {
+    #[cfg(feature = "storage")]
+    {
+        db()
+    }
+    #[cfg(not(feature = "storage"))]
+    {
+        moved::receipt::ReceiptMemory::new()
+    }
+}
+
+pub fn block_queries() -> impl BlockQueries<Storage = SharedStorage> + Send + Sync + 'static {
+    #[cfg(feature = "storage")]
+    {
+        moved_storage::block::RocksDbBlockQueries
+    }
+    #[cfg(not(feature = "storage"))]
+    {
+        moved::block::InMemoryBlockQueries
+    }
+}
+
+#[cfg(feature = "storage")]
+lazy_static::lazy_static! {
+    static ref Database: moved_storage::RocksDb = {
+        create_db()
+    };
+}
+
+#[cfg(feature = "storage")]
+fn db() -> &'static moved_storage::RocksDb {
+    &Database
+}
+
+#[cfg(feature = "storage")]
+fn create_db() -> moved_storage::RocksDb {
+    let path = "db";
+
+    if std::fs::exists(path).unwrap() {
+        std::fs::remove_dir_all(path)
+            .expect("Removing non-empty database directory should succeed");
+    }
+
+    let mut options = moved_storage::rocksdb::Options::default();
+    options.create_if_missing(true);
+    options.create_missing_column_families(true);
+
+    moved_storage::RocksDb::open_cf(&options, path, moved_storage::COLUMN_FAMILIES)
+        .expect("Database should open in db dir")
+}

--- a/server/src/dependency.rs
+++ b/server/src/dependency.rs
@@ -1,5 +1,4 @@
 use {
-    move_binary_format::errors::PartialVMError,
     moved::{
         block::{BlockHash, BlockQueries, BlockRepository, MovedBlockHash},
         move_execution::{BaseTokenAccounts, MovedBaseTokenAccounts},
@@ -55,7 +54,7 @@ pub fn block_repository() -> impl BlockRepository<Storage = SharedStorage> + Sen
     }
 }
 
-pub fn state() -> impl State<Err = PartialVMError> + Send + Sync + 'static {
+pub fn state() -> impl State + Send + Sync + 'static {
     #[cfg(feature = "storage")]
     {
         moved_storage::RocksDbState::new(std::sync::Arc::new(moved_storage::RocksEthTrieDb::new(

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -3,7 +3,6 @@ use {
     clap::Parser,
     flate2::read::GzDecoder,
     jsonwebtoken::{DecodingKey, Validation},
-    move_binary_format::errors::PartialVMError,
     moved::{
         block::{
             BaseGasFee, Block, BlockHash, BlockQueries, BlockRepository, Eip1559GasFee,
@@ -133,7 +132,7 @@ pub fn initialize_state_actor(
     genesis_config: GenesisConfig,
     rx: mpsc::Receiver<StateMessage>,
 ) -> StateActor<
-    impl State<Err = PartialVMError> + Send + Sync + 'static,
+    impl State + Send + Sync + 'static,
     impl NewPayloadId + Send + Sync + 'static,
     impl BlockHash + Send + Sync + 'static,
     impl BlockRepository<Storage = dependency::SharedStorage> + Send + Sync + 'static,

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -177,7 +177,9 @@ pub fn initialize_state_actor(
 
     let genesis_block = create_genesis_block(&block_hash, &genesis_config);
     let head = genesis_block.hash;
-    block_repository.add(&mut storage, genesis_block);
+    block_repository
+        .add(&mut storage, genesis_block)
+        .expect("Database should be ready");
 
     StateActor::new(
         rx,

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -54,7 +54,7 @@ pub trait State {
 
     /// Returns a reference to a [`MoveResolver`] that can resolve both resources and modules on
     /// the current blockchain state.
-    fn resolver(&self) -> &(impl MoveResolver<Self::Err> + TableResolver);
+    fn resolver(&self) -> &(impl MoveResolver<PartialVMError> + TableResolver);
 
     /// Retrieves the value of the root node of the merkle trie that holds the blockchain state.
     fn state_root(&self) -> B256;

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+bytes.workspace = true
 eth_trie.workspace = true
 move-binary-format.workspace = true
 move-core-types.workspace = true

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -17,4 +17,6 @@ serde.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]
+alloy.workspace = true
 hex-literal.workspace = true
+op-alloy.workspace = true

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -5,7 +5,6 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-bcs.workspace = true
 eth_trie.workspace = true
 move-binary-format.workspace = true
 move-core-types.workspace = true
@@ -14,6 +13,8 @@ moved.workspace = true
 moved-shared.workspace = true
 moved-state.workspace = true
 rocksdb.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 hex-literal.workspace = true

--- a/storage/src/block.rs
+++ b/storage/src/block.rs
@@ -15,7 +15,7 @@ pub const HEIGHT_COLUMN_FAMILY: &str = "height";
 pub struct RocksDbBlockRepository;
 
 impl BlockRepository for RocksDbBlockRepository {
-    type Storage = RocksDb;
+    type Storage = &'static RocksDb;
 
     fn add(&mut self, db: &mut Self::Storage, block: ExtendedBlock) {
         let cf = block_cf(db);
@@ -38,7 +38,7 @@ pub struct RocksDbBlockQueries;
 
 impl BlockQueries for RocksDbBlockQueries {
     type Err = rocksdb::Error;
-    type Storage = RocksDb;
+    type Storage = &'static RocksDb;
 
     fn by_hash(
         &self,

--- a/storage/src/block.rs
+++ b/storage/src/block.rs
@@ -87,7 +87,7 @@ impl BlockQueries for RocksDbBlockQueries {
         include_transactions: bool,
     ) -> Result<Option<BlockResponse>, Self::Err> {
         db.get_pinned_cf(&height_cf(db), height.to_key())?
-            .map(|hash| B256::from_slice(hash.as_ref()))
+            .map(|hash| B256::new(hash.as_ref().try_into().unwrap()))
             .map(|hash| self.by_hash(db, hash, include_transactions))
             .unwrap_or(Ok(None))
     }

--- a/storage/src/generic.rs
+++ b/storage/src/generic.rs
@@ -40,6 +40,7 @@ impl<T: serde::Serialize> ToValue for T {
 
 impl<'de, T: serde::Deserialize<'de>> FromValue<'de> for T {
     fn from_value(slice: &'de [u8]) -> Self {
-        serde_json::from_slice(slice).unwrap()
+        serde_json::from_slice(slice)
+            .unwrap_or_else(|e| panic!("{e}: {}", String::from_utf8_lossy(slice)))
     }
 }

--- a/storage/src/generic.rs
+++ b/storage/src/generic.rs
@@ -7,6 +7,14 @@ pub trait ToKey {
     fn to_key(&self) -> impl AsRef<[u8]>;
 }
 
+pub trait ToValue {
+    fn to_value(&self) -> Vec<u8>;
+}
+
+pub trait FromValue<'de> {
+    fn from_value(slice: &'de [u8]) -> Self;
+}
+
 /// Implements the [`ToKey`] trait for an integer type.
 macro_rules! int_impl {
     ($int:tt,$($types:tt)*) => {
@@ -23,3 +31,15 @@ macro_rules! int_impl {
 }
 
 int_impl!(u64);
+
+impl<T: serde::Serialize> ToValue for T {
+    fn to_value(&self) -> Vec<u8> {
+        serde_json::to_vec(self).unwrap()
+    }
+}
+
+impl<'de, T: serde::Deserialize<'de>> FromValue<'de> for T {
+    fn from_value(slice: &'de [u8]) -> Self {
+        serde_json::from_slice(slice).unwrap()
+    }
+}

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,14 +1,15 @@
 mod all;
-mod block;
-mod generic;
-mod receipt;
-mod state;
-mod transaction;
-mod trie;
+pub mod block;
+pub mod generic;
+pub mod receipt;
+pub mod state;
+pub mod transaction;
+pub mod trie;
 
 pub use {
     all::COLUMN_FAMILIES,
     block::RocksDbBlockRepository,
+    rocksdb::{self, DB as RocksDb},
     state::RocksDbState,
     trie::{RocksEthTrieDb, ROOT_KEY},
 };

--- a/storage/src/receipt.rs
+++ b/storage/src/receipt.rs
@@ -11,7 +11,7 @@ pub struct RocksDbReceiptRepository;
 
 impl ReceiptRepository for RocksDbReceiptRepository {
     type Err = rocksdb::Error;
-    type Storage = RocksDb;
+    type Storage = &'static RocksDb;
 
     fn contains(&self, db: &Self::Storage, transaction_hash: B256) -> Result<bool, Self::Err> {
         let cf = cf(db);
@@ -41,7 +41,7 @@ pub struct RocksDbReceiptQueries;
 
 impl ReceiptQueries for RocksDbReceiptQueries {
     type Err = rocksdb::Error;
-    type Storage = RocksDb;
+    type Storage = &'static RocksDb;
 
     fn by_transaction_hash(
         &self,

--- a/storage/src/state.rs
+++ b/storage/src/state.rs
@@ -1,10 +1,10 @@
 use {
-    crate::RocksEthTrieDb,
-    eth_trie::{EthTrie, DB},
+    crate::{trie::FromOptRoot, RocksEthTrieDb},
+    eth_trie::{EthTrie, TrieError, DB},
     move_binary_format::errors::PartialVMError,
     move_core_types::{effects::ChangeSet, resolver::MoveResolver},
     move_table_extension::{TableChangeSet, TableResolver},
-    moved::state_actor::HistoricResolver,
+    moved::state_actor::EthTrieResolver,
     moved_shared::primitives::B256,
     moved_state::{InsertChangeSetIntoMerkleTrie, State},
     std::sync::Arc,
@@ -13,47 +13,42 @@ use {
 /// A blockchain state implementation backed by [`rocksdb`] as its persistent storage engine.
 pub struct RocksDbState<'db> {
     db: Arc<RocksEthTrieDb<'db>>,
-    resolver: HistoricResolver<RocksEthTrieDb<'db>>,
-    state_root: B256,
+    resolver: EthTrieResolver<RocksEthTrieDb<'db>>,
+    state_root: Option<B256>,
 }
 
 impl<'db> RocksDbState<'db> {
     pub fn new(db: Arc<RocksEthTrieDb<'db>>) -> Self {
         let state_root = db
             .root()
-            .expect("Database should be able to fetch state root")
-            .unwrap_or(B256::ZERO);
+            .expect("Database should be able to fetch state root");
 
         Self {
-            resolver: HistoricResolver::new(db.clone(), state_root),
+            resolver: EthTrieResolver::new(EthTrie::from_opt_root(db.clone(), state_root)),
             state_root,
             db,
         }
     }
 
     fn persist_state_root(&self) -> Result<(), rocksdb::Error> {
-        self.db.put_root(self.state_root)
+        self.state_root
+            .map(|root| self.db.put_root(root))
+            .unwrap_or(Ok(()))
     }
 
     fn tree(&self) -> EthTrie<RocksEthTrieDb<'db>> {
-        let db = self.db.clone();
-
-        match self.state_root {
-            B256::ZERO => EthTrie::new(db),
-            root => EthTrie::from(db, root).unwrap(),
-        }
+        EthTrie::from_opt_root(self.db.clone(), self.state_root)
     }
 }
 
 impl<'db> State for RocksDbState<'db> {
-    type Err = PartialVMError;
+    type Err = TrieError;
 
     fn apply(&mut self, changes: ChangeSet) -> Result<(), Self::Err> {
-        self.state_root = self
-            .tree()
-            .insert_change_set_into_merkle_trie(&changes)
-            .unwrap();
-        self.resolver = HistoricResolver::new(self.db.clone(), self.state_root);
+        let mut tree = self.tree();
+        let root = tree.insert_change_set_into_merkle_trie(&changes)?;
+        self.state_root.replace(root);
+        self.resolver = EthTrieResolver::new(tree);
         self.persist_state_root().unwrap();
         Ok(())
     }
@@ -63,24 +58,18 @@ impl<'db> State for RocksDbState<'db> {
         changes: ChangeSet,
         _table_changes: TableChangeSet,
     ) -> Result<(), Self::Err> {
-        self.state_root = self
-            .tree()
-            .insert_change_set_into_merkle_trie(&changes)
-            .unwrap();
-        self.resolver = HistoricResolver::new(self.db.clone(), self.state_root);
-        self.persist_state_root().unwrap();
-        Ok(())
+        self.apply(changes)
     }
 
     fn db(&self) -> Arc<impl DB> {
         self.db.clone()
     }
 
-    fn resolver(&self) -> &(impl MoveResolver<Self::Err> + TableResolver) {
+    fn resolver(&self) -> &(impl MoveResolver<PartialVMError> + TableResolver) {
         &self.resolver
     }
 
     fn state_root(&self) -> B256 {
-        self.state_root
+        self.state_root.unwrap_or_default()
     }
 }

--- a/storage/src/transaction.rs
+++ b/storage/src/transaction.rs
@@ -1,4 +1,5 @@
 use {
+    crate::generic::{FromValue, ToValue},
     moved::transaction::{
         ExtendedTransaction, TransactionQueries, TransactionRepository, TransactionResponse,
     },
@@ -24,7 +25,7 @@ impl TransactionRepository for RocksDbTransactionRepository {
         let mut batch = WriteBatchWithTransaction::<false>::default();
 
         for transaction in transactions {
-            let bytes = bcs::to_bytes(&transaction).unwrap();
+            let bytes = transaction.to_value();
             batch.put_cf(&cf, transaction.hash(), bytes);
         }
 
@@ -47,8 +48,8 @@ impl TransactionQueries for RocksDbTransactionQueries {
         let cf = cf(db);
 
         Ok(db
-            .get_cf(&cf, hash)?
-            .and_then(|v| bcs::from_bytes(v.as_slice()).ok()))
+            .get_pinned_cf(&cf, hash)?
+            .and_then(|v| FromValue::from_value(v.as_ref())))
     }
 }
 

--- a/storage/src/transaction.rs
+++ b/storage/src/transaction.rs
@@ -57,3 +57,88 @@ pub(crate) fn cf(db: &RocksDb) -> impl AsColumnFamilyRef + use<'_> {
     db.cf_handle(COLUMN_FAMILY)
         .expect("Column family should exist")
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        alloy::{
+            consensus::{SignableTransaction, TxEip1559},
+            primitives::{address, Sealable, TxKind},
+            signers::local::PrivateKeySigner,
+        },
+        hex_literal::hex,
+        moved_shared::primitives::U256,
+        op_alloy::{
+            consensus::{OpTxEnvelope, TxDeposit},
+            network::TxSignerSync,
+        },
+    };
+
+    pub const PRIVATE_KEY: [u8; 32] = [0xaa; 32];
+
+    #[test]
+    fn test_transaction_deserializes_from_serialized_bytes() {
+        let signer = PrivateKeySigner::from_bytes(&PRIVATE_KEY.into()).unwrap();
+        let mut tx = TxEip1559 {
+            chain_id: 404,
+            nonce: 1,
+            gas_limit: u64::MAX,
+            max_fee_per_gas: 2,
+            max_priority_fee_per_gas: 3,
+            to: TxKind::Call(address!("ddddddddddadddddddddddd00000000022222222")),
+            value: U256::from(23u64),
+            access_list: Default::default(),
+            input: vec![9, 9, 9].into(),
+        };
+        let signature = signer.sign_transaction_sync(&mut tx).unwrap();
+        let signed_tx = OpTxEnvelope::Eip1559(tx.into_signed(signature));
+
+        let transaction = ExtendedTransaction {
+            inner: signed_tx,
+            block_number: 1,
+            block_hash: B256::new(hex!(
+                "2222223123123121231231231231232222222231231231212312312312312322"
+            )),
+            transaction_index: 1,
+            effective_gas_price: 1,
+        };
+
+        let serialized = transaction.to_value();
+        let expected_transaction = transaction;
+        let actual_transaction = ExtendedTransaction::from_value(serialized.as_slice());
+
+        assert_eq!(actual_transaction, expected_transaction);
+    }
+
+    #[test]
+    fn test_deposit_transaction_deserializes_from_serialized_bytes() {
+        let tx = TxDeposit {
+            source_hash: Default::default(),
+            gas_limit: u64::MAX,
+            to: TxKind::Call(address!("ddddddddddadddddddddddd00000000022222222")),
+            mint: None,
+            value: U256::from(23u64),
+            input: vec![9, 9, 9].into(),
+            from: Default::default(),
+            is_system_transaction: false,
+        };
+        let sealed_tx = OpTxEnvelope::Deposit(tx.seal_slow());
+
+        let transaction = ExtendedTransaction {
+            inner: sealed_tx,
+            block_number: 1,
+            block_hash: B256::new(hex!(
+                "2222223123123121231231231231232222222231231231212312312312312322"
+            )),
+            transaction_index: 1,
+            effective_gas_price: 1,
+        };
+
+        let serialized = transaction.to_value();
+        let expected_transaction = transaction;
+        let actual_transaction = ExtendedTransaction::from_value(serialized.as_slice());
+
+        assert_eq!(actual_transaction, expected_transaction);
+    }
+}

--- a/storage/src/transaction.rs
+++ b/storage/src/transaction.rs
@@ -13,7 +13,7 @@ pub struct RocksDbTransactionRepository;
 
 impl TransactionRepository for RocksDbTransactionRepository {
     type Err = rocksdb::Error;
-    type Storage = RocksDb;
+    type Storage = &'static RocksDb;
 
     fn extend(
         &mut self,
@@ -37,7 +37,7 @@ pub struct RocksDbTransactionQueries;
 
 impl TransactionQueries for RocksDbTransactionQueries {
     type Err = rocksdb::Error;
-    type Storage = RocksDb;
+    type Storage = &'static RocksDb;
 
     fn by_hash(
         &self,

--- a/storage/src/trie.rs
+++ b/storage/src/trie.rs
@@ -53,8 +53,9 @@ impl<'db> DB for RocksEthTrieDb<'db> {
         self.db.put_cf(self.cf(), key, value)
     }
 
-    fn remove(&self, key: &[u8]) -> Result<(), Self::Error> {
-        self.db.delete_cf(self.cf(), key)
+    fn remove(&self, _key: &[u8]) -> Result<(), Self::Error> {
+        // Intentionally ignored to not remove historical trie nodes
+        Ok(())
     }
 
     fn flush(&self) -> Result<(), Self::Error> {


### PR DESCRIPTION
Closes #216 

### Description
Includes all the newly created dependencies implemented using `rocksdb`.

Allows switching between in-memory and rocksdb configuration using `storage` feature flag

### Changes
- Integrate dependencies that use `rocksdb` as a backing storage engine
- Allow switching between in-memory and rocksdb configuration using `storage` feature flag

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt

### Notes

You may now launch the node
* Using in-memory:
```
cargo run --bin op-move
```
* Using rocksdb:
```
cargo run ---bin op-move --features storage
```
