### PR TITLE
refactor(api): Remove V2 engine methods and schema

### DIFF
--- a/api/src/method_name.rs
+++ b/api/src/method_name.rs
@@ -2,9 +2,6 @@ use {crate::jsonrpc::JsonRpcError, std::str::FromStr};
 
 #[derive(Debug)]
 pub enum MethodName {
-    ForkChoiceUpdatedV2,
-    GetPayloadV2,
-    NewPayloadV2,
     ForkChoiceUpdatedV3,
     GetPayloadV3,
     NewPayloadV3,
@@ -28,11 +25,8 @@ impl FromStr for MethodName {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
-            "engine_forkchoiceUpdatedV2" => Self::ForkChoiceUpdatedV2,
             "engine_forkchoiceUpdatedV3" => Self::ForkChoiceUpdatedV3,
-            "engine_getPayloadV2" => Self::GetPayloadV2,
             "engine_getPayloadV3" => Self::GetPayloadV3,
-            "engine_newPayloadV2" => Self::NewPayloadV2,
             "engine_newPayloadV3" => Self::NewPayloadV3,
             "eth_chainId" => Self::ChainId,
             "eth_getBalance" => Self::GetBalance,

--- a/api/src/request.rs
+++ b/api/src/request.rs
@@ -59,8 +59,5 @@ async fn inner_handle_request(
         Call => call::execute(request, state_channel).await,
         TransactionReceipt => get_transaction_receipt::execute(request, state_channel).await,
         GetProof => get_proof::execute(request, state_channel).await,
-        ForkChoiceUpdatedV2 => todo!(),
-        GetPayloadV2 => todo!(),
-        NewPayloadV2 => todo!(),
     }
 }

--- a/api/src/schema/engine.rs
+++ b/api/src/schema/engine.rs
@@ -10,50 +10,11 @@ use {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
-pub struct ExecutionPayloadV1 {
-    pub parent_hash: B256,
-    pub fee_recipient: Address,
-    pub state_root: B256,
-    pub receipts_root: B256,
-    pub logs_bloom: Bytes,
-    pub prev_randao: B256,
-    pub block_number: U64,
-    pub gas_limit: U64,
-    pub gas_used: U64,
-    pub timestamp: U64,
-    pub extra_data: Bytes,
-    pub base_fee_per_gas: U256,
-    pub block_hash: B256,
-    pub transactions: Vec<Bytes>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
 pub struct WithdrawalV1 {
     pub index: U64,
     pub validator_index: U64,
     pub address: Address,
     pub amount: U64,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct ExecutionPayloadV2 {
-    pub parent_hash: B256,
-    pub fee_recipient: Address,
-    pub state_root: B256,
-    pub receipts_root: B256,
-    pub logs_bloom: Bytes,
-    pub prev_randao: B256,
-    pub block_number: U64,
-    pub gas_limit: U64,
-    pub gas_used: U64,
-    pub timestamp: U64,
-    pub extra_data: Bytes,
-    pub base_fee_per_gas: U256,
-    pub block_hash: B256,
-    pub transactions: Vec<Bytes>,
-    pub withdrawals: Vec<WithdrawalV1>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -84,23 +45,6 @@ pub struct ForkchoiceStateV1 {
     pub head_block_hash: B256,
     pub safe_block_hash: B256,
     pub finalized_block_hash: B256,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct PayloadAttributesV1 {
-    pub timestamp: U64,
-    pub prev_randao: B256,
-    pub suggested_fee_recipient: Address,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct PayloadAttributesV2 {
-    pub timestamp: U64,
-    pub prev_randao: B256,
-    pub suggested_fee_recipient: Address,
-    pub withdrawals: Vec<WithdrawalV1>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]


### PR DESCRIPTION
Closes #48 

### Description
Removes V2 engine methods and schema.

These were never implemented and not needed to be.

### Changes
- Removes V2 engine method names
- Removes V2 engine schema structs

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt