### PR TITLE
feat(api): Protect engine API access only to the authenticated port `8551`

### DIFF
--- a/api/src/method_name.rs
+++ b/api/src/method_name.rs
@@ -20,6 +20,19 @@ pub enum MethodName {
     GetProof,
 }
 
+impl MethodName {
+    pub fn is_non_engine_api(&self) -> bool {
+        !self.is_engine_api()
+    }
+
+    pub fn is_engine_api(&self) -> bool {
+        matches!(
+            self,
+            Self::ForkChoiceUpdatedV3 | Self::GetPayloadV3 | Self::NewPayloadV3
+        )
+    }
+}
+
 impl FromStr for MethodName {
     type Err = JsonRpcError;
 

--- a/server/src/tests/get_proof.rs
+++ b/server/src/tests/get_proof.rs
@@ -155,7 +155,8 @@ async fn handle_request<T: DeserializeOwned>(
     request: serde_json::Value,
     state_channel: &mpsc::Sender<StateMessage>,
 ) -> anyhow::Result<T> {
-    let response = moved_api::request::handle(request.clone(), state_channel.clone()).await;
+    let response =
+        moved_api::request::handle(request.clone(), state_channel.clone(), |_| true).await;
 
     if let Some(error) = response.error {
         anyhow::bail!("Error response from request {request:?}: {error:?}");


### PR DESCRIPTION
Closes #43 

### Description
The `enigne_` APIs should be callable only on the secure port `8551` with the JWT token.

### Changes
- Restrict access to the engine API only to the auhenticated endpoint
- Keep public endpoints open to all other endpoints.

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt