### PR TITLE
Fix: Provide API responses for Viem SDK

### DIFF
--- a/api/src/method_name.rs
+++ b/api/src/method_name.rs
@@ -18,6 +18,7 @@ pub enum MethodName {
     Call,
     TransactionReceipt,
     GetProof,
+    GasPrice,
 }
 
 impl MethodName {
@@ -54,6 +55,7 @@ impl FromStr for MethodName {
             "eth_call" => Self::Call,
             "eth_getTransactionReceipt" => Self::TransactionReceipt,
             "eth_getProof" => Self::GetProof,
+            "eth_gasPrice" => Self::GasPrice,
             other => {
                 return Err(JsonRpcError::without_data(
                     -32601,

--- a/api/src/methods/gas_price.rs
+++ b/api/src/methods/gas_price.rs
@@ -1,0 +1,18 @@
+use crate::jsonrpc::JsonRpcError;
+
+pub async fn execute() -> Result<serde_json::Value, JsonRpcError> {
+    Ok(serde_json::to_value("0x3b9aca00").expect("Must be able to JSON-serialize response"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_execute() {
+        // TODO: Return the actual gas price, currently hardcoded to 1,000,000,000
+        let expected_response: serde_json::Value = serde_json::from_str(r#""0x3b9aca00""#).unwrap();
+        let response = execute().await.unwrap();
+        assert_eq!(response, expected_response);
+    }
+}

--- a/api/src/methods/mod.rs
+++ b/api/src/methods/mod.rs
@@ -4,6 +4,7 @@ pub mod chain_id;
 pub mod estimate_gas;
 pub mod fee_history;
 pub mod forkchoice_updated;
+pub mod gas_price;
 pub mod get_balance;
 pub mod get_block_by_hash;
 pub mod get_block_by_number;

--- a/api/src/request.rs
+++ b/api/src/request.rs
@@ -65,5 +65,6 @@ async fn inner_handle_request(
         Call => call::execute(request, state_channel).await,
         TransactionReceipt => get_transaction_receipt::execute(request, state_channel).await,
         GetProof => get_proof::execute(request, state_channel).await,
+        GasPrice => gas_price::execute().await,
     }
 }


### PR DESCRIPTION
### Description
Viem SDK is the official client for Optimism. In order to make deposits and withdrawals estimate gas and gas price APIs should work as expected.

### Changes
- Return min 21,000 for gas estimate
- Respond to gas price API

### Testing
✓ Viem SDK examples for [deposit](https://viem.sh/op-stack/guides/deposits) and [withdrawal](https://viem.sh/op-stack/guides/withdrawals) work now.
✓ Unit tests and other checks pass.