### PR TITLE
test(server): Turn on non-interactive flag in `forge`

### DIFF
--- a/server/src/tests/integration.rs
+++ b/server/src/tests/integration.rs
@@ -188,6 +188,7 @@ fn deploy_l1_contracts() {
             &var("L1_RPC_URL").expect("Missing Ethereum L1 RPC URL"),
             "--slow",
             "--legacy",
+            "--non-interactive",
         ])
         .spawn()
         .unwrap();


### PR DESCRIPTION
### Description
Avoids holding for user input when asking to add transactions with no code

### Changes
- Add `--non-interactive` flag into `forge` deploy L1 contracts stage of the integration test

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt
