### PR TITLE
feat(storage): Implement `StateQueries` using `rocksdb`

### DIFF
--- a/server/src/dependency.rs
+++ b/server/src/dependency.rs
@@ -136,8 +136,8 @@ pub fn on_tx_batch<
         Box::new(|| {
             Box::new(|state| {
                 state
-                    .state_queries
-                    .push_state_root(state.state.state_root())
+                    .state_queries()
+                    .push_state_root(state.state().state_root())
                     .unwrap()
             })
         })

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -204,8 +204,8 @@ pub fn initialize_state_actor(
         receipt_storage,
         receipt_repository,
         receipt_queries,
-        moved::state_actor::StateActor::on_tx_in_memory(),
-        moved::state_actor::StateActor::on_tx_batch_in_memory(),
+        dependency::on_tx(),
+        dependency::on_tx_batch(),
     )
 }
 

--- a/storage/src/all.rs
+++ b/storage/src/all.rs
@@ -1,8 +1,10 @@
-use crate::{block, receipt, transaction, trie};
+use crate::{block, receipt, state, transaction, trie};
 
-pub const COLUMN_FAMILIES: [&str; 6] = [
+pub const COLUMN_FAMILIES: [&str; 8] = [
     block::BLOCK_COLUMN_FAMILY,
     block::HEIGHT_COLUMN_FAMILY,
+    state::COLUMN_FAMILY,
+    state::HEIGHT_COLUMN_FAMILY,
     trie::TRIE_COLUMN_FAMILY,
     trie::ROOT_COLUMN_FAMILY,
     transaction::COLUMN_FAMILY,

--- a/storage/src/generic.rs
+++ b/storage/src/generic.rs
@@ -7,6 +7,10 @@ pub trait ToKey {
     fn to_key(&self) -> impl AsRef<[u8]>;
 }
 
+pub trait FromKey<'de> {
+    fn from_key(slice: &'de [u8]) -> Self;
+}
+
 pub trait ToValue {
     fn to_value(&self) -> Vec<u8>;
 }
@@ -25,6 +29,11 @@ macro_rules! int_impl {
         impl ToKey for $int {
             fn to_key(&self) -> impl AsRef<[u8]> {
                 self.to_be_bytes()
+            }
+        }
+        impl<'de> FromKey<'de> for $int {
+            fn from_key(slice: &'de [u8]) -> Self {
+                $int::from_be_bytes(slice.try_into().unwrap())
             }
         }
     };

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -10,6 +10,6 @@ pub use {
     all::COLUMN_FAMILIES,
     block::RocksDbBlockRepository,
     rocksdb::{self, DB as RocksDb},
-    state::RocksDbState,
+    state::{RocksDbState, RocksDbStateQueries},
     trie::{RocksEthTrieDb, ROOT_KEY},
 };

--- a/storage/src/state.rs
+++ b/storage/src/state.rs
@@ -1,14 +1,35 @@
 use {
-    crate::{trie::FromOptRoot, RocksEthTrieDb},
+    crate::{
+        generic::{FromKey, ToKey},
+        trie::FromOptRoot,
+        RocksDb, RocksEthTrieDb,
+    },
     eth_trie::{EthTrie, TrieError, DB},
     move_binary_format::errors::PartialVMError,
-    move_core_types::{effects::ChangeSet, resolver::MoveResolver},
+    move_core_types::{
+        account_address::AccountAddress, effects::ChangeSet, resolver::MoveResolver,
+    },
     move_table_extension::{TableChangeSet, TableResolver},
-    moved::state_actor::EthTrieResolver,
-    moved_shared::primitives::B256,
+    moved::{
+        move_execution::{quick_get_eth_balance, quick_get_nonce},
+        state_actor::{
+            proof_from_trie_and_resolver, Balance, BlockHeight, EthTrieResolver, Nonce,
+            StateQueries,
+        },
+        types::{
+            queries::ProofResponse,
+            transactions::{L2_HIGHEST_ADDRESS, L2_LOWEST_ADDRESS},
+        },
+    },
+    moved_shared::primitives::{ToEthAddress, B256, U256},
     moved_state::{InsertChangeSetIntoMerkleTrie, State},
+    rocksdb::{AsColumnFamilyRef, WriteBatchWithTransaction},
     std::sync::Arc,
 };
+
+pub const COLUMN_FAMILY: &str = "state";
+pub const HEIGHT_COLUMN_FAMILY: &str = "state_height";
+pub const HEIGHT_KEY: &str = "state_height";
 
 /// A blockchain state implementation backed by [`rocksdb`] as its persistent storage engine.
 pub struct RocksDbState<'db> {
@@ -71,5 +92,118 @@ impl<'db> State for RocksDbState<'db> {
 
     fn state_root(&self) -> B256 {
         self.state_root.unwrap_or_default()
+    }
+}
+
+#[derive(Debug)]
+pub struct RocksDbStateQueries<'db> {
+    db: &'db RocksDb,
+}
+
+impl<'db> RocksDbStateQueries<'db> {
+    pub fn new(db: &'db RocksDb) -> Self {
+        Self { db }
+    }
+
+    pub fn from_genesis(db: &'db RocksDb, genesis_state_root: B256) -> Self {
+        let this = Self { db };
+        this.push_state_root(genesis_state_root).unwrap();
+        this
+    }
+
+    pub fn push_state_root(&self, state_root: B256) -> Result<(), rocksdb::Error> {
+        let height = self.height()?;
+        let mut batch = WriteBatchWithTransaction::<false>::default();
+
+        batch.put_cf(&self.cf(), height.to_key(), state_root);
+        batch.put_cf(&self.height_cf(), HEIGHT_KEY, (height + 1).to_key());
+
+        self.db.write(batch)
+    }
+
+    fn height(&self) -> Result<u64, rocksdb::Error> {
+        Ok(self
+            .db
+            .get_pinned_cf(&self.height_cf(), HEIGHT_KEY)?
+            .map(|v| u64::from_key(v.as_ref()))
+            .unwrap_or(0))
+    }
+
+    fn root_by_height(&self, height: u64) -> Result<Option<B256>, rocksdb::Error> {
+        Ok(self
+            .db
+            .get_pinned_cf(&self.cf(), height.to_key())?
+            .map(|v| B256::new(v.as_ref().try_into().unwrap())))
+    }
+
+    fn tree<D: DB>(&self, db: Arc<D>, height: u64) -> Result<EthTrie<D>, rocksdb::Error> {
+        Ok(match self.root_by_height(height)? {
+            Some(root) => EthTrie::from(db, root).expect("State root should be valid"),
+            None => EthTrie::new(db),
+        })
+    }
+
+    fn resolver<'a>(
+        &self,
+        db: Arc<impl DB + 'a>,
+        height: BlockHeight,
+    ) -> Result<impl MoveResolver<PartialVMError> + TableResolver + 'a, rocksdb::Error> {
+        Ok(EthTrieResolver::new(self.tree(db, height)?))
+    }
+
+    fn height_cf(&self) -> impl AsColumnFamilyRef + use<'_> {
+        self.db
+            .cf_handle(HEIGHT_COLUMN_FAMILY)
+            .expect("Column family should exist")
+    }
+
+    fn cf(&self) -> impl AsColumnFamilyRef + use<'_> {
+        self.db
+            .cf_handle(COLUMN_FAMILY)
+            .expect("Column family should exist")
+    }
+}
+
+impl<'db> StateQueries for RocksDbStateQueries<'db> {
+    fn balance_at(
+        &self,
+        db: Arc<impl DB>,
+        account: AccountAddress,
+        height: BlockHeight,
+    ) -> Option<Balance> {
+        let resolver = self.resolver(db, height).ok()?;
+
+        Some(quick_get_eth_balance(&account, &resolver))
+    }
+
+    fn nonce_at(
+        &self,
+        db: Arc<impl DB>,
+        account: AccountAddress,
+        height: BlockHeight,
+    ) -> Option<Nonce> {
+        let resolver = self.resolver(db, height).ok()?;
+
+        Some(quick_get_nonce(&account, &resolver))
+    }
+
+    fn proof_at(
+        &self,
+        db: Arc<impl DB>,
+        account: AccountAddress,
+        storage_slots: &[U256],
+        height: BlockHeight,
+    ) -> Option<ProofResponse> {
+        let address = account.to_eth_address();
+
+        // Only L2 contract addresses supported at this time
+        if address < L2_LOWEST_ADDRESS || L2_HIGHEST_ADDRESS < address {
+            return None;
+        }
+
+        let mut tree = self.tree(db.clone(), height).ok()?;
+        let resolver = self.resolver(db, height).ok()?;
+
+        proof_from_trie_and_resolver(address, storage_slots, &mut tree, &resolver)
     }
 }


### PR DESCRIPTION
### Description
Adds new `StateQueries` implementation backed by `rocksdb`

### Changes
- Adds new `StateQueries` implementation backed by `rocksdb`
- Adds new `OnTxBatch` callback specific to the `rocksdb` implementation of `StateQueries`
- Moves some trait types into type aliases to avoid clippy warning about complex types
- Uses this implementation when building with `--features storage`.

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt