### PR TITLE
docs: Annotate the disallowment of nested references

### DIFF
--- a/moved/src/move_execution/execute.rs
+++ b/moved/src/move_execution/execute.rs
@@ -182,8 +182,8 @@ fn strip_reference(t: &Type) -> crate::Result<&Type> {
         Type::Reference(inner) | Type::MutableReference(inner) => {
             match inner.as_ref() {
                 Type::Reference(_) | Type::MutableReference(_) => {
-                    // Based on Aptos code, it looks like references are not allowed to be nested.
-                    // TODO: check this assumption.
+                    // References to references are not allowed and will not compile
+                    // https://move-language.github.io/move/references.html#reference-operators
                     Err(InvalidTransactionCause::UnsupportedNestedReference)?
                 }
                 other => Ok(other),


### PR DESCRIPTION
Closes #61 

### Description
After reviewing nested references invariant, I conclude that it is valid based on the official Move book.

### Changes
- Annotate the disallowment of nested references
- Remove TODO comment referencing this issue

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt
