### PR TITLE
Feat(server): Health check response on GET requests

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -34,7 +34,7 @@ use {
     warp::{
         hyper::{body::Bytes, Body, Response},
         path::FullPath,
-        Filter, Rejection,
+        Filter, Rejection, Reply,
     },
     warp_reverse_proxy::{
         extract_request_data_filter, proxy_to_and_forward_response, Headers, Method,
@@ -259,6 +259,11 @@ async fn mirror(
     is_allowed: impl Fn(&MethodName) -> bool,
 ) -> Result<warp::reply::Response, Rejection> {
     let (path, query, method, headers, body) = request;
+
+    // Handle load balancer health check with a simple response
+    if method == Method::GET {
+        return Ok("healthy".into_response());
+    }
 
     let is_zipped = headers
         .get("accept-encoding")

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -32,6 +32,7 @@ use {
     },
     tokio::sync::mpsc,
     warp::{
+        http::StatusCode,
         hyper::{body::Bytes, Body, Response},
         path::FullPath,
         Filter, Rejection, Reply,
@@ -262,7 +263,7 @@ async fn mirror(
 
     // Handle load balancer health check with a simple response
     if method == Method::GET {
-        return Ok("healthy".into_response());
+        return Ok(StatusCode::OK.into_response());
     }
 
     let is_zipped = headers


### PR DESCRIPTION
### Description
Load balancers make health check requests to include VMs in the backend. The requests use GET method. This PR responds to any GET request with 200 success status and `healthy` response.

### Changes
- Shortcut server response if it's a GET request with `healthy` string response

### Testing
✓ Tested on load balancer and the VM got included after this change