### PR TITLE
build: Remove optimism submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ server/*.log
 
 # Docker mounted volumes
 docker/volumes
+
+# Optimism cloned repository
+server/src/tests/optimism

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "server/src/tests/optimism"]
-	path = server/src/tests/optimism
-	url = https://github.com/ethereum-optimism/optimism

--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ A Move VM execution layer for OP Stack.
 
 Make sure you have `go` installed on your system. Other dependencies include [foundry](http://getfoundry.sh/) for smart contract interaction and [jq](https://jqlang.github.io/jq/) being called indirectly by Optimism itself.
 
-Optimism monorepo is pulled in as a submodule of this repo. The submodule is used to compile and deploy Optimism contracts.
-If you don't see it inside the test folder, try bringing in the Optimism submodule manually
+First, clone the Optimism monorepo. The repo is used to compile and deploy Optimism contracts.
 
 ```bash
-git submodule update --init --recursive
+git clone https://github.com/ethereum-optimism/optimism server/src/tests/optimism
 ```
 
 Make sure the Optimism binaries are built and are in the PATH, i.e. under the `go` path.
 
 ```bash
 cd server/src/tests/optimism
+git checkout f2e5a7a5
 make op-node op-batcher op-proposer
 mv op-node/bin/op-node ~/go/bin/
 mv op-batcher/bin/op-batcher ~/go/bin/
@@ -28,6 +28,7 @@ Similarly, clone the [`op-geth` project](https://github.com/ethereum-optimism/op
 ```bash
 git clone https://github.com/ethereum-optimism/op-geth.git
 cd op-geth
+git checkout f2e69450
 make geth
 mv build/bin/geth ~/go/bin/op-geth # make sure it's saved as op-geth instead of geth
 ```


### PR DESCRIPTION
### Description
Using submodules is unneccessary and brings in complexity and messes up the staging area.

It is also inconsistent with other dependencies like `geth` that are cloned without submodule.

This PR gets rid of the submodule setup while keeping everything adjusted to cloning and makes it all consistent.

### Changes
- Remove submodules from the repository
- Adjust readme instructions for the cloning
- Ignore optimism directory in git to avoid adding it and including it in git status

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt