### PR TITLE
refactor(genesis): Add L2 contract genesis to `GenesisConfig`

### DIFF
--- a/genesis/src/config.rs
+++ b/genesis/src/config.rs
@@ -1,13 +1,14 @@
 use {
-    alloy::primitives::hex,
+    alloy::{genesis::Genesis, primitives::hex},
     aptos_gas_schedule::{InitialGasSchedule, VMGasParameters},
     aptos_vm_types::storage::StorageGasParameters,
     move_core_types::account_address::AccountAddress,
     moved_shared::primitives::B256,
-    std::path::{Path, PathBuf},
 };
 
 pub const CHAIN_ID: u64 = 404;
+const DEFAULT_L2_CONTRACT_GENESIS: &str =
+    include_str!("../../moved/src/tests/res/l2_genesis_tests.json");
 
 #[derive(Debug, Clone)]
 pub struct GasCosts {
@@ -22,8 +23,7 @@ pub struct GenesisConfig {
     pub initial_state_root: B256,
     pub gas_costs: GasCosts,
     pub treasury: AccountAddress,
-    // TODO: the genesis config should be self-contained instead of referring to an external file.
-    pub l2_contract_genesis: PathBuf,
+    pub l2_contract_genesis: Genesis,
 }
 
 impl Default for GasCosts {
@@ -45,7 +45,8 @@ impl Default for GenesisConfig {
             )),
             gas_costs: GasCosts::default(),
             treasury: AccountAddress::ONE, // todo: fill in the real address
-            l2_contract_genesis: Path::new("../moved/src/tests/res/l2_genesis_tests.json").into(),
+            l2_contract_genesis: serde_json::from_str(DEFAULT_L2_CONTRACT_GENESIS)
+                .expect("Default L2 contract genesis should be JSON encoded `Genesis` struct"),
         }
     }
 }

--- a/genesis/src/lib.rs
+++ b/genesis/src/lib.rs
@@ -23,19 +23,13 @@ pub fn build(
     config: &GenesisConfig,
     state: &impl State,
 ) -> (ChangeSet, TableChangeSet) {
-    // Read L2 contract data
-    let l2_genesis_file = std::fs::File::open(&config.l2_contract_genesis)
-        .expect("L2 contracts genesis file must exist");
-    let l2_contract_genesis =
-        serde_json::from_reader(l2_genesis_file).expect("L2 genesis file must parse successfully");
-
-    let mut changes = ChangeSet::new();
-
     // Deploy Move/Aptos/Sui frameworks
     let (changes_framework, table_changes) = framework::init_state(vm, state);
 
     // Deploy OP stack L2 contracts
-    let changes_l2 = l2_contracts::init_state(l2_contract_genesis, state);
+    let changes_l2 = l2_contracts::init_state(config.l2_contract_genesis.clone(), state);
+
+    let mut changes = ChangeSet::new();
 
     changes
         .squash(changes_framework)

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -27,7 +27,6 @@ use {
         fs,
         io::Read,
         net::{Ipv4Addr, SocketAddr, SocketAddrV4},
-        path::Path,
         time::SystemTime,
     },
     tokio::sync::mpsc,
@@ -81,10 +80,13 @@ pub async fn run() {
     // TODO: genesis should come from a file (path specified by CLI)
     let genesis_config = GenesisConfig {
         chain_id: 42069,
-        l2_contract_genesis: Path::new(
-            "src/tests/optimism/packages/contracts-bedrock/deployments/genesis.json",
+        l2_contract_genesis: serde_json::from_reader(
+            &fs::File::open(
+                "src/tests/optimism/packages/contracts-bedrock/deployments/genesis.json",
+            )
+            .expect("L2 contract genesis file should exist and be readable"),
         )
-        .into(),
+        .expect("Path should point to JSON encoded L2 contract `Genesis` struct"),
         ..Default::default()
     };
 


### PR DESCRIPTION
### Description
Makes the `GenesisConfig` self-contained instead of relying on external file.

Furthermore, the default file is embedded instead of being read at runtime.

Resolves one TODO item.

### Changes
- Add `Genesis` into `GenesisConfig`
- Embed default `Genesis` into the binary

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt
:green_circle: `docker compose build && docker compose up-d`