### PR TITLE
build(docker): Ignore volumes directory from the docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .*
 
 !docker
+docker/volumes
 
 !server
 server/src/tests/optimism


### PR DESCRIPTION
### Description
Avoids copying unnecessary files and directories that are created by containers, therefore will never be used in the image build process.

In a future version there will likely be a database volume which will be very large, slowing down the build process significantly.

### Changes
- Add `docker/volumes` to `.dockerignore`

### Testing
:green_circle: `docker compose build`