### PR TITLE
feat(storage): Implement `ReceiptRepository` and `ReceiptQueries` using `heed`

### DIFF
--- a/storage/heed/src/block.rs
+++ b/storage/heed/src/block.rs
@@ -22,13 +22,13 @@ impl BlockRepository for HeedBlockRepository {
 
         let db: heed::Database<EncodableB256, EncodableBlock> = env
             .open_database(&transaction, Some(BLOCK_DB))?
-            .expect("Database should exist");
+            .expect("Block database should exist");
 
         db.put(&mut transaction, &block.hash, &block)?;
 
         let db: heed::Database<EncodableU64, EncodableB256> = env
             .open_database(&transaction, Some(HEIGHT_DB))?
-            .expect("Database should exist");
+            .expect("Block height database should exist");
 
         db.put(&mut transaction, &block.block.header.number, &block.hash)
     }
@@ -38,7 +38,7 @@ impl BlockRepository for HeedBlockRepository {
 
         let db: heed::Database<EncodableB256, EncodableBlock> = env
             .open_database(&transaction, Some(BLOCK_DB))?
-            .expect("Database should exist");
+            .expect("Block database should exist");
 
         db.get(&transaction, &hash)
     }

--- a/storage/heed/src/lib.rs
+++ b/storage/heed/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod block;
 mod generic;
+pub mod receipt;

--- a/storage/heed/src/receipt.rs
+++ b/storage/heed/src/receipt.rs
@@ -1,0 +1,71 @@
+use {
+    crate::generic::EncodableB256,
+    heed::types::{LazyDecode, SerdeBincode},
+    moved_blockchain::receipt::{
+        ExtendedReceipt, ReceiptQueries, ReceiptRepository, TransactionReceipt,
+    },
+    moved_shared::primitives::B256,
+};
+
+pub type EncodableReceipt = SerdeBincode<ExtendedReceipt>;
+
+pub const RECEIPT_DB: &str = "receipt";
+
+#[derive(Debug)]
+pub struct HeedReceiptRepository;
+
+impl ReceiptRepository for HeedReceiptRepository {
+    type Err = heed::Error;
+    type Storage = &'static heed::Env;
+
+    fn contains(&self, env: &Self::Storage, transaction_hash: B256) -> Result<bool, Self::Err> {
+        let transaction = env.read_txn()?;
+
+        let db: heed::Database<EncodableB256, LazyDecode<EncodableReceipt>> = env
+            .open_database(&transaction, Some(RECEIPT_DB))?
+            .expect("Receipt database should exist")
+            .lazily_decode_data();
+
+        db.get(&transaction, &transaction_hash).map(|v| v.is_some())
+    }
+
+    fn extend(
+        &self,
+        env: &mut Self::Storage,
+        receipts: impl IntoIterator<Item = ExtendedReceipt>,
+    ) -> Result<(), Self::Err> {
+        let mut transaction = env.write_txn()?;
+
+        let db: heed::Database<EncodableB256, EncodableReceipt> = env
+            .open_database(&transaction, Some(RECEIPT_DB))?
+            .expect("Receipt database should exist");
+
+        receipts
+            .into_iter()
+            .try_for_each(|receipt| db.put(&mut transaction, &receipt.transaction_hash, &receipt))
+    }
+}
+
+#[derive(Debug)]
+pub struct HeedReceiptQueries;
+
+impl ReceiptQueries for HeedReceiptQueries {
+    type Err = heed::Error;
+    type Storage = &'static heed::Env;
+
+    fn by_transaction_hash(
+        &self,
+        env: &Self::Storage,
+        transaction_hash: B256,
+    ) -> Result<Option<TransactionReceipt>, Self::Err> {
+        let transaction = env.read_txn()?;
+
+        let db: heed::Database<EncodableB256, EncodableReceipt> = env
+            .open_database(&transaction, Some(RECEIPT_DB))?
+            .expect("Receipt database should exist");
+
+        Ok(db
+            .get(&transaction, &transaction_hash)?
+            .map(TransactionReceipt::from))
+    }
+}


### PR DESCRIPTION
### Description
Adds the receipts backing storage implementation using `heed`.

`heed` is a crate that defines the rust bindings for LMDB.

### Changes
- Implement `ReceiptRepository` using `heed`
- Implement `ReceiptQueries` using `heed`

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt