### PR TITLE
feat(storage): Implement `TransactionRepository` and `TransactionQueries` using `heed`

### DIFF
--- a/storage/heed/src/lib.rs
+++ b/storage/heed/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod block;
 mod generic;
 pub mod receipt;
+pub mod transaction;

--- a/storage/heed/src/transaction.rs
+++ b/storage/heed/src/transaction.rs
@@ -1,0 +1,58 @@
+use {
+    crate::generic::EncodableB256,
+    heed::types::SerdeBincode,
+    moved_blockchain::transaction::{
+        ExtendedTransaction, TransactionQueries, TransactionRepository, TransactionResponse,
+    },
+    moved_shared::primitives::B256,
+};
+
+pub type EncodableTransaction = SerdeBincode<ExtendedTransaction>;
+
+pub const TRANSACTION_DB: &str = "transaction";
+
+#[derive(Debug)]
+pub struct HeedTransactionRepository;
+
+impl TransactionRepository for HeedTransactionRepository {
+    type Err = heed::Error;
+    type Storage = &'static heed::Env;
+
+    fn extend(
+        &mut self,
+        env: &mut Self::Storage,
+        transactions: impl IntoIterator<Item = ExtendedTransaction>,
+    ) -> Result<(), Self::Err> {
+        let mut db_transaction = env.write_txn()?;
+
+        let db: heed::Database<EncodableB256, EncodableTransaction> = env
+            .open_database(&db_transaction, Some(TRANSACTION_DB))?
+            .expect("Database should exist");
+
+        transactions.into_iter().try_for_each(|transaction| {
+            db.put(&mut db_transaction, &transaction.hash(), &transaction)
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct HeedTransactionQueries;
+
+impl TransactionQueries for HeedTransactionQueries {
+    type Err = heed::Error;
+    type Storage = &'static heed::Env;
+
+    fn by_hash(
+        &self,
+        env: &Self::Storage,
+        hash: B256,
+    ) -> Result<Option<TransactionResponse>, Self::Err> {
+        let transaction = env.read_txn()?;
+
+        let db: heed::Database<EncodableB256, EncodableTransaction> = env
+            .open_database(&transaction, Some(TRANSACTION_DB))?
+            .expect("Database should exist");
+
+        Ok(db.get(&transaction, &hash)?.map(TransactionResponse::from))
+    }
+}


### PR DESCRIPTION
### Description
Adds the transactions backing storage implementation using `heed`.

`heed` is a crate that defines the rust bindings for LMDB.

### Changes
- Implement `TransactionRepository` using `heed`
- Implement `TransactionQueries` using `heed`

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt