### PR TITLE
feat(storage): Implement `BlockQueries` using `heed`

### DIFF
--- a/storage/heed/src/block.rs
+++ b/storage/heed/src/block.rs
@@ -1,7 +1,10 @@
 use {
-    crate::generic::{EncodableB256, EncodableU64},
+    crate::{
+        generic::{EncodableB256, EncodableU64},
+        transaction::{EncodableTransaction, TRANSACTION_DB},
+    },
     heed::types::SerdeBincode,
-    moved_blockchain::block::{BlockRepository, ExtendedBlock},
+    moved_blockchain::block::{BlockQueries, BlockRepository, BlockResponse, ExtendedBlock},
     moved_shared::primitives::B256,
 };
 
@@ -41,5 +44,64 @@ impl BlockRepository for HeedBlockRepository {
             .expect("Block database should exist");
 
         db.get(&transaction, &hash)
+    }
+}
+
+#[derive(Debug)]
+pub struct HeedBlockQueries;
+
+impl BlockQueries for HeedBlockQueries {
+    type Err = heed::Error;
+    type Storage = &'static heed::Env;
+
+    fn by_hash(
+        &self,
+        env: &Self::Storage,
+        hash: B256,
+        include_transactions: bool,
+    ) -> Result<Option<BlockResponse>, Self::Err> {
+        let transaction = env.read_txn()?;
+
+        let db: heed::Database<EncodableB256, EncodableBlock> = env
+            .open_database(&transaction, Some(BLOCK_DB))?
+            .expect("Database should exist");
+
+        let block = db.get(&transaction, &hash)?;
+
+        Ok(Some(match block {
+            Some(block) if include_transactions => {
+                let db_transaction = env.read_txn()?;
+
+                let db: heed::Database<EncodableB256, EncodableTransaction> = env
+                    .open_database(&db_transaction, Some(TRANSACTION_DB))?
+                    .expect("Database should exist");
+
+                let transactions = block
+                    .transaction_hashes()
+                    .filter_map(|hash| db.get(&transaction, &hash).transpose())
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                BlockResponse::from_block_with_transactions(block, transactions)
+            }
+            Some(block) => BlockResponse::from_block_with_transaction_hashes(block),
+            None => return Ok(None),
+        }))
+    }
+
+    fn by_height(
+        &self,
+        env: &Self::Storage,
+        height: u64,
+        include_transactions: bool,
+    ) -> Result<Option<BlockResponse>, Self::Err> {
+        let transaction = env.read_txn()?;
+
+        let db: heed::Database<EncodableU64, EncodableB256> = env
+            .open_database(&transaction, Some(HEIGHT_DB))?
+            .expect("Database should exist");
+
+        db.get(&transaction, &height)?
+            .map(|hash| self.by_hash(env, hash, include_transactions))
+            .unwrap_or(Ok(None))
     }
 }


### PR DESCRIPTION
### Description
Adds the `BlockQueries` backing storage implementation using `heed`.

Contrary to the repository implementation, this one is dependent on the transaction implementation, that's why it is split.

`heed` is a crate that defines the rust bindings for LMDB.

### Changes
- Implement `BlockQueries` using `heed`

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt