### PR TITLE
feat(storage): Implement `EthTrie` using `heed`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7028,6 +7028,7 @@ dependencies = [
 name = "moved-storage-heed"
 version = "0.1.0"
 dependencies = [
+ "eth_trie",
  "heed",
  "moved-blockchain",
  "moved-shared",

--- a/storage/heed/Cargo.toml
+++ b/storage/heed/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+eth_trie.workspace = true
+heed.workspace = true
 moved-blockchain.workspace = true
 moved-shared.workspace = true
-heed.workspace = true

--- a/storage/heed/src/generic.rs
+++ b/storage/heed/src/generic.rs
@@ -1,5 +1,9 @@
 use {
-    heed::{byteorder::LittleEndian, types::U64, BoxedError, BytesDecode, BytesEncode},
+    heed::{
+        byteorder::LittleEndian,
+        types::{Bytes, U64},
+        BoxedError, BytesDecode, BytesEncode,
+    },
     moved_shared::primitives::B256,
     std::borrow::Cow,
 };
@@ -24,3 +28,4 @@ impl<'item> BytesDecode<'item> for EncodableB256 {
 }
 
 pub type EncodableU64 = U64<LittleEndian>;
+pub type EncodableBytes = Bytes;

--- a/storage/heed/src/lib.rs
+++ b/storage/heed/src/lib.rs
@@ -3,3 +3,4 @@ mod generic;
 pub mod payload;
 pub mod receipt;
 pub mod transaction;
+pub mod trie;

--- a/storage/heed/src/trie.rs
+++ b/storage/heed/src/trie.rs
@@ -1,0 +1,105 @@
+use {
+    crate::generic::{EncodableB256, EncodableBytes, EncodableU64},
+    eth_trie::{EthTrie, TrieError, DB},
+    moved_shared::primitives::B256,
+    std::sync::Arc,
+};
+
+pub const TRIE_DB: &str = "trie";
+pub const ROOT_DB: &str = "trie_root";
+pub const ROOT_KEY: u64 = 0u64;
+
+pub struct HeedEthTrieDb<'db> {
+    env: &'db heed::Env,
+}
+
+impl<'db> HeedEthTrieDb<'db> {
+    pub fn new(env: &'db heed::Env) -> Self {
+        Self { env }
+    }
+
+    pub fn root(&self) -> Result<Option<B256>, heed::Error> {
+        let transaction = self.env.read_txn()?;
+
+        let db: heed::Database<EncodableU64, EncodableB256> = self
+            .env
+            .open_database(&transaction, Some(ROOT_DB))?
+            .expect("Database should exist");
+
+        db.get(&transaction, &ROOT_KEY)
+    }
+
+    pub fn put_root(&self, root: B256) -> Result<(), heed::Error> {
+        let mut transaction = self.env.write_txn()?;
+
+        let db: heed::Database<EncodableU64, EncodableB256> = self
+            .env
+            .open_database(&transaction, Some(ROOT_DB))?
+            .expect("Database should exist");
+
+        db.put(&mut transaction, &ROOT_KEY, &root)
+    }
+}
+
+impl<'db> DB for HeedEthTrieDb<'db> {
+    type Error = heed::Error;
+
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        let transaction = self.env.read_txn()?;
+
+        let db: heed::Database<EncodableBytes, EncodableBytes> = self
+            .env
+            .open_database(&transaction, Some(ROOT_DB))?
+            .expect("Database should exist");
+
+        Ok(db.get(&transaction, key)?.map(<[u8]>::to_vec))
+    }
+
+    fn insert(&self, key: &[u8], value: Vec<u8>) -> Result<(), Self::Error> {
+        let mut transaction = self.env.write_txn()?;
+
+        let db: heed::Database<EncodableBytes, EncodableBytes> = self
+            .env
+            .open_database(&transaction, Some(ROOT_DB))?
+            .expect("Database should exist");
+
+        db.put(&mut transaction, key, value.as_slice())
+    }
+
+    fn remove(&self, _key: &[u8]) -> Result<(), Self::Error> {
+        // Intentionally ignored to not remove historical trie nodes
+        Ok(())
+    }
+
+    fn flush(&self) -> Result<(), Self::Error> {
+        // Intentionally ignored as cache management is delegated to the database
+        Ok(())
+    }
+}
+
+pub trait TryFromOptRoot<D> {
+    fn try_from_opt_root(db: Arc<D>, root: Option<B256>) -> Result<Self, TrieError>
+    where
+        Self: Sized;
+}
+
+impl<D: DB> TryFromOptRoot<D> for EthTrie<D> {
+    fn try_from_opt_root(db: Arc<D>, root: Option<B256>) -> Result<EthTrie<D>, TrieError> {
+        match root {
+            None => Ok(EthTrie::new(db)),
+            Some(root) => EthTrie::from(db, root),
+        }
+    }
+}
+
+pub trait FromOptRoot<D> {
+    fn from_opt_root(db: Arc<D>, root: Option<B256>) -> Self
+    where
+        Self: Sized;
+}
+
+impl<D, T: TryFromOptRoot<D>> FromOptRoot<D> for T {
+    fn from_opt_root(db: Arc<D>, root: Option<B256>) -> Self {
+        Self::try_from_opt_root(db, root).expect("Root node should exist")
+    }
+}


### PR DESCRIPTION
### Description
Adds the merkle trie backing storage implementation using `heed`.

`heed` is a crate that defines the rust bindings for LMDB.

### Changes
- Implement `eth_trie::DB` using `heed`

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt