### PR TITLE
feat(storage): Implement `State` using `heed`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7030,8 +7030,13 @@ version = "0.1.0"
 dependencies = [
  "eth_trie",
  "heed",
+ "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.14.0)",
+ "move-core-types 0.0.4 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.14.0)",
+ "move-table-extension",
  "moved-blockchain",
+ "moved-execution",
  "moved-shared",
+ "moved-state",
 ]
 
 [[package]]

--- a/storage/heed/Cargo.toml
+++ b/storage/heed/Cargo.toml
@@ -7,5 +7,10 @@ edition.workspace = true
 [dependencies]
 eth_trie.workspace = true
 heed.workspace = true
+move-binary-format.workspace = true
+move-core-types.workspace = true
+move-table-extension.workspace = true
 moved-blockchain.workspace = true
+moved-execution.workspace = true
 moved-shared.workspace = true
+moved-state.workspace = true

--- a/storage/heed/src/block.rs
+++ b/storage/heed/src/block.rs
@@ -64,7 +64,7 @@ impl BlockQueries for HeedBlockQueries {
 
         let db: heed::Database<EncodableB256, EncodableBlock> = env
             .open_database(&transaction, Some(BLOCK_DB))?
-            .expect("Database should exist");
+            .expect("Block database should exist");
 
         let block = db.get(&transaction, &hash)?;
 
@@ -74,7 +74,7 @@ impl BlockQueries for HeedBlockQueries {
 
                 let db: heed::Database<EncodableB256, EncodableTransaction> = env
                     .open_database(&db_transaction, Some(TRANSACTION_DB))?
-                    .expect("Database should exist");
+                    .expect("Transaction database should exist");
 
                 let transactions = block
                     .transaction_hashes()
@@ -98,7 +98,7 @@ impl BlockQueries for HeedBlockQueries {
 
         let db: heed::Database<EncodableU64, EncodableB256> = env
             .open_database(&transaction, Some(HEIGHT_DB))?
-            .expect("Database should exist");
+            .expect("Block height database should exist");
 
         db.get(&transaction, &height)?
             .map(|hash| self.by_hash(env, hash, include_transactions))

--- a/storage/heed/src/lib.rs
+++ b/storage/heed/src/lib.rs
@@ -2,5 +2,6 @@ pub mod block;
 mod generic;
 pub mod payload;
 pub mod receipt;
+pub mod state;
 pub mod transaction;
 pub mod trie;

--- a/storage/heed/src/payload.rs
+++ b/storage/heed/src/payload.rs
@@ -25,7 +25,7 @@ impl HeedPayloadQueries {
         let db: heed::Database<EncodableU64, EncodableB256> = self
             .env
             .open_database(&transaction, Some(PAYLOAD_DB))?
-            .expect("Database should exist");
+            .expect("Payload database should exist");
 
         db.put(&mut transaction, &id.to_u64(), &block_hash)
     }
@@ -44,7 +44,7 @@ impl PayloadQueries for HeedPayloadQueries {
 
         let db: heed::Database<EncodableB256, EncodableBlock> = env
             .open_database(&transaction, Some(BLOCK_DB))?
-            .expect("Database should exist");
+            .expect("Block database should exist");
 
         Ok(db
             .get(&transaction, &hash)?
@@ -60,7 +60,7 @@ impl PayloadQueries for HeedPayloadQueries {
 
         let db: heed::Database<EncodableU64, EncodableB256> = env
             .open_database(&transaction, Some(PAYLOAD_DB))?
-            .expect("Database should exist");
+            .expect("Payload database should exist");
 
         db.get(&transaction, &id.to_u64())?
             .map(|hash| self.by_hash(env, hash))

--- a/storage/heed/src/state.rs
+++ b/storage/heed/src/state.rs
@@ -1,0 +1,208 @@
+use {
+    crate::{
+        generic::{EncodableB256, EncodableU64},
+        trie::{FromOptRoot, HeedEthTrieDb},
+    },
+    eth_trie::{EthTrie, TrieError, DB},
+    move_binary_format::errors::PartialVMError,
+    move_core_types::{
+        account_address::AccountAddress, effects::ChangeSet, resolver::MoveResolver,
+    },
+    move_table_extension::{TableChangeSet, TableResolver},
+    moved_blockchain::state::{
+        proof_from_trie_and_resolver, Balance, BlockHeight, EthTrieResolver, Nonce, ProofResponse,
+        StateQueries,
+    },
+    moved_execution::{
+        quick_get_eth_balance, quick_get_nonce,
+        transaction::{L2_HIGHEST_ADDRESS, L2_LOWEST_ADDRESS},
+    },
+    moved_shared::primitives::{ToEthAddress, B256, U256},
+    moved_state::{InsertChangeSetIntoMerkleTrie, State},
+    std::sync::Arc,
+};
+
+pub const STATE_DB: &str = "state";
+pub const HEIGHT_DB: &str = "state_height";
+pub const HEIGHT_KEY: u64 = 0;
+
+/// A blockchain state implementation backed by [`heed`] as its persistent storage engine.
+pub struct HeedState<'db> {
+    db: Arc<HeedEthTrieDb<'db>>,
+    resolver: EthTrieResolver<HeedEthTrieDb<'db>>,
+    state_root: Option<B256>,
+}
+
+impl<'db> HeedState<'db> {
+    pub fn new(db: Arc<HeedEthTrieDb<'db>>) -> Self {
+        let state_root = db
+            .root()
+            .expect("Database should be able to fetch state root");
+
+        Self {
+            resolver: EthTrieResolver::new(EthTrie::from_opt_root(db.clone(), state_root)),
+            state_root,
+            db,
+        }
+    }
+
+    fn persist_state_root(&self) -> Result<(), heed::Error> {
+        self.state_root
+            .map(|root| self.db.put_root(root))
+            .unwrap_or(Ok(()))
+    }
+
+    fn tree(&self) -> EthTrie<HeedEthTrieDb<'db>> {
+        EthTrie::from_opt_root(self.db.clone(), self.state_root)
+    }
+}
+
+impl<'db> State for HeedState<'db> {
+    type Err = TrieError;
+
+    fn apply(&mut self, changes: ChangeSet) -> Result<(), Self::Err> {
+        let mut tree = self.tree();
+        let root = tree.insert_change_set_into_merkle_trie(&changes)?;
+        self.state_root.replace(root);
+        self.resolver = EthTrieResolver::new(tree);
+        self.persist_state_root().unwrap();
+        Ok(())
+    }
+
+    fn apply_with_tables(
+        &mut self,
+        changes: ChangeSet,
+        _table_changes: TableChangeSet,
+    ) -> Result<(), Self::Err> {
+        self.apply(changes)
+    }
+
+    fn db(&self) -> Arc<impl DB> {
+        self.db.clone()
+    }
+
+    fn resolver(&self) -> &(impl MoveResolver<PartialVMError> + TableResolver) {
+        &self.resolver
+    }
+
+    fn state_root(&self) -> B256 {
+        self.state_root.unwrap_or_default()
+    }
+}
+
+#[derive(Debug)]
+pub struct HeedStateQueries<'db> {
+    env: &'db heed::Env,
+}
+
+impl<'db> HeedStateQueries<'db> {
+    pub fn new(env: &'db heed::Env) -> Self {
+        Self { env }
+    }
+
+    pub fn from_genesis(env: &'db heed::Env, genesis_state_root: B256) -> Self {
+        let this = Self { env };
+        this.push_state_root(genesis_state_root).unwrap();
+        this
+    }
+
+    pub fn push_state_root(&self, state_root: B256) -> Result<(), heed::Error> {
+        let height = self.height()?;
+        let mut transaction = self.env.write_txn()?;
+
+        let db: heed::Database<EncodableU64, EncodableB256> = self
+            .env
+            .open_database(&transaction, Some(STATE_DB))?
+            .expect("State root database should exist");
+
+        db.put(&mut transaction, &height, &state_root)?;
+
+        let db: heed::Database<EncodableU64, EncodableU64> = self
+            .env
+            .open_database(&transaction, Some(HEIGHT_DB))?
+            .expect("State height database should exist");
+
+        db.put(&mut transaction, &HEIGHT_KEY, &(height + 1))
+    }
+
+    fn height(&self) -> Result<u64, heed::Error> {
+        let transaction = self.env.read_txn()?;
+
+        let db: heed::Database<EncodableU64, EncodableU64> = self
+            .env
+            .open_database(&transaction, Some(HEIGHT_DB))?
+            .expect("State height database should exist");
+
+        Ok(db.get(&transaction, &HEIGHT_KEY)?.unwrap_or(0))
+    }
+
+    fn root_by_height(&self, height: u64) -> Result<Option<B256>, heed::Error> {
+        let transaction = self.env.read_txn()?;
+
+        let db: heed::Database<EncodableU64, EncodableB256> = self
+            .env
+            .open_database(&transaction, Some(STATE_DB))?
+            .expect("State root database should exist");
+
+        db.get(&transaction, &height)
+    }
+
+    fn tree<D: DB>(&self, db: Arc<D>, height: u64) -> Result<EthTrie<D>, heed::Error> {
+        Ok(match self.root_by_height(height)? {
+            Some(root) => EthTrie::from(db, root).expect("State root should be valid"),
+            None => EthTrie::new(db),
+        })
+    }
+
+    fn resolver<'a>(
+        &self,
+        db: Arc<impl DB + 'a>,
+        height: BlockHeight,
+    ) -> Result<impl MoveResolver<PartialVMError> + TableResolver + 'a, heed::Error> {
+        Ok(EthTrieResolver::new(self.tree(db, height)?))
+    }
+}
+
+impl<'db> StateQueries for HeedStateQueries<'db> {
+    fn balance_at(
+        &self,
+        db: Arc<impl DB>,
+        account: AccountAddress,
+        height: BlockHeight,
+    ) -> Option<Balance> {
+        let resolver = self.resolver(db, height).ok()?;
+
+        Some(quick_get_eth_balance(&account, &resolver))
+    }
+
+    fn nonce_at(
+        &self,
+        db: Arc<impl DB>,
+        account: AccountAddress,
+        height: BlockHeight,
+    ) -> Option<Nonce> {
+        let resolver = self.resolver(db, height).ok()?;
+
+        Some(quick_get_nonce(&account, &resolver))
+    }
+
+    fn proof_at(
+        &self,
+        db: Arc<impl DB>,
+        account: AccountAddress,
+        storage_slots: &[U256],
+        height: BlockHeight,
+    ) -> Option<ProofResponse> {
+        let address = account.to_eth_address();
+
+        // Only L2 contract addresses supported at this time
+        if address < L2_LOWEST_ADDRESS || L2_HIGHEST_ADDRESS < address {
+            return None;
+        }
+
+        let mut tree = self.tree(db.clone(), height).ok()?;
+        let resolver = self.resolver(db, height).ok()?;
+
+        proof_from_trie_and_resolver(address, storage_slots, &mut tree, &resolver)
+    }
+}

--- a/storage/heed/src/transaction.rs
+++ b/storage/heed/src/transaction.rs
@@ -27,7 +27,7 @@ impl TransactionRepository for HeedTransactionRepository {
 
         let db: heed::Database<EncodableB256, EncodableTransaction> = env
             .open_database(&db_transaction, Some(TRANSACTION_DB))?
-            .expect("Database should exist");
+            .expect("Transaction database should exist");
 
         transactions.into_iter().try_for_each(|transaction| {
             db.put(&mut db_transaction, &transaction.hash(), &transaction)
@@ -51,7 +51,7 @@ impl TransactionQueries for HeedTransactionQueries {
 
         let db: heed::Database<EncodableB256, EncodableTransaction> = env
             .open_database(&transaction, Some(TRANSACTION_DB))?
-            .expect("Database should exist");
+            .expect("Transaction database should exist");
 
         Ok(db.get(&transaction, &hash)?.map(TransactionResponse::from))
     }

--- a/storage/heed/src/trie.rs
+++ b/storage/heed/src/trie.rs
@@ -24,7 +24,7 @@ impl<'db> HeedEthTrieDb<'db> {
         let db: heed::Database<EncodableU64, EncodableB256> = self
             .env
             .open_database(&transaction, Some(ROOT_DB))?
-            .expect("Database should exist");
+            .expect("Trie root database should exist");
 
         db.get(&transaction, &ROOT_KEY)
     }
@@ -35,7 +35,7 @@ impl<'db> HeedEthTrieDb<'db> {
         let db: heed::Database<EncodableU64, EncodableB256> = self
             .env
             .open_database(&transaction, Some(ROOT_DB))?
-            .expect("Database should exist");
+            .expect("Trie root database should exist");
 
         db.put(&mut transaction, &ROOT_KEY, &root)
     }
@@ -49,8 +49,8 @@ impl<'db> DB for HeedEthTrieDb<'db> {
 
         let db: heed::Database<EncodableBytes, EncodableBytes> = self
             .env
-            .open_database(&transaction, Some(ROOT_DB))?
-            .expect("Database should exist");
+            .open_database(&transaction, Some(TRIE_DB))?
+            .expect("Trie root database should exist");
 
         Ok(db.get(&transaction, key)?.map(<[u8]>::to_vec))
     }
@@ -60,8 +60,8 @@ impl<'db> DB for HeedEthTrieDb<'db> {
 
         let db: heed::Database<EncodableBytes, EncodableBytes> = self
             .env
-            .open_database(&transaction, Some(ROOT_DB))?
-            .expect("Database should exist");
+            .open_database(&transaction, Some(TRIE_DB))?
+            .expect("Trie root database should exist");
 
         db.put(&mut transaction, key, value.as_slice())
     }


### PR DESCRIPTION
### Description
Adds the state backing storage implementation using `heed`.

`heed` is a crate that defines the rust bindings for LMDB.

### Changes
- Implement `State` using `heed`

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt