### PR TITLE
feat(server): Integrate with LMDB persistent backing storage engine using `heed`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ docker/volumes
 
 # Optimism cloned repository
 server/src/tests/optimism
+
+# Persistent storage directory
+server/db/
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6984,6 +6984,7 @@ dependencies = [
  "moved-genesis-image",
  "moved-shared",
  "moved-state",
+ "moved-storage-heed",
  "moved-storage-rocksdb",
  "once_cell",
  "openssl",
@@ -7037,6 +7038,8 @@ dependencies = [
  "moved-execution",
  "moved-shared",
  "moved-state",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ moved-genesis-image = { path = "genesis-image" }
 moved-shared = { path = "shared" }
 moved-state = { path = "state" }
 moved-storage = { package = "moved-storage-rocksdb", path = "storage/rocksdb" }
+moved-storage-heed = { path = "storage/heed" }
 once_cell = "1.19"
 op-alloy = { version = "0.6", features = ["full", "std", "k256", "serde"] }
 openssl = "0.10"

--- a/app/src/actor.rs
+++ b/app/src/actor.rs
@@ -565,9 +565,9 @@ impl<
 
             on_tx(self, outcome.changes.clone());
 
-            self.state
-                .apply(outcome.changes)
-                .unwrap_or_else(|_| panic!("ERROR: state update failed for transaction {tx:?}"));
+            self.state.apply(outcome.changes).unwrap_or_else(|e| {
+                panic!("ERROR: state update failed for transaction {tx:?}\n{e:?}")
+            });
 
             cumulative_gas_used = cumulative_gas_used.saturating_add(outcome.gas_used as u128);
 

--- a/docker/Dockerfile.op-move
+++ b/docker/Dockerfile.op-move
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
 # RocksDB breaks the build with libclang.so not found https://github.com/apache/skywalking/issues/10439
 # Aptos-core breaks the build with `disable_lifo_slot` not found https://github.com/aptos-labs/aptos-core/issues/5655 \
     RUSTFLAGS="-C target-feature=-crt-static --cfg tokio_unstable" \
-    cargo build --bin op-move --release --features storage \
+    cargo build --bin op-move --release --features storage-lmdb \
     && mv target/release/op-move /volume/op-move
 
 # Switch to clean image

--- a/execution/src/eth_token.rs
+++ b/execution/src/eth_token.rs
@@ -248,7 +248,9 @@ pub fn get_eth_balance<G: GasMeter>(
             gas_meter,
             traversal_context,
         )
-        .map_err(|_| {
+        .map_err(|e| {
+            println!("{e:?}");
+
             moved_shared::error::Error::eth_token_invariant_violation(
                 EthToken::GetBalanceAlwaysSucceeds,
             )

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [features]
 default = []
 storage = ["moved-storage"]
+storage-lmdb = ["moved-storage-heed"]
 
 [dependencies]
 anyhow.workspace = true
@@ -29,6 +30,8 @@ moved-shared.workspace = true
 moved-state.workspace = true
 moved-storage.optional = true
 moved-storage.workspace = true
+moved-storage-heed.optional = true
+moved-storage-heed.workspace = true
 once_cell.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/server/src/dependency/heed.rs
+++ b/server/src/dependency/heed.rs
@@ -1,0 +1,189 @@
+use {
+    crate::dependency::shared::*,
+    moved_blockchain::{
+        block::{BaseGasFee, BlockHash, BlockRepository, MovedBlockHash},
+        payload::NewPayloadId,
+    },
+    moved_execution::{BaseTokenAccounts, CreateL1GasFee, CreateL2GasFee, MovedBaseTokenAccounts},
+    moved_genesis::config::GenesisConfig,
+    moved_state::State,
+    moved_storage_heed::{block, heed::EnvOpenOptions, payload, receipt, state, transaction, trie},
+};
+
+pub type SharedStorage = &'static moved_storage_heed::Env;
+pub type ReceiptStorage = &'static moved_storage_heed::Env;
+pub type StateQueries = state::HeedStateQueries<'static>;
+pub type ReceiptRepository = receipt::HeedReceiptRepository;
+pub type ReceiptQueries = receipt::HeedReceiptQueries;
+pub type PayloadQueries = payload::HeedPayloadQueries;
+pub type TransactionRepository = transaction::HeedTransactionRepository;
+pub type TransactionQueries = transaction::HeedTransactionQueries;
+pub type BlockQueries = block::HeedBlockQueries;
+
+pub fn block_hash() -> impl BlockHash + Send + Sync + 'static {
+    MovedBlockHash
+}
+
+pub fn base_token(
+    genesis_config: &GenesisConfig,
+) -> impl BaseTokenAccounts + Send + Sync + 'static {
+    MovedBaseTokenAccounts::new(genesis_config.treasury)
+}
+
+pub fn memory() -> SharedStorage {
+    db()
+}
+
+pub fn block_repository() -> impl BlockRepository<Storage = SharedStorage> + Send + Sync + 'static {
+    block::HeedBlockRepository
+}
+
+pub fn state() -> impl State + Send + Sync + 'static {
+    state::HeedState::new(std::sync::Arc::new(trie::HeedEthTrieDb::new(db())))
+}
+
+pub fn state_query(genesis_config: &GenesisConfig) -> StateQueries {
+    state::HeedStateQueries::from_genesis(db(), genesis_config.initial_state_root)
+}
+
+pub fn on_tx_batch<
+    A: State,
+    B: NewPayloadId,
+    C: BlockHash,
+    D: BlockRepository<Storage = SharedStorage>,
+    E: BaseGasFee,
+    F: CreateL1GasFee,
+    G: CreateL2GasFee,
+    H: BaseTokenAccounts,
+>() -> OnTxBatch<A, B, C, D, E, F, G, H> {
+    Box::new(|| {
+        Box::new(|state| {
+            state
+                .state_queries()
+                .push_state_root(state.state().state_root())
+                .unwrap()
+        })
+    })
+}
+
+pub fn on_tx<
+    A: State,
+    B: NewPayloadId,
+    C: BlockHash,
+    D: BlockRepository<Storage = SharedStorage>,
+    E: BaseGasFee,
+    F: CreateL1GasFee,
+    G: CreateL2GasFee,
+    H: BaseTokenAccounts,
+>() -> OnTx<A, B, C, D, E, F, G, H> {
+    StateActor::on_tx_noop()
+}
+
+pub fn on_payload<
+    A: State,
+    B: NewPayloadId,
+    C: BlockHash,
+    D: BlockRepository<Storage = SharedStorage>,
+    E: BaseGasFee,
+    F: CreateL1GasFee,
+    G: CreateL2GasFee,
+    H: BaseTokenAccounts,
+>() -> OnPayload<A, B, C, D, E, F, G, H> {
+    Box::new(|| {
+        Box::new(|state, id, hash| state.payload_queries().add_block_hash(id, hash).unwrap())
+    })
+}
+
+pub fn transaction_repository() -> TransactionRepository {
+    transaction::HeedTransactionRepository
+}
+
+pub fn transaction_queries() -> TransactionQueries {
+    transaction::HeedTransactionQueries
+}
+
+pub fn receipt_repository() -> ReceiptRepository {
+    receipt::HeedReceiptRepository
+}
+
+pub fn receipt_queries() -> ReceiptQueries {
+    receipt::HeedReceiptQueries
+}
+
+pub fn receipt_memory() -> ReceiptStorage {
+    db()
+}
+
+pub fn block_queries() -> BlockQueries {
+    block::HeedBlockQueries
+}
+
+pub fn payload_queries() -> PayloadQueries {
+    payload::HeedPayloadQueries::new(db())
+}
+
+lazy_static::lazy_static! {
+    static ref Database: moved_storage_heed::Env = {
+        create_db()
+    };
+}
+
+fn db() -> &'static moved_storage_heed::Env {
+    &Database
+}
+
+fn create_db() -> moved_storage_heed::Env {
+    assert_eq!(moved_storage_heed::DATABASES.len(), 9);
+
+    let path = "db";
+
+    if std::fs::exists(path).unwrap() {
+        std::fs::remove_dir_all(path)
+            .expect("Removing non-empty database directory should succeed");
+    }
+    std::fs::create_dir(path).unwrap();
+
+    let env = unsafe {
+        EnvOpenOptions::new()
+            .max_dbs(moved_storage_heed::DATABASES.len() as u32)
+            .map_size(1024 * 1024 * 1024 * 1024) // 1 TiB
+            .open(path)
+            .expect("Database dir should be accessible")
+    };
+
+    {
+        let mut transaction = env.write_txn().expect("Transaction should be exclusive");
+
+        let _: block::Db = env
+            .create_database(&mut transaction, Some(block::DB))
+            .expect("Database should be new");
+        let _: block::HeightDb = env
+            .create_database(&mut transaction, Some(block::HEIGHT_DB))
+            .expect("Database should be new");
+        let _: state::Db = env
+            .create_database(&mut transaction, Some(state::DB))
+            .expect("Database should be new");
+        let _: state::HeightDb = env
+            .create_database(&mut transaction, Some(state::HEIGHT_DB))
+            .expect("Database should be new");
+        let _: trie::Db = env
+            .create_database(&mut transaction, Some(trie::DB))
+            .expect("Database should be new");
+        let _: trie::RootDb = env
+            .create_database(&mut transaction, Some(trie::ROOT_DB))
+            .expect("Database should be new");
+        let _: transaction::Db = env
+            .create_database(&mut transaction, Some(transaction::DB))
+            .expect("Database should be new");
+        let _: receipt::Db = env
+            .create_database(&mut transaction, Some(receipt::DB))
+            .expect("Database should be new");
+        let _: payload::Db = env
+            .create_database(&mut transaction, Some(payload::DB))
+            .expect("Database should be new");
+
+        transaction.commit().expect("Transaction should succeed");
+    }
+
+    env
+}

--- a/server/src/dependency/mod.rs
+++ b/server/src/dependency/mod.rs
@@ -1,10 +1,14 @@
-#[cfg(not(feature = "storage"))]
+#[cfg(feature = "storage-lmdb")]
+pub use heed::*;
+#[cfg(all(not(feature = "storage"), not(feature = "storage-lmdb")))]
 pub use in_memory::*;
-#[cfg(feature = "storage")]
+#[cfg(all(feature = "storage", not(feature = "storage-lmdb")))]
 pub use rocksdb::*;
 
-#[cfg(not(feature = "storage"))]
+#[cfg(feature = "storage-lmdb")]
+mod heed;
+#[cfg(all(not(feature = "storage"), not(feature = "storage-lmdb")))]
 mod in_memory;
-#[cfg(feature = "storage")]
+#[cfg(all(feature = "storage", not(feature = "storage-lmdb")))]
 mod rocksdb;
 mod shared;

--- a/storage/heed/Cargo.toml
+++ b/storage/heed/Cargo.toml
@@ -14,3 +14,5 @@ moved-blockchain.workspace = true
 moved-execution.workspace = true
 moved-shared.workspace = true
 moved-state.workspace = true
+serde.workspace = true
+serde_json.workspace = true

--- a/storage/heed/src/all.rs
+++ b/storage/heed/src/all.rs
@@ -1,0 +1,26 @@
+use crate::{block, payload, receipt, state, transaction, trie};
+
+pub const DATABASES: [&str; 9] = [
+    block::DB,
+    block::HEIGHT_DB,
+    state::DB,
+    state::HEIGHT_DB,
+    trie::DB,
+    trie::ROOT_DB,
+    transaction::DB,
+    receipt::DB,
+    payload::DB,
+];
+
+#[cfg(test)]
+mod tests {
+    use {super::*, std::collections::HashSet};
+
+    #[test]
+    fn test_databases_have_unique_names() {
+        let expected_unique_len = DATABASES.len();
+        let actual_unique_len = HashSet::from(DATABASES).len();
+
+        assert_eq!(actual_unique_len, expected_unique_len);
+    }
+}

--- a/storage/heed/src/block.rs
+++ b/storage/heed/src/block.rs
@@ -1,17 +1,18 @@
 use {
     crate::{
-        generic::{EncodableB256, EncodableU64},
-        transaction::{EncodableTransaction, TRANSACTION_DB},
+        generic::{EncodableB256, EncodableU64, SerdeJson},
+        transaction,
     },
-    heed::types::SerdeBincode,
     moved_blockchain::block::{BlockQueries, BlockRepository, BlockResponse, ExtendedBlock},
     moved_shared::primitives::B256,
 };
 
-pub const BLOCK_DB: &str = "block";
-pub const HEIGHT_DB: &str = "height";
+pub type Db = heed::Database<EncodableB256, EncodableBlock>;
+pub type HeightDb = heed::Database<EncodableU64, EncodableB256>;
+pub type EncodableBlock = SerdeJson<ExtendedBlock>;
 
-pub type EncodableBlock = SerdeBincode<ExtendedBlock>;
+pub const DB: &str = "block";
+pub const HEIGHT_DB: &str = "height";
 
 #[derive(Debug)]
 pub struct HeedBlockRepository;
@@ -23,27 +24,33 @@ impl BlockRepository for HeedBlockRepository {
     fn add(&mut self, env: &mut Self::Storage, block: ExtendedBlock) -> Result<(), Self::Err> {
         let mut transaction = env.write_txn()?;
 
-        let db: heed::Database<EncodableB256, EncodableBlock> = env
-            .open_database(&transaction, Some(BLOCK_DB))?
+        let db: Db = env
+            .open_database(&transaction, Some(DB))?
             .expect("Block database should exist");
 
         db.put(&mut transaction, &block.hash, &block)?;
 
-        let db: heed::Database<EncodableU64, EncodableB256> = env
+        let db: HeightDb = env
             .open_database(&transaction, Some(HEIGHT_DB))?
             .expect("Block height database should exist");
 
-        db.put(&mut transaction, &block.block.header.number, &block.hash)
+        db.put(&mut transaction, &block.block.header.number, &block.hash)?;
+
+        transaction.commit()
     }
 
     fn by_hash(&self, env: &Self::Storage, hash: B256) -> Result<Option<ExtendedBlock>, Self::Err> {
         let transaction = env.read_txn()?;
 
-        let db: heed::Database<EncodableB256, EncodableBlock> = env
-            .open_database(&transaction, Some(BLOCK_DB))?
+        let db: Db = env
+            .open_database(&transaction, Some(DB))?
             .expect("Block database should exist");
 
-        db.get(&transaction, &hash)
+        let response = db.get(&transaction, &hash);
+
+        transaction.commit()?;
+
+        response
     }
 }
 
@@ -60,31 +67,39 @@ impl BlockQueries for HeedBlockQueries {
         hash: B256,
         include_transactions: bool,
     ) -> Result<Option<BlockResponse>, Self::Err> {
-        let transaction = env.read_txn()?;
+        let db_transaction = env.read_txn()?;
 
-        let db: heed::Database<EncodableB256, EncodableBlock> = env
-            .open_database(&transaction, Some(BLOCK_DB))?
+        let db: Db = env
+            .open_database(&db_transaction, Some(DB))?
             .expect("Block database should exist");
 
-        let block = db.get(&transaction, &hash)?;
+        let block = db.get(&db_transaction, &hash)?;
 
         Ok(Some(match block {
             Some(block) if include_transactions => {
-                let db_transaction = env.read_txn()?;
-
-                let db: heed::Database<EncodableB256, EncodableTransaction> = env
-                    .open_database(&db_transaction, Some(TRANSACTION_DB))?
+                let db: transaction::Db = env
+                    .open_database(&db_transaction, Some(transaction::DB))?
                     .expect("Transaction database should exist");
 
                 let transactions = block
                     .transaction_hashes()
-                    .filter_map(|hash| db.get(&transaction, &hash).transpose())
+                    .filter_map(|hash| db.get(&db_transaction, &hash).transpose())
                     .collect::<Result<Vec<_>, _>>()?;
+
+                db_transaction.commit()?;
 
                 BlockResponse::from_block_with_transactions(block, transactions)
             }
-            Some(block) => BlockResponse::from_block_with_transaction_hashes(block),
-            None => return Ok(None),
+            Some(block) => {
+                db_transaction.commit()?;
+
+                BlockResponse::from_block_with_transaction_hashes(block)
+            }
+            None => {
+                db_transaction.commit()?;
+
+                return Ok(None);
+            }
         }))
     }
 
@@ -96,12 +111,15 @@ impl BlockQueries for HeedBlockQueries {
     ) -> Result<Option<BlockResponse>, Self::Err> {
         let transaction = env.read_txn()?;
 
-        let db: heed::Database<EncodableU64, EncodableB256> = env
+        let db: HeightDb = env
             .open_database(&transaction, Some(HEIGHT_DB))?
             .expect("Block height database should exist");
 
         db.get(&transaction, &height)?
-            .map(|hash| self.by_hash(env, hash, include_transactions))
+            .map(|hash| {
+                transaction.commit()?;
+                self.by_hash(env, hash, include_transactions)
+            })
             .unwrap_or(Ok(None))
     }
 }

--- a/storage/heed/src/generic.rs
+++ b/storage/heed/src/generic.rs
@@ -5,6 +5,7 @@ use {
         BoxedError, BytesDecode, BytesEncode,
     },
     moved_shared::primitives::B256,
+    serde::{Deserialize, Serialize},
     std::borrow::Cow,
 };
 
@@ -29,3 +30,32 @@ impl<'item> BytesDecode<'item> for EncodableB256 {
 
 pub type EncodableU64 = U64<LittleEndian>;
 pub type EncodableBytes = Bytes;
+
+/// Describes a type that is [`Serialize`]/[`Deserialize`] and uses `serde_json` to do so.
+pub struct SerdeJson<T>(std::marker::PhantomData<T>);
+
+impl<'a, T: 'a> BytesEncode<'a> for SerdeJson<T>
+where
+    T: Serialize,
+{
+    type EItem = T;
+
+    fn bytes_encode(item: &'a Self::EItem) -> Result<Cow<'a, [u8]>, BoxedError> {
+        serde_json::to_vec(item).map(Cow::Owned).map_err(Into::into)
+    }
+}
+
+impl<'a, T: 'a> BytesDecode<'a> for SerdeJson<T>
+where
+    T: Deserialize<'a>,
+{
+    type DItem = T;
+
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, BoxedError> {
+        serde_json::from_slice(bytes).map_err(Into::into)
+    }
+}
+
+unsafe impl<T> Send for SerdeJson<T> {}
+
+unsafe impl<T> Sync for SerdeJson<T> {}

--- a/storage/heed/src/lib.rs
+++ b/storage/heed/src/lib.rs
@@ -1,5 +1,11 @@
+pub use {
+    all::DATABASES,
+    heed::{self, Env},
+};
+
+mod all;
 pub mod block;
-mod generic;
+pub mod generic;
 pub mod payload;
 pub mod receipt;
 pub mod state;


### PR DESCRIPTION
### Description
Follows-up on previous PRs about LMDB implementation and integrates it with the server into an executable binary.

### Changes
- Add `server` configuration with `heed` storage
- Add transaction commit per database call
- Create LMDB environment with 1 TiB total size limit

### Testing
Long running `docker compose down && docker compose build && docker compose up -d`

Collecting statistics using `pidstat`

### Notes
To run with LMDB:
```
cargo run --bin op-move --features storage-lmdb
```