### PR TITLE
build: Mention storage backend name in the feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ moved-genesis = { path = "genesis" }
 moved-genesis-image = { path = "genesis-image" }
 moved-shared = { path = "shared" }
 moved-state = { path = "state" }
-moved-storage = { package = "moved-storage-rocksdb", path = "storage/rocksdb" }
+moved-storage-rocksdb = { path = "storage/rocksdb" }
 moved-storage-heed = { path = "storage/heed" }
 once_cell = "1.19"
 op-alloy = { version = "0.6", features = ["full", "std", "k256", "serde"] }

--- a/docker/Dockerfile.op-move
+++ b/docker/Dockerfile.op-move
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
 # RocksDB breaks the build with libclang.so not found https://github.com/apache/skywalking/issues/10439
 # Aptos-core breaks the build with `disable_lifo_slot` not found https://github.com/aptos-labs/aptos-core/issues/5655 \
     RUSTFLAGS="-C target-feature=-crt-static --cfg tokio_unstable" \
-    cargo build --bin op-move --release --features storage-lmdb \
+    cargo build --bin op-move --release --features storage \
     && mv target/release/op-move /volume/op-move
 
 # Switch to clean image

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2021"
 
 [features]
 default = []
-storage = ["moved-storage"]
+storage = ["storage-lmdb"]
 storage-lmdb = ["moved-storage-heed"]
+storage-rocksdb = ["moved-storage-rocksdb"]
 
 [dependencies]
 anyhow.workspace = true
@@ -28,10 +29,10 @@ moved-execution.workspace = true
 moved-genesis.workspace = true
 moved-shared.workspace = true
 moved-state.workspace = true
-moved-storage.optional = true
-moved-storage.workspace = true
 moved-storage-heed.optional = true
 moved-storage-heed.workspace = true
+moved-storage-rocksdb.optional = true
+moved-storage-rocksdb.workspace = true
 once_cell.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/server/src/dependency/mod.rs
+++ b/server/src/dependency/mod.rs
@@ -1,14 +1,14 @@
 #[cfg(feature = "storage-lmdb")]
 pub use heed::*;
-#[cfg(all(not(feature = "storage"), not(feature = "storage-lmdb")))]
+#[cfg(all(not(feature = "storage-rocksdb"), not(feature = "storage-lmdb")))]
 pub use in_memory::*;
-#[cfg(all(feature = "storage", not(feature = "storage-lmdb")))]
+#[cfg(all(feature = "storage-rocksdb", not(feature = "storage-lmdb")))]
 pub use rocksdb::*;
 
 #[cfg(feature = "storage-lmdb")]
 mod heed;
-#[cfg(all(not(feature = "storage"), not(feature = "storage-lmdb")))]
+#[cfg(all(not(feature = "storage-rocksdb"), not(feature = "storage-lmdb")))]
 mod in_memory;
-#[cfg(all(feature = "storage", not(feature = "storage-lmdb")))]
+#[cfg(all(feature = "storage-rocksdb", not(feature = "storage-lmdb")))]
 mod rocksdb;
 mod shared;


### PR DESCRIPTION
### Description
It is no longer clear from just `storage` flag what persistent backend it is pointing to, since there are now multiple.

To make the feature flag names consistent and explicit, this PR unifies the naming.

Addresses https://github.com/MovedNetwork/op-move/pull/294#discussion_r1976258219

The reasoning behind the naming is explained here https://github.com/MovedNetwork/op-move/pull/294#discussion_r1976523224

### Changes
- Rename the old `storage` flag to `storage-rocksdb` to make it clear which backend it is poiting to.
- Add `storage` flag pointing to `storage-lmdb` as the default storage backend.

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt
