### PR TITLE
feat(storage-heed): Wrap database in a custom type

### DIFF
--- a/storage/heed/src/all.rs
+++ b/storage/heed/src/all.rs
@@ -1,4 +1,7 @@
-use crate::{block, payload, receipt, state, transaction, trie};
+use {
+    crate::{block, payload, receipt, state, transaction, trie},
+    heed::{types::LazyDecode, BytesDecode, BytesEncode, RoTxn, RwTxn},
+};
 
 pub const DATABASES: [&str; 9] = [
     block::DB,
@@ -11,6 +14,40 @@ pub const DATABASES: [&str; 9] = [
     receipt::DB,
     payload::DB,
 ];
+
+#[derive(Debug)]
+pub struct HeedDb<Key, Value>(pub heed::Database<Key, Value>);
+
+impl<Key, Value> HeedDb<Key, Value> {
+    pub fn put<'a>(
+        &self,
+        txn: &mut RwTxn,
+        key: &'a Key::EItem,
+        value: &'a Value::EItem,
+    ) -> heed::Result<()>
+    where
+        Key: BytesEncode<'a>,
+        Value: BytesEncode<'a>,
+    {
+        self.0.put(txn, key, value)
+    }
+
+    pub fn get<'a, 'txn>(
+        &self,
+        txn: &'txn RoTxn,
+        key: &'a Key::EItem,
+    ) -> heed::Result<Option<Value::DItem>>
+    where
+        Key: BytesEncode<'a>,
+        Value: BytesDecode<'txn>,
+    {
+        self.0.get(txn, key)
+    }
+
+    pub fn lazily_decode_data(&self) -> HeedDb<Key, LazyDecode<Value>> {
+        HeedDb(self.0.lazily_decode_data())
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/storage/heed/src/generic.rs
+++ b/storage/heed/src/generic.rs
@@ -6,7 +6,7 @@ use {
     },
     moved_shared::primitives::B256,
     serde::{Deserialize, Serialize},
-    std::borrow::Cow,
+    std::{borrow::Cow, fmt::Debug},
 };
 
 #[derive(Debug)]

--- a/storage/heed/src/payload.rs
+++ b/storage/heed/src/payload.rs
@@ -1,13 +1,17 @@
 use {
     crate::{
-        block,
+        all::HeedDb,
+        block::HeedBlockExt,
         generic::{EncodableB256, EncodableU64},
     },
+    heed::RoTxn,
     moved_blockchain::payload::{PayloadId, PayloadQueries, PayloadResponse},
     moved_shared::primitives::{ToU64, B256},
 };
 
-pub type Db = heed::Database<EncodableU64, EncodableB256>;
+pub type Key = EncodableU64;
+pub type Value = EncodableB256;
+pub type Db = heed::Database<Key, Value>;
 
 pub const DB: &str = "payload";
 
@@ -24,10 +28,7 @@ impl HeedPayloadQueries {
     pub fn add_block_hash(&self, id: PayloadId, block_hash: B256) -> Result<(), heed::Error> {
         let mut transaction = self.env.write_txn()?;
 
-        let db: Db = self
-            .env
-            .open_database(&transaction, Some(DB))?
-            .expect("Payload database should exist");
+        let db = self.env.payload_database(&transaction)?;
 
         db.put(&mut transaction, &id.to_u64(), &block_hash)?;
 
@@ -46,9 +47,7 @@ impl PayloadQueries for HeedPayloadQueries {
     ) -> Result<Option<PayloadResponse>, Self::Err> {
         let transaction = env.read_txn()?;
 
-        let db: block::Db = env
-            .open_database(&transaction, Some(block::DB))?
-            .expect("Block database should exist");
+        let db = env.block_database(&transaction)?;
 
         let response = db.get(&transaction, &hash);
 
@@ -64,9 +63,7 @@ impl PayloadQueries for HeedPayloadQueries {
     ) -> Result<Option<PayloadResponse>, Self::Err> {
         let transaction = env.read_txn()?;
 
-        let db: Db = env
-            .open_database(&transaction, Some(DB))?
-            .expect("Payload database should exist");
+        let db = env.payload_database(&transaction)?;
 
         db.get(&transaction, &id.to_u64())?
             .map(|hash| {
@@ -74,5 +71,19 @@ impl PayloadQueries for HeedPayloadQueries {
                 self.by_hash(env, hash)
             })
             .unwrap_or(Ok(None))
+    }
+}
+
+pub trait HeedPayloadExt {
+    fn payload_database(&self, rtxn: &RoTxn) -> heed::Result<HeedDb<Key, Value>>;
+}
+
+impl HeedPayloadExt for heed::Env {
+    fn payload_database(&self, rtxn: &RoTxn) -> heed::Result<HeedDb<Key, Value>> {
+        let db: Db = self
+            .open_database(rtxn, Some(DB))?
+            .expect("Payload database should exist");
+
+        Ok(HeedDb(db))
     }
 }

--- a/storage/heed/src/transaction.rs
+++ b/storage/heed/src/transaction.rs
@@ -1,12 +1,18 @@
 use {
-    crate::generic::{EncodableB256, SerdeJson},
+    crate::{
+        all::HeedDb,
+        generic::{EncodableB256, SerdeJson},
+    },
+    heed::RoTxn,
     moved_blockchain::transaction::{
         ExtendedTransaction, TransactionQueries, TransactionRepository, TransactionResponse,
     },
     moved_shared::primitives::B256,
 };
 
-pub type Db = heed::Database<EncodableB256, EncodableTransaction>;
+pub type Key = EncodableB256;
+pub type Value = EncodableTransaction;
+pub type Db = heed::Database<Key, Value>;
 pub type EncodableTransaction = SerdeJson<ExtendedTransaction>;
 
 pub const DB: &str = "transaction";
@@ -25,9 +31,7 @@ impl TransactionRepository for HeedTransactionRepository {
     ) -> Result<(), Self::Err> {
         let mut db_transaction = env.write_txn()?;
 
-        let db: Db = env
-            .open_database(&db_transaction, Some(DB))?
-            .expect("Transaction database should exist");
+        let db = env.transaction_database(&db_transaction)?;
 
         transactions.into_iter().try_for_each(|transaction| {
             db.put(&mut db_transaction, &transaction.hash(), &transaction)
@@ -51,14 +55,26 @@ impl TransactionQueries for HeedTransactionQueries {
     ) -> Result<Option<TransactionResponse>, Self::Err> {
         let transaction = env.read_txn()?;
 
-        let db: Db = env
-            .open_database(&transaction, Some(DB))?
-            .expect("Transaction database should exist");
+        let db = env.transaction_database(&transaction)?;
 
         let response = db.get(&transaction, &hash)?.map(TransactionResponse::from);
 
         transaction.commit()?;
 
         Ok(response)
+    }
+}
+
+pub trait HeedTransactionExt {
+    fn transaction_database(&self, rtxn: &RoTxn) -> heed::Result<HeedDb<Key, Value>>;
+}
+
+impl HeedTransactionExt for heed::Env {
+    fn transaction_database(&self, rtxn: &RoTxn) -> heed::Result<HeedDb<Key, Value>> {
+        let db: Db = self
+            .open_database(rtxn, Some(DB))?
+            .expect("Transaction database should exist");
+
+        Ok(HeedDb(db))
     }
 }


### PR DESCRIPTION
### Description
Having a custom type for a database gives us a better modeling opportunities. It allows us to only permit behavior that we expect to be using. Thanks to zero-cost abstractions, this comes at no performance cost.

What's more it gives us a better control and transparency over which calls are being made. When all the calls to database go through our type, we can extend the calls to always include our custom behavior. For example, we can log every call or place a debugger breakpoint in there. This helps to debug a performance issue, for example.

It also reduces code duplication of redundant database opening calls and error handling.

### Changes
- Add wrapper type for `heed::Database`
- Add extension traits for opening known databases
- Implement extension traits for `heed::Env`

### Testing
:green_circle: Build
:green_circle: Test   
:green_circle: Clippy
:green_circle: Rustfmt
:green_circle: `docker-compose down && docker-compose build && docker-compose up -d`