### PR TITLE
Fix: Simplify cloud logs and get eth_estimateGas tx input data

### DIFF
--- a/docker/Dockerfile.geth
+++ b/docker/Dockerfile.geth
@@ -45,9 +45,10 @@ COPY docker/wait-for-it.sh /usr/local/bin/wait-for-it
 COPY docker/prefund.sh prefund.sh
 COPY .env .env
 COPY docker/geth.sh entrypoint.sh
+COPY docker/keystore.sh keystore.sh
 COPY docker/geth-init.sh geth-init.sh
 
 # Set entrypoint to geth binary
-RUN chmod +x entrypoint.sh /usr/local/bin/wait-for-it prefund.sh geth-init.sh
+RUN chmod +x entrypoint.sh /usr/local/bin/wait-for-it prefund.sh keystore.sh geth-init.sh
 
 ENTRYPOINT [ "/volume/entrypoint.sh" ]

--- a/docker/geth.sh
+++ b/docker/geth.sh
@@ -6,10 +6,12 @@
 # -x Print out command arguments during execution
 set -eux
 L1_DATADIR="./l1_datadir"
+KEYFILE="89d740330e773e42edf98bba1d8d1d6c545d78a6"
 
 # In case of restart, data dir will not be empty
 # Wipe it to avoid an attempt to restore the state which is not persisted in `--dev` mode
-rm -rf "${L1_DATADIR}" && mkdir -p "${L1_DATADIR}"
+rm -rf "${L1_DATADIR}" && mkdir -p "${L1_DATADIR}" && mkdir -p "${L1_DATADIR}/keystore"
+echo '{"address":"89d740330e773e42edf98bba1d8d1d6c545d78a6","crypto":{"cipher":"aes-128-ctr","ciphertext":"755bbdc3f7bed78a5434fcce4dc118795dd049b0538084c3ce12a91035b32c60","cipherparams":{"iv":"22e00eec04c8d117ad12c0b2924f6a6b"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":4096,"p":6,"r":8,"salt":"cab7899fd54ef0164f572aa41b3941d366ccd38ec624d06ee4e8ee088ef4da3d"},"mac":"0b0a2137144d1efdea0083a22e265300a11bf0d3e5b55285f4ce366a8eb1f8bf"},"id":"52f30552-f758-4cd0-97d4-7f957b51ef30","version":3}' > "${L1_DATADIR}/keystore/${KEYFILE}"
 
 ./geth-init.sh &
 

--- a/docker/geth.sh
+++ b/docker/geth.sh
@@ -6,14 +6,12 @@
 # -x Print out command arguments during execution
 set -eux
 L1_DATADIR="./l1_datadir"
-KEYFILE="89d740330e773e42edf98bba1d8d1d6c545d78a6"
 
 # In case of restart, data dir will not be empty
 # Wipe it to avoid an attempt to restore the state which is not persisted in `--dev` mode
-rm -rf "${L1_DATADIR}" && mkdir -p "${L1_DATADIR}" && mkdir -p "${L1_DATADIR}/keystore"
-echo '{"address":"89d740330e773e42edf98bba1d8d1d6c545d78a6","crypto":{"cipher":"aes-128-ctr","ciphertext":"755bbdc3f7bed78a5434fcce4dc118795dd049b0538084c3ce12a91035b32c60","cipherparams":{"iv":"22e00eec04c8d117ad12c0b2924f6a6b"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":4096,"p":6,"r":8,"salt":"cab7899fd54ef0164f572aa41b3941d366ccd38ec624d06ee4e8ee088ef4da3d"},"mac":"0b0a2137144d1efdea0083a22e265300a11bf0d3e5b55285f4ce366a8eb1f8bf"},"id":"52f30552-f758-4cd0-97d4-7f957b51ef30","version":3}' > "${L1_DATADIR}/keystore/${KEYFILE}"
+rm -rf "${L1_DATADIR}" && mkdir -p "${L1_DATADIR}"
 
-./geth-init.sh &
+./keystore.sh & ./geth-init.sh &
 
 # Ephemeral proof-of-authority network with a pre-funded developer account,
 # with automatic mining when there are pending transactions.

--- a/docker/keystore.sh
+++ b/docker/keystore.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Serve with the same keystore file so the faucet address doesn't change
+
+KEYSTORE_DIR="./l1_datadir/keystore"
+KEYFILE="UTC--2025-01-01T00-00-00.000000000Z--89d740330e773e42edf98bba1d8d1d6c545d78a6"
+
+mkdir -p "${KEYSTORE_DIR}"
+
+cat > "${KEYSTORE_DIR}/${KEYFILE}" <<EOL
+{
+  "address": "89d740330e773e42edf98bba1d8d1d6c545d78a6",
+  "crypto": {
+    "cipher": "aes-128-ctr",
+    "ciphertext": "755bbdc3f7bed78a5434fcce4dc118795dd049b0538084c3ce12a91035b32c60",
+    "cipherparams": { "iv": "22e00eec04c8d117ad12c0b2924f6a6b" },
+    "kdf": "scrypt",
+    "kdfparams": {
+      "dklen": 32,
+      "n": 4096,
+      "p": 6,
+      "r": 8,
+      "salt": "cab7899fd54ef0164f572aa41b3941d366ccd38ec624d06ee4e8ee088ef4da3d"
+    },
+    "mac": "0b0a2137144d1efdea0083a22e265300a11bf0d3e5b55285f4ce366a8eb1f8bf"
+  },
+  "id": "52f30552-f758-4cd0-97d4-7f957b51ef30",
+  "version": 3
+}
+
+EOL

--- a/execution/src/transaction.rs
+++ b/execution/src/transaction.rs
@@ -463,7 +463,7 @@ impl From<TransactionRequest> for NormalizedEthTransaction {
                 value.max_priority_fee_per_gas.unwrap_or_default(),
             ),
             max_fee_per_gas: U256::from(value.max_fee_per_gas.unwrap_or_default()),
-            data: value.input.input.unwrap_or_default(),
+            data: value.input.into_input().unwrap_or_default(),
             access_list: value.access_list.unwrap_or_default(),
         }
     }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -295,10 +295,7 @@ async fn mirror(
                 match serde_json::from_slice::<serde_json::Value>(&bytes) {
                     Ok(parsed_response) => (parts, raw_bytes, parsed_response),
                     Err(_) => {
-                        println!(
-                            "Request: {}",
-                            serde_json::to_string_pretty(&request.unwrap()).unwrap()
-                        );
+                        println!("Request: {:?}", &request);
                         println!("headers: {headers:?}");
                         println!("WARN: op-geth non-json response: {:?}", bytes);
                         let body = hyper::Body::from(bytes);
@@ -318,7 +315,7 @@ async fn mirror(
         op_move_response: &op_move_response,
         port,
     };
-    println!("{}", serde_json::to_string_pretty(&log).unwrap());
+    println!("{}", serde_json::to_string(&log).unwrap());
 
     // TODO: this is a hack because we currently can't compute the genesis
     // hash expected by op-node.


### PR DESCRIPTION
### Description
A few fixes combined.

### Changes
- Cloud logs are better when they are in a single line
- `eth_estimateGas` transaction input can come from either `input` or `data`
- Serve the Devnet with the same key file so the faucet address doesn't change

### Testing
✓ Docker works
✓ Hardhat is able to deploy by calling `eth_estimateGas`
✓ Cloud logs come through one request at a time, instead of each line in the request JSON being split into a separate log