### PR TITLE
Fix(integration-test): Separate thread for heartbeat

### DIFF
--- a/server/src/tests/integration.rs
+++ b/server/src/tests/integration.rs
@@ -89,7 +89,7 @@ async fn test_on_ethereum() -> Result<()> {
     deploy_move_counter().await?;
 
     // 12. Cleanup generated files and folders
-    hb.shutdown().await;
+    hb.shutdown();
     cleanup_files();
     op_move_runtime.shutdown_background();
     cleanup_processes(vec![geth, op_geth, op_node, op_batcher, op_proposer])

--- a/server/src/tests/integration/heartbeat.rs
+++ b/server/src/tests/integration/heartbeat.rs
@@ -2,7 +2,16 @@
 //! This heartbeat ensures that the L1 makes regular progress and this is
 //! necessary because it is an assumption the proposer makes.
 
-use {super::*, tokio::task::JoinHandle};
+use {
+    super::*,
+    std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        thread::JoinHandle,
+    },
+};
 
 pub const ADDRESS: Address = address!("88f9b82462f6c4bf4a0fb15e5c3971559a316e7f");
 const SK: [u8; 32] = [0xbb; 32];
@@ -10,48 +19,57 @@ const TARGET: Address = address!("1111111111111111111111222222222222222222");
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(3);
 
 pub struct HeartbeatTask {
+    should_stop: Arc<AtomicBool>,
     inner: JoinHandle<anyhow::Result<()>>,
 }
 
 impl HeartbeatTask {
     pub fn new() -> Self {
-        let inner = tokio::spawn(async {
-            let signer = PrivateKeySigner::from_slice(&SK).unwrap();
-            let provider = ProviderBuilder::new()
-                .with_recommended_fillers()
-                .wallet(EthereumWallet::from(signer))
-                .on_http(Url::parse(&var("L1_RPC_URL")?)?);
-            let amount = U256::from(100_u64);
-            loop {
-                let tx = provider
-                    .transaction_request()
-                    .to(TARGET)
-                    .value(amount)
-                    .gas_limit(21_000);
-                let pending = provider
-                    .send_transaction(tx)
-                    .await
-                    .inspect_err(|e| println!("HEARTBEAT ERROR {e}"))?;
-                let _tx_hash = pending
-                    .watch()
-                    .await
-                    .inspect_err(|e| println!("HEARTBEAT ERROR {e}"))?;
-                tokio::time::sleep(HEARTBEAT_INTERVAL).await;
-            }
+        let should_stop = Arc::new(AtomicBool::new(false));
+        let thread_stop = Arc::clone(&should_stop);
+        let inner = std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?;
+            runtime.block_on(async {
+                let signer = PrivateKeySigner::from_slice(&SK).unwrap();
+                let provider = ProviderBuilder::new()
+                    .with_recommended_fillers()
+                    .wallet(EthereumWallet::from(signer))
+                    .on_http(Url::parse(&var("L1_RPC_URL")?)?);
+                let amount = U256::from(100_u64);
+                loop {
+                    if thread_stop.load(Ordering::Relaxed) {
+                        return Ok(());
+                    }
+                    let tx = provider
+                        .transaction_request()
+                        .to(TARGET)
+                        .value(amount)
+                        .gas_limit(21_000);
+                    let pending = provider
+                        .send_transaction(tx)
+                        .await
+                        .inspect_err(|e| println!("HEARTBEAT ERROR {e:?}"))?;
+                    let _tx_hash = pending
+                        .with_required_confirmations(0)
+                        .with_timeout(Some(HEARTBEAT_INTERVAL / 2))
+                        .watch()
+                        .await
+                        .inspect_err(|e| println!("HEARTBEAT ERROR {e:?}"))?;
+                    tokio::time::sleep(HEARTBEAT_INTERVAL).await;
+                }
+            })
         });
 
-        Self { inner }
+        Self { should_stop, inner }
     }
 
-    pub async fn shutdown(self) {
-        self.inner.abort();
-        tokio::select! {
-            join_result = self.inner => {
-                join_result.expect_err("Task aborted");
-            }
-            _ = tokio::time::sleep(Duration::from_secs(30)) => {
-                println!("WARN: failed to shutdown heartbeat task within 30s");
-            }
+    pub fn shutdown(self) {
+        self.should_stop.store(true, Ordering::Relaxed);
+        let join_result = self.inner.join().expect("Heartbeat thread should complete");
+        if let Err(e) = join_result {
+            println!("HEARTBEAT ERROR {e:?}");
         }
     }
 }


### PR DESCRIPTION
### Description
I was finding the integration test could be flaky because of the heartbeat task getting stuck for some reason. So I made some changes to try to make it more reliable. This PR has no impact on any production code.

### Changes
- Integration test heartbeat process now happens in a separate thread with its own tokio runtime

### Testing
- Integration test