### PR TITLE
Feat(server): Send content type header in the response

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -31,7 +31,7 @@ use {
     },
     tokio::sync::mpsc,
     warp::{
-        http::StatusCode,
+        http::{header::CONTENT_TYPE, HeaderMap, HeaderValue, StatusCode},
         hyper::{body::Bytes, Body, Response},
         path::FullPath,
         Filter, Rejection, Reply,
@@ -94,6 +94,8 @@ pub async fn run() {
 
     let http_state_channel = state_channel.clone();
     let http_server_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 8545));
+    let mut content_type = HeaderMap::new();
+    content_type.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
     let http_route = warp::any()
         .map(move || http_state_channel.clone())
         .and(extract_request_data_filter())
@@ -106,6 +108,7 @@ pub async fn run() {
                 MethodName::is_non_engine_api,
             )
         })
+        // .with(warp::reply::with::headers(content_type))
         .with(warp::cors().allow_any_origin());
 
     let auth_state_channel = state_channel;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -108,7 +108,7 @@ pub async fn run() {
                 MethodName::is_non_engine_api,
             )
         })
-        // .with(warp::reply::with::headers(content_type))
+        .with(warp::reply::with::headers(content_type))
         .with(warp::cors().allow_any_origin());
 
     let auth_state_channel = state_channel;


### PR DESCRIPTION
### Description
Start sending custom headers in a `map` starting with the `Content-Type: application/json` header.

### Changes
- Send `Content-Type` header in server response to clients only for now.

### Testing
REST clients detect the content type and parse the response automatically accordingly. Here's how the response shows up on a client:

| With Header | Without |
|--|--|
| <img width="432" alt="Screenshot 2025-03-12 at 2 52 55 PM" src="https://github.com/user-attachments/assets/439ae900-2957-4f8c-a8a3-ebaef6cda25d" /> | <img width="430" alt="Screenshot 2025-03-12 at 2 55 27 PM" src="https://github.com/user-attachments/assets/6cb6e16b-f6f1-4b68-8378-41270857d545" /> |