### PR TITLE
perf: Generate payload ID before starting block build

### DIFF
--- a/api/src/methods/get_block_by_number.rs
+++ b/api/src/methods/get_block_by_number.rs
@@ -39,7 +39,7 @@ async fn inner_execute(
 mod tests {
     use {
         super::*, crate::methods::tests::create_state_actor, alloy::eips::BlockNumberOrTag::*,
-        moved_app::Command, test_case::test_case,
+        moved_app::Command, moved_shared::primitives::U64, test_case::test_case,
     };
 
     pub fn example_request(tag: BlockNumberOrTag) -> serde_json::Value {
@@ -107,10 +107,9 @@ mod tests {
         assert_eq!(get_block_number_from_response(response), "0x0");
 
         // Create a block, so the block height becomes 1
-        let (tx, _) = oneshot::channel();
         let msg = Command::StartBlockBuild {
             payload_attributes: Default::default(),
-            response_channel: tx,
+            payload_id: U64::from(0x03421ee50df45cacu64),
         }
         .into();
         state_channel.send(msg).await.unwrap();
@@ -129,10 +128,9 @@ mod tests {
         let (state, state_channel) = create_state_actor();
         let state_handle = state.spawn();
 
-        let (tx, _) = oneshot::channel();
         let msg = Command::StartBlockBuild {
             payload_attributes: Default::default(),
-            response_channel: tx,
+            payload_id: U64::from(0x03421ee50df45cacu64),
         }
         .into();
         state_channel.send(msg).await.unwrap();

--- a/api/src/methods/get_payload.rs
+++ b/api/src/methods/get_payload.rs
@@ -120,7 +120,6 @@ mod tests {
             head_hash,
             0,
             genesis_config,
-            0x03421ee50df45cacu64,
             head_hash,
             repository,
             Eip1559GasFee::default(),
@@ -154,6 +153,7 @@ mod tests {
         forkchoice_updated::execute_v3(
             forkchoice_updated::tests::example_request(),
             state_channel.clone(),
+            &0x03421ee50df45cacu64,
         )
         .await
         .unwrap();

--- a/api/src/methods/get_transaction_by_hash.rs
+++ b/api/src/methods/get_transaction_by_hash.rs
@@ -68,6 +68,7 @@ mod tests {
             forkchoice_updated::execute_v3(
                 forkchoice_updated::tests::example_request(),
                 state_channel.clone(),
+                &0x03421ee50df45cacu64,
             )
             .await
             .unwrap(),

--- a/api/src/methods/get_transaction_receipt.rs
+++ b/api/src/methods/get_transaction_receipt.rs
@@ -65,6 +65,7 @@ mod tests {
             forkchoice_updated::execute_v3(
                 forkchoice_updated::tests::example_request(),
                 state_channel.clone(),
+                &0x03421ee50df45cacu64,
             )
             .await
             .unwrap(),

--- a/api/src/methods/mod.rs
+++ b/api/src/methods/mod.rs
@@ -36,7 +36,7 @@ pub mod tests {
                 InMemoryBlockQueries, InMemoryBlockRepository, MovedBlockHash,
             },
             in_memory::SharedMemory,
-            payload::{InMemoryPayloadQueries, NewPayloadId, PayloadQueries},
+            payload::{InMemoryPayloadQueries, PayloadQueries},
             receipt::{
                 InMemoryReceiptQueries, InMemoryReceiptRepository, ReceiptMemory, ReceiptQueries,
                 ReceiptRepository,
@@ -55,10 +55,7 @@ pub mod tests {
         moved_genesis::config::{GenesisConfig, CHAIN_ID},
         moved_shared::primitives::{Address, B256, U256, U64},
         moved_state::InMemoryState,
-        tokio::sync::{
-            mpsc::{self, Sender},
-            oneshot,
-        },
+        tokio::sync::mpsc::{self, Sender},
     };
 
     /// The address corresponding to this private key is 0x8fd379246834eac74B8419FfdA202CF8051F7A03
@@ -96,7 +93,6 @@ pub mod tests {
             head_hash,
             0,
             genesis_config,
-            0x03421ee50df45cacu64,
             MovedBlockHash,
             repository,
             Eip1559GasFee::default(),
@@ -138,14 +134,12 @@ pub mod tests {
         let mut payload_attributes = Payload::default();
         payload_attributes.transactions.push(encoded.into());
 
-        let (sender, receiver) = oneshot::channel();
         let msg = Command::StartBlockBuild {
             payload_attributes,
-            response_channel: sender,
+            payload_id: U64::from(0x03421ee50df45cacu64),
         }
         .into();
         channel.send(msg).await.map_err(access_state_error).unwrap();
-        receiver.await.map_err(access_state_error).unwrap();
     }
 
     pub async fn deploy_contract(contract_bytes: Bytes, channel: &Sender<StateMessage>) {
@@ -171,14 +165,12 @@ pub mod tests {
         let mut payload_attributes = Payload::default();
         payload_attributes.transactions.push(encoded.into());
 
-        let (sender, receiver) = oneshot::channel();
         let msg = Command::StartBlockBuild {
             payload_attributes,
-            response_channel: sender,
+            payload_id: U64::from(0x03421ee50df45cacu64),
         }
         .into();
         channel.send(msg).await.map_err(access_state_error).unwrap();
-        receiver.await.map_err(access_state_error).unwrap();
     }
 
     pub fn create_state_actor_with_mock_state_queries(
@@ -187,7 +179,6 @@ pub mod tests {
     ) -> (
         StateActor<
             InMemoryState,
-            impl NewPayloadId,
             impl BlockHash,
             impl BlockRepository<Storage = ()>,
             impl BaseGasFee,
@@ -216,7 +207,6 @@ pub mod tests {
             )),
             height,
             GenesisConfig::default(),
-            0x03421ee50df45cacu64,
             MovedBlockHash,
             (),
             Eip1559GasFee::default(),

--- a/api/src/methods/new_payload.rs
+++ b/api/src/methods/new_payload.rs
@@ -282,7 +282,6 @@ mod tests {
             head_hash,
             0,
             genesis_config,
-            0x0306d51fc5aa1533u64,
             B256::from(hex!(
                 "c013e1ff1b8bca9f0d074618cc9e661983bc91d7677168b156765781aee775d3"
             )),
@@ -384,9 +383,13 @@ mod tests {
         )
         .unwrap();
 
-        forkchoice_updated::execute_v3(fc_updated_request, state_channel.clone())
-            .await
-            .unwrap();
+        forkchoice_updated::execute_v3(
+            fc_updated_request,
+            state_channel.clone(),
+            &0x0306d51fc5aa1533u64,
+        )
+        .await
+        .unwrap();
 
         get_payload::execute_v3(get_payload_request, state_channel.clone())
             .await

--- a/app/src/input.rs
+++ b/app/src/input.rs
@@ -42,7 +42,7 @@ pub enum Command {
     },
     StartBlockBuild {
         payload_attributes: Payload,
-        response_channel: oneshot::Sender<PayloadId>,
+        payload_id: PayloadId,
     },
     AddTransaction {
         tx: TxEnvelope,
@@ -160,7 +160,7 @@ impl WithExecutionOutcome for Header {
     }
 }
 
-pub(crate) trait ToPayloadIdInput<'a> {
+pub trait ToPayloadIdInput<'a> {
     fn to_payload_id_input(&'a self, head: &'a B256) -> NewPayloadIdInput<'a>;
 }
 

--- a/server/src/dependency/heed.rs
+++ b/server/src/dependency/heed.rs
@@ -1,9 +1,6 @@
 use {
     crate::dependency::shared::*,
-    moved_blockchain::{
-        block::{BaseGasFee, BlockHash, BlockRepository, MovedBlockHash},
-        payload::NewPayloadId,
-    },
+    moved_blockchain::block::{BaseGasFee, BlockHash, BlockRepository, MovedBlockHash},
     moved_execution::{BaseTokenAccounts, CreateL1GasFee, CreateL2GasFee, MovedBaseTokenAccounts},
     moved_genesis::config::GenesisConfig,
     moved_state::State,
@@ -51,15 +48,14 @@ pub fn state_query(genesis_config: &GenesisConfig) -> StateQueries {
 }
 
 pub fn on_tx_batch<
-    A: State,
-    B: NewPayloadId,
-    C: BlockHash,
-    D: BlockRepository<Storage = SharedStorage>,
-    E: BaseGasFee,
-    F: CreateL1GasFee,
-    G: CreateL2GasFee,
-    H: BaseTokenAccounts,
->() -> OnTxBatch<A, B, C, D, E, F, G, H> {
+    S: State,
+    BH: BlockHash,
+    BR: BlockRepository<Storage = SharedStorage>,
+    Fee: BaseGasFee,
+    L1F: CreateL1GasFee,
+    L2F: CreateL2GasFee,
+    Token: BaseTokenAccounts,
+>() -> OnTxBatch<S, BH, BR, Fee, L1F, L2F, Token> {
     Box::new(|| {
         Box::new(|state| {
             state
@@ -71,28 +67,26 @@ pub fn on_tx_batch<
 }
 
 pub fn on_tx<
-    A: State,
-    B: NewPayloadId,
-    C: BlockHash,
-    D: BlockRepository<Storage = SharedStorage>,
-    E: BaseGasFee,
-    F: CreateL1GasFee,
-    G: CreateL2GasFee,
-    H: BaseTokenAccounts,
->() -> OnTx<A, B, C, D, E, F, G, H> {
+    S: State,
+    BH: BlockHash,
+    BR: BlockRepository<Storage = SharedStorage>,
+    Fee: BaseGasFee,
+    L1F: CreateL1GasFee,
+    L2F: CreateL2GasFee,
+    Token: BaseTokenAccounts,
+>() -> OnTx<S, BH, BR, Fee, L1F, L2F, Token> {
     StateActor::on_tx_noop()
 }
 
 pub fn on_payload<
-    A: State,
-    B: NewPayloadId,
-    C: BlockHash,
-    D: BlockRepository<Storage = SharedStorage>,
-    E: BaseGasFee,
-    F: CreateL1GasFee,
-    G: CreateL2GasFee,
-    H: BaseTokenAccounts,
->() -> OnPayload<A, B, C, D, E, F, G, H> {
+    S: State,
+    BH: BlockHash,
+    BR: BlockRepository<Storage = SharedStorage>,
+    Fee: BaseGasFee,
+    L1F: CreateL1GasFee,
+    L2F: CreateL2GasFee,
+    Token: BaseTokenAccounts,
+>() -> OnPayload<S, BH, BR, Fee, L1F, L2F, Token> {
     Box::new(|| {
         Box::new(|state, id, hash| state.payload_queries().add_block_hash(id, hash).unwrap())
     })

--- a/server/src/dependency/in_memory.rs
+++ b/server/src/dependency/in_memory.rs
@@ -1,9 +1,6 @@
 use {
     crate::dependency::shared::*,
-    moved_blockchain::{
-        block::{BaseGasFee, BlockHash, BlockRepository, MovedBlockHash},
-        payload::NewPayloadId,
-    },
+    moved_blockchain::block::{BaseGasFee, BlockHash, BlockRepository, MovedBlockHash},
     moved_execution::{BaseTokenAccounts, CreateL1GasFee, CreateL2GasFee, MovedBaseTokenAccounts},
     moved_genesis::config::GenesisConfig,
     moved_state::State,
@@ -47,41 +44,38 @@ pub fn state_query(genesis_config: &GenesisConfig) -> StateQueries {
 }
 
 pub fn on_tx_batch<
-    A: State,
-    B: NewPayloadId,
-    C: BlockHash,
-    D: BlockRepository<Storage = SharedStorage>,
-    E: BaseGasFee,
-    F: CreateL1GasFee,
-    G: CreateL2GasFee,
-    H: BaseTokenAccounts,
->() -> OnTxBatch<A, B, C, D, E, F, G, H> {
+    S: State,
+    BH: BlockHash,
+    BR: BlockRepository<Storage = SharedStorage>,
+    Fee: BaseGasFee,
+    L1F: CreateL1GasFee,
+    L2F: CreateL2GasFee,
+    Token: BaseTokenAccounts,
+>() -> OnTxBatch<S, BH, BR, Fee, L1F, L2F, Token> {
     moved_app::StateActor::on_tx_batch_in_memory()
 }
 
 pub fn on_tx<
-    A: State,
-    B: NewPayloadId,
-    C: BlockHash,
-    D: BlockRepository<Storage = SharedStorage>,
-    E: BaseGasFee,
-    F: CreateL1GasFee,
-    G: CreateL2GasFee,
-    H: BaseTokenAccounts,
->() -> OnTx<A, B, C, D, E, F, G, H> {
+    S: State,
+    BH: BlockHash,
+    BR: BlockRepository<Storage = SharedStorage>,
+    Fee: BaseGasFee,
+    L1F: CreateL1GasFee,
+    L2F: CreateL2GasFee,
+    Token: BaseTokenAccounts,
+>() -> OnTx<S, BH, BR, Fee, L1F, L2F, Token> {
     moved_app::StateActor::on_tx_in_memory()
 }
 
 pub fn on_payload<
-    A: State,
-    B: NewPayloadId,
-    C: BlockHash,
-    D: BlockRepository<Storage = SharedStorage>,
-    E: BaseGasFee,
-    F: CreateL1GasFee,
-    G: CreateL2GasFee,
-    H: BaseTokenAccounts,
->() -> OnPayload<A, B, C, D, E, F, G, H> {
+    S: State,
+    BH: BlockHash,
+    BR: BlockRepository<Storage = SharedStorage>,
+    Fee: BaseGasFee,
+    L1F: CreateL1GasFee,
+    L2F: CreateL2GasFee,
+    Token: BaseTokenAccounts,
+>() -> OnPayload<S, BH, BR, Fee, L1F, L2F, Token> {
     moved_app::StateActor::on_payload_in_memory()
 }
 

--- a/server/src/dependency/rocksdb.rs
+++ b/server/src/dependency/rocksdb.rs
@@ -1,9 +1,6 @@
 use {
     crate::dependency::shared::*,
-    moved_blockchain::{
-        block::{BaseGasFee, BlockHash, BlockRepository, MovedBlockHash},
-        payload::NewPayloadId,
-    },
+    moved_blockchain::block::{BaseGasFee, BlockHash, BlockRepository, MovedBlockHash},
     moved_execution::{BaseTokenAccounts, CreateL1GasFee, CreateL2GasFee, MovedBaseTokenAccounts},
     moved_genesis::config::GenesisConfig,
     moved_state::State,
@@ -52,15 +49,14 @@ pub fn state_query(genesis_config: &GenesisConfig) -> StateQueries {
 }
 
 pub fn on_tx_batch<
-    A: State,
-    B: NewPayloadId,
-    C: BlockHash,
-    D: BlockRepository<Storage = SharedStorage>,
-    E: BaseGasFee,
-    F: CreateL1GasFee,
-    G: CreateL2GasFee,
-    H: BaseTokenAccounts,
->() -> OnTxBatch<A, B, C, D, E, F, G, H> {
+    S: State,
+    BH: BlockHash,
+    BR: BlockRepository<Storage = SharedStorage>,
+    Fee: BaseGasFee,
+    L1F: CreateL1GasFee,
+    L2F: CreateL2GasFee,
+    Token: BaseTokenAccounts,
+>() -> OnTxBatch<S, BH, BR, Fee, L1F, L2F, Token> {
     Box::new(|| {
         Box::new(|state| {
             state
@@ -72,28 +68,26 @@ pub fn on_tx_batch<
 }
 
 pub fn on_tx<
-    A: State,
-    B: NewPayloadId,
-    C: BlockHash,
-    D: BlockRepository<Storage = SharedStorage>,
-    E: BaseGasFee,
-    F: CreateL1GasFee,
-    G: CreateL2GasFee,
-    H: BaseTokenAccounts,
->() -> OnTx<A, B, C, D, E, F, G, H> {
+    S: State,
+    BH: BlockHash,
+    BR: BlockRepository<Storage = SharedStorage>,
+    Fee: BaseGasFee,
+    L1F: CreateL1GasFee,
+    L2F: CreateL2GasFee,
+    Token: BaseTokenAccounts,
+>() -> OnTx<S, BH, BR, Fee, L1F, L2F, Token> {
     moved_app::StateActor::on_tx_noop()
 }
 
 pub fn on_payload<
-    A: State,
-    B: NewPayloadId,
-    C: BlockHash,
-    D: BlockRepository<Storage = SharedStorage>,
-    E: BaseGasFee,
-    F: CreateL1GasFee,
-    G: CreateL2GasFee,
-    H: BaseTokenAccounts,
->() -> OnPayload<A, B, C, D, E, F, G, H> {
+    S: State,
+    BH: BlockHash,
+    BR: BlockRepository<Storage = SharedStorage>,
+    Fee: BaseGasFee,
+    L1F: CreateL1GasFee,
+    L2F: CreateL2GasFee,
+    Token: BaseTokenAccounts,
+>() -> OnPayload<S, BH, BR, Fee, L1F, L2F, Token> {
     Box::new(|| {
         Box::new(|state, id, hash| state.payload_queries().add_block_hash(id, hash).unwrap())
     })

--- a/server/src/dependency/shared.rs
+++ b/server/src/dependency/shared.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(super) type StateActor<A, B, C, D, E, F, G, H> = moved_app::StateActor<
+pub(super) type StateActor<A, B, C, D, E, F, G> = moved_app::StateActor<
     A,
     B,
     C,
@@ -8,7 +8,6 @@ pub(super) type StateActor<A, B, C, D, E, F, G, H> = moved_app::StateActor<
     E,
     F,
     G,
-    H,
     BlockQueries,
     SharedStorage,
     StateQueries,
@@ -20,8 +19,8 @@ pub(super) type StateActor<A, B, C, D, E, F, G, H> = moved_app::StateActor<
     PayloadQueries,
     StorageTrieRepository,
 >;
-pub(super) type OnTxBatch<A, B, C, D, E, F, G, H> =
-    moved_app::OnTxBatch<StateActor<A, B, C, D, E, F, G, H>>;
-pub(super) type OnTx<A, B, C, D, E, F, G, H> = moved_app::OnTx<StateActor<A, B, C, D, E, F, G, H>>;
-pub(super) type OnPayload<A, B, C, D, E, F, G, H> =
-    moved_app::OnPayload<StateActor<A, B, C, D, E, F, G, H>>;
+pub(super) type OnTxBatch<A, B, C, D, E, F, G> =
+    moved_app::OnTxBatch<StateActor<A, B, C, D, E, F, G>>;
+pub(super) type OnTx<A, B, C, D, E, F, G> = moved_app::OnTx<StateActor<A, B, C, D, E, F, G>>;
+pub(super) type OnPayload<A, B, C, D, E, F, G> =
+    moved_app::OnPayload<StateActor<A, B, C, D, E, F, G>>;

--- a/server/src/tests/get_proof.rs
+++ b/server/src/tests/get_proof.rs
@@ -6,7 +6,7 @@ use {
         Status,
     },
     moved_app::StateMessage,
-    moved_blockchain::state::ProofResponse,
+    moved_blockchain::{payload::StatePayloadId, state::ProofResponse},
     moved_evm_ext::state,
     moved_genesis::config::GenesisConfig,
     serde::de::DeserializeOwned,
@@ -156,8 +156,13 @@ async fn handle_request<T: DeserializeOwned>(
     request: serde_json::Value,
     state_channel: &mpsc::Sender<StateMessage>,
 ) -> anyhow::Result<T> {
-    let response =
-        moved_api::request::handle(request.clone(), state_channel.clone(), |_| true).await;
+    let response = moved_api::request::handle(
+        request.clone(),
+        state_channel.clone(),
+        |_| true,
+        &StatePayloadId,
+    )
+    .await;
 
     if let Some(error) = response.error {
         anyhow::bail!("Error response from request {request:?}: {error:?}");


### PR DESCRIPTION
# About
Unblocks forkchoice API handler from waiting on generated payload ID.

From a general point of view, unblocks any API handler that sends commands from waiting on response as no command should have a response to begin with. This PR makes it so that this invariant holds true.

# Motivation
The application layer receives two different kinds of messages. 

* **Queries:** Immutable and always returns value
* **Commands:** Mutable and never returns value

Working with this assumption, the commands are always handled asynchronously in a background task and do not block the thread that dispatched it - the RPC API method handler. In this way the method handler can return without waiting for the task to finish as there is no reason to wait.

This assumption, however, is broken by one command, which is the `StartBlockBuild`.

# Problem
When sending `StartBlockBuild` to the asynchronous queue for processing, it requires us to wait for its response using a `oneshot` channel. This effectively makes the background task block as if it was foreground.

What's more the request is not being processed immediately as there might be older unprocessed messages in the queue. This makes the API wait for the whole message queue to be processed before it can return a response.

# Solution
Instead of making the command handler responsible for generating the payload ID, make it receive the payload ID and move the responsibility to the layer above. The API handler generates payload ID and returns it in its response. Now there is no need for the command to have a response or for it to block the API handler.

To posses the ability to generate payload IDs, the API delegates this to an abstract dependency. It works the same way as when called from the `StateActor`. It is now simply a dependency of the API handler instead.

# Changes
- Remove `NewPayloadId` dependency from `StateActor`
- Add `NewPayloadId` dependency to `forkchoiceUpdated` request handler
- Remove `oneshot` response sender from `Command::StartBlockBuild`
- Add payload ID to `Command::StartBlockBuild`
- Remove waiting on `oneshot` response receiver when sending `Command::StartBlockBuild` by directly returning the generated ID

# Testing
:green_circle: Build
:green_circle: Test
:green_circle: Clippy
:green_circle: Rustfmt
:green_circle: `docker compose down && docker compose build && docker compose up -d`
