### PR TITLE
fix(move): do not encode empty args

### DIFF
--- a/genesis-builder/framework/l2/sources/BaseFeeVault.move
+++ b/genesis-builder/framework/l2/sources/BaseFeeVault.move
@@ -1,113 +1,83 @@
 module BaseFeeVault::base_fee_vault {
     use aptos_framework::fungible_asset_u256::zero;
     use EthToken::eth_token::get_metadata;
-    use Evm::evm::{abi_encode_params, emit_evm_logs, evm_call, is_result_success, EvmResult};
+    use Evm::evm::{emit_evm_logs, evm_call, is_result_success, EvmResult};
     use std::error;
 
     const ENOT_SUCCESS: u64 = 1;
 
-    struct MinWithdrawalAmountArgs {}
 
     public fun min_withdrawal_amount(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = MinWithdrawalAmountArgs {};
+        let data = vector[211, 229, 121, 43];
 
-        let data = abi_encode_params(
-            vector[211, 229, 121, 43],
-            arg_struct,
-        );
         let result = evm_call(caller, @BaseFeeVault, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct RecipientArgs {}
 
     public fun recipient(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = RecipientArgs {};
+        let data = vector[13, 144, 25, 225];
 
-        let data = abi_encode_params(
-            vector[13, 144, 25, 225],
-            arg_struct,
-        );
         let result = evm_call(caller, @BaseFeeVault, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct WithdrawalNetworkArgs {}
 
     public fun withdrawal_network(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = WithdrawalNetworkArgs {};
+        let data = vector[208, 225, 47, 144];
 
-        let data = abi_encode_params(
-            vector[208, 225, 47, 144],
-            arg_struct,
-        );
         let result = evm_call(caller, @BaseFeeVault, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct TotalProcessedArgs {}
 
     public fun total_processed(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = TotalProcessedArgs {};
+        let data = vector[132, 65, 29, 101];
 
-        let data = abi_encode_params(
-            vector[132, 65, 29, 101],
-            arg_struct,
-        );
         let result = evm_call(caller, @BaseFeeVault, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct VersionArgs {}
 
     public fun version(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = VersionArgs {};
+        let data = vector[84, 253, 77, 80];
 
-        let data = abi_encode_params(
-            vector[84, 253, 77, 80],
-            arg_struct,
-        );
         let result = evm_call(caller, @BaseFeeVault, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct WithdrawArgs {}
 
     public fun withdraw(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = WithdrawArgs {};
+        let data = vector[60, 207, 214, 11];
 
-        let data = abi_encode_params(
-            vector[60, 207, 214, 11],
-            arg_struct,
-        );
         let result = evm_call(caller, @BaseFeeVault, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);

--- a/genesis-builder/framework/l2/sources/CrossL2Inbox.move
+++ b/genesis-builder/framework/l2/sources/CrossL2Inbox.move
@@ -14,36 +14,26 @@ module CrossL2Inbox::cross_l2_inbox {
         chain_id: u256,
     }
 
-    struct BlockNumberArgs {}
 
     public fun block_number(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = BlockNumberArgs {};
+        let data = vector[87, 232, 113, 231];
 
-        let data = abi_encode_params(
-            vector[87, 232, 113, 231],
-            arg_struct,
-        );
         let result = evm_call(caller, @CrossL2Inbox, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct ChainIdArgs {}
 
     public fun chain_id(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = ChainIdArgs {};
+        let data = vector[154, 138, 5, 146];
 
-        let data = abi_encode_params(
-            vector[154, 138, 5, 146],
-            arg_struct,
-        );
         let result = evm_call(caller, @CrossL2Inbox, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -73,78 +63,59 @@ module CrossL2Inbox::cross_l2_inbox {
             vector[89, 132, 197, 62],
             arg_struct,
         );
+
         let result = evm_call(caller, @CrossL2Inbox, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct LogIndexArgs {}
 
     public fun log_index(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = LogIndexArgs {};
+        let data = vector[218, 153, 247, 41];
 
-        let data = abi_encode_params(
-            vector[218, 153, 247, 41],
-            arg_struct,
-        );
         let result = evm_call(caller, @CrossL2Inbox, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct OriginArgs {}
 
     public fun origin(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = OriginArgs {};
+        let data = vector[147, 139, 95, 50];
 
-        let data = abi_encode_params(
-            vector[147, 139, 95, 50],
-            arg_struct,
-        );
         let result = evm_call(caller, @CrossL2Inbox, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct TimestampArgs {}
 
     public fun timestamp(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = TimestampArgs {};
+        let data = vector[184, 7, 119, 234];
 
-        let data = abi_encode_params(
-            vector[184, 7, 119, 234],
-            arg_struct,
-        );
         let result = evm_call(caller, @CrossL2Inbox, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct VersionArgs {}
 
     public fun version(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = VersionArgs {};
+        let data = vector[84, 253, 77, 80];
 
-        let data = abi_encode_params(
-            vector[84, 253, 77, 80],
-            arg_struct,
-        );
         let result = evm_call(caller, @CrossL2Inbox, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);

--- a/genesis-builder/framework/l2/sources/GasPriceOracle.move
+++ b/genesis-builder/framework/l2/sources/GasPriceOracle.move
@@ -6,108 +6,78 @@ module GasPriceOracle::gas_price_oracle {
 
     const ENOT_SUCCESS: u64 = 1;
 
-    struct DecimalsArgs {}
 
     public fun decimals(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = DecimalsArgs {};
+        let data = vector[46, 15, 38, 37];
 
-        let data = abi_encode_params(
-            vector[46, 15, 38, 37],
-            arg_struct,
-        );
         let result = evm_call(caller, @GasPriceOracle, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct BaseFeeArgs {}
 
     public fun base_fee(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = BaseFeeArgs {};
+        let data = vector[110, 242, 92, 58];
 
-        let data = abi_encode_params(
-            vector[110, 242, 92, 58],
-            arg_struct,
-        );
         let result = evm_call(caller, @GasPriceOracle, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct BaseFeeScalarArgs {}
 
     public fun base_fee_scalar(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = BaseFeeScalarArgs {};
+        let data = vector[197, 152, 89, 24];
 
-        let data = abi_encode_params(
-            vector[197, 152, 89, 24],
-            arg_struct,
-        );
         let result = evm_call(caller, @GasPriceOracle, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct BlobBaseFeeArgs {}
 
     public fun blob_base_fee(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = BlobBaseFeeArgs {};
+        let data = vector[248, 32, 97, 64];
 
-        let data = abi_encode_params(
-            vector[248, 32, 97, 64],
-            arg_struct,
-        );
         let result = evm_call(caller, @GasPriceOracle, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct BlobBaseFeeScalarArgs {}
 
     public fun blob_base_fee_scalar(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = BlobBaseFeeScalarArgs {};
+        let data = vector[104, 213, 220, 166];
 
-        let data = abi_encode_params(
-            vector[104, 213, 220, 166],
-            arg_struct,
-        );
         let result = evm_call(caller, @GasPriceOracle, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct GasPriceArgs {}
 
     public fun gas_price(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = GasPriceArgs {};
+        let data = vector[254, 23, 59, 151];
 
-        let data = abi_encode_params(
-            vector[254, 23, 59, 151],
-            arg_struct,
-        );
         let result = evm_call(caller, @GasPriceOracle, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -131,6 +101,7 @@ module GasPriceOracle::gas_price_oracle {
             vector[73, 148, 142, 14],
             arg_struct,
         );
+
         let result = evm_call(caller, @GasPriceOracle, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -154,6 +125,7 @@ module GasPriceOracle::gas_price_oracle {
             vector[241, 199, 165, 139],
             arg_struct,
         );
+
         let result = evm_call(caller, @GasPriceOracle, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -177,150 +149,111 @@ module GasPriceOracle::gas_price_oracle {
             vector[222, 38, 196, 161],
             arg_struct,
         );
+
         let result = evm_call(caller, @GasPriceOracle, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct IsEcotoneArgs {}
 
     public fun is_ecotone(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = IsEcotoneArgs {};
+        let data = vector[78, 246, 226, 36];
 
-        let data = abi_encode_params(
-            vector[78, 246, 226, 36],
-            arg_struct,
-        );
         let result = evm_call(caller, @GasPriceOracle, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct IsFjordArgs {}
 
     public fun is_fjord(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = IsFjordArgs {};
+        let data = vector[150, 14, 58, 35];
 
-        let data = abi_encode_params(
-            vector[150, 14, 58, 35],
-            arg_struct,
-        );
         let result = evm_call(caller, @GasPriceOracle, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct L1BaseFeeArgs {}
 
     public fun l1_base_fee(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = L1BaseFeeArgs {};
+        let data = vector[81, 155, 75, 211];
 
-        let data = abi_encode_params(
-            vector[81, 155, 75, 211],
-            arg_struct,
-        );
         let result = evm_call(caller, @GasPriceOracle, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct OverheadArgs {}
 
     public fun overhead(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = OverheadArgs {};
+        let data = vector[12, 24, 193, 98];
 
-        let data = abi_encode_params(
-            vector[12, 24, 193, 98],
-            arg_struct,
-        );
         let result = evm_call(caller, @GasPriceOracle, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct ScalarArgs {}
 
     public fun scalar(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = ScalarArgs {};
+        let data = vector[244, 94, 101, 216];
 
-        let data = abi_encode_params(
-            vector[244, 94, 101, 216],
-            arg_struct,
-        );
         let result = evm_call(caller, @GasPriceOracle, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct SetEcotoneArgs {}
 
     public fun set_ecotone(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = SetEcotoneArgs {};
+        let data = vector[34, 185, 10, 179];
 
-        let data = abi_encode_params(
-            vector[34, 185, 10, 179],
-            arg_struct,
-        );
         let result = evm_call(caller, @GasPriceOracle, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct SetFjordArgs {}
 
     public fun set_fjord(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = SetFjordArgs {};
+        let data = vector[142, 152, 177, 6];
 
-        let data = abi_encode_params(
-            vector[142, 152, 177, 6],
-            arg_struct,
-        );
         let result = evm_call(caller, @GasPriceOracle, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct VersionArgs {}
 
     public fun version(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = VersionArgs {};
+        let data = vector[84, 253, 77, 80];
 
-        let data = abi_encode_params(
-            vector[84, 253, 77, 80],
-            arg_struct,
-        );
         let result = evm_call(caller, @GasPriceOracle, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);

--- a/genesis-builder/framework/l2/sources/GovernanceToken.move
+++ b/genesis-builder/framework/l2/sources/GovernanceToken.move
@@ -6,18 +6,13 @@ module GovernanceToken::governance_token {
 
     const ENOT_SUCCESS: u64 = 1;
 
-    struct DomainSeparatorArgs {}
 
     public fun domain_separator(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = DomainSeparatorArgs {};
+        let data = vector[54, 68, 229, 21];
 
-        let data = abi_encode_params(
-            vector[54, 68, 229, 21],
-            arg_struct,
-        );
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -44,6 +39,7 @@ module GovernanceToken::governance_token {
             vector[221, 98, 237, 62],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -70,6 +66,7 @@ module GovernanceToken::governance_token {
             vector[9, 94, 167, 179],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -93,6 +90,7 @@ module GovernanceToken::governance_token {
             vector[112, 160, 130, 49],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -116,6 +114,7 @@ module GovernanceToken::governance_token {
             vector[66, 150, 108, 104],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -142,6 +141,7 @@ module GovernanceToken::governance_token {
             vector[121, 204, 103, 144],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -168,24 +168,20 @@ module GovernanceToken::governance_token {
             vector[241, 18, 126, 216],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct DecimalsArgs {}
 
     public fun decimals(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = DecimalsArgs {};
+        let data = vector[49, 60, 229, 103];
 
-        let data = abi_encode_params(
-            vector[49, 60, 229, 103],
-            arg_struct,
-        );
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -212,6 +208,7 @@ module GovernanceToken::governance_token {
             vector[164, 87, 194, 215],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -235,6 +232,7 @@ module GovernanceToken::governance_token {
             vector[92, 25, 169, 92],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -273,6 +271,7 @@ module GovernanceToken::governance_token {
             vector[195, 205, 165, 32],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -296,6 +295,7 @@ module GovernanceToken::governance_token {
             vector[88, 124, 222, 30],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -319,6 +319,7 @@ module GovernanceToken::governance_token {
             vector[142, 83, 158, 140],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -345,6 +346,7 @@ module GovernanceToken::governance_token {
             vector[58, 70, 177, 168],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -368,6 +370,7 @@ module GovernanceToken::governance_token {
             vector[154, 178, 78, 176],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -394,6 +397,7 @@ module GovernanceToken::governance_token {
             vector[57, 80, 147, 81],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -420,24 +424,20 @@ module GovernanceToken::governance_token {
             vector[64, 193, 15, 25],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct NameArgs {}
 
     public fun name(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = NameArgs {};
+        let data = vector[6, 253, 222, 3];
 
-        let data = abi_encode_params(
-            vector[6, 253, 222, 3],
-            arg_struct,
-        );
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -461,6 +461,7 @@ module GovernanceToken::governance_token {
             vector[126, 206, 190, 0],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -484,24 +485,20 @@ module GovernanceToken::governance_token {
             vector[111, 207, 255, 69],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct OwnerArgs {}
 
     public fun owner(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = OwnerArgs {};
+        let data = vector[141, 165, 203, 91];
 
-        let data = abi_encode_params(
-            vector[141, 165, 203, 91],
-            arg_struct,
-        );
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -543,60 +540,46 @@ module GovernanceToken::governance_token {
             vector[213, 5, 172, 207],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct RenounceOwnershipArgs {}
 
     public fun renounce_ownership(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = RenounceOwnershipArgs {};
+        let data = vector[113, 80, 24, 166];
 
-        let data = abi_encode_params(
-            vector[113, 80, 24, 166],
-            arg_struct,
-        );
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct SymbolArgs {}
 
     public fun symbol(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = SymbolArgs {};
+        let data = vector[149, 216, 155, 65];
 
-        let data = abi_encode_params(
-            vector[149, 216, 155, 65],
-            arg_struct,
-        );
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct TotalSupplyArgs {}
 
     public fun total_supply(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = TotalSupplyArgs {};
+        let data = vector[24, 22, 13, 221];
 
-        let data = abi_encode_params(
-            vector[24, 22, 13, 221],
-            arg_struct,
-        );
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -623,6 +606,7 @@ module GovernanceToken::governance_token {
             vector[169, 5, 156, 187],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -652,6 +636,7 @@ module GovernanceToken::governance_token {
             vector[35, 184, 114, 221],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -675,6 +660,7 @@ module GovernanceToken::governance_token {
             vector[242, 253, 227, 139],
             arg_struct,
         );
+
         let result = evm_call(caller, @GovernanceToken, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);

--- a/genesis-builder/framework/l2/sources/L1Block.move
+++ b/genesis-builder/framework/l2/sources/L1Block.move
@@ -6,270 +6,195 @@ module L1Block::l1_block {
 
     const ENOT_SUCCESS: u64 = 1;
 
-    struct DepositorAccountArgs {}
 
     public fun depositor_account(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = DepositorAccountArgs {};
+        let data = vector[229, 145, 178, 130];
 
-        let data = abi_encode_params(
-            vector[229, 145, 178, 130],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct BaseFeeScalarArgs {}
 
     public fun base_fee_scalar(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = BaseFeeScalarArgs {};
+        let data = vector[197, 152, 89, 24];
 
-        let data = abi_encode_params(
-            vector[197, 152, 89, 24],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct BasefeeArgs {}
 
     public fun basefee(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = BasefeeArgs {};
+        let data = vector[92, 242, 73, 105];
 
-        let data = abi_encode_params(
-            vector[92, 242, 73, 105],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct BatcherHashArgs {}
 
     public fun batcher_hash(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = BatcherHashArgs {};
+        let data = vector[232, 27, 44, 109];
 
-        let data = abi_encode_params(
-            vector[232, 27, 44, 109],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct BlobBaseFeeArgs {}
 
     public fun blob_base_fee(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = BlobBaseFeeArgs {};
+        let data = vector[248, 32, 97, 64];
 
-        let data = abi_encode_params(
-            vector[248, 32, 97, 64],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct BlobBaseFeeScalarArgs {}
 
     public fun blob_base_fee_scalar(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = BlobBaseFeeScalarArgs {};
+        let data = vector[104, 213, 220, 166];
 
-        let data = abi_encode_params(
-            vector[104, 213, 220, 166],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct GasPayingTokenArgs {}
 
     public fun gas_paying_token(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = GasPayingTokenArgs {};
+        let data = vector[67, 151, 223, 239];
 
-        let data = abi_encode_params(
-            vector[67, 151, 223, 239],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct GasPayingTokenNameArgs {}
 
     public fun gas_paying_token_name(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = GasPayingTokenNameArgs {};
+        let data = vector[216, 68, 71, 21];
 
-        let data = abi_encode_params(
-            vector[216, 68, 71, 21],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct GasPayingTokenSymbolArgs {}
 
     public fun gas_paying_token_symbol(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = GasPayingTokenSymbolArgs {};
+        let data = vector[85, 15, 205, 201];
 
-        let data = abi_encode_params(
-            vector[85, 15, 205, 201],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct HashArgs {}
 
     public fun hash(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = HashArgs {};
+        let data = vector[9, 189, 90, 96];
 
-        let data = abi_encode_params(
-            vector[9, 189, 90, 96],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct IsCustomGasTokenArgs {}
 
     public fun is_custom_gas_token(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = IsCustomGasTokenArgs {};
+        let data = vector[33, 50, 104, 73];
 
-        let data = abi_encode_params(
-            vector[33, 50, 104, 73],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct L1FeeOverheadArgs {}
 
     public fun l1_fee_overhead(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = L1FeeOverheadArgs {};
+        let data = vector[139, 35, 159, 115];
 
-        let data = abi_encode_params(
-            vector[139, 35, 159, 115],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct L1FeeScalarArgs {}
 
     public fun l1_fee_scalar(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = L1FeeScalarArgs {};
+        let data = vector[158, 140, 73, 102];
 
-        let data = abi_encode_params(
-            vector[158, 140, 73, 102],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct NumberArgs {}
 
     public fun number(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = NumberArgs {};
+        let data = vector[131, 129, 245, 138];
 
-        let data = abi_encode_params(
-            vector[131, 129, 245, 138],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct SequenceNumberArgs {}
 
     public fun sequence_number(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = SequenceNumberArgs {};
+        let data = vector[100, 202, 35, 239];
 
-        let data = abi_encode_params(
-            vector[100, 202, 35, 239],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -302,6 +227,7 @@ module L1Block::l1_block {
             vector[113, 207, 170, 63],
             arg_struct,
         );
+
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -346,60 +272,46 @@ module L1Block::l1_block {
             vector[1, 93, 142, 185],
             arg_struct,
         );
+
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct SetL1BlockValuesEcotoneArgs {}
 
     public fun set_l1_block_values_ecotone(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = SetL1BlockValuesEcotoneArgs {};
+        let data = vector[68, 10, 94, 32];
 
-        let data = abi_encode_params(
-            vector[68, 10, 94, 32],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct TimestampArgs {}
 
     public fun timestamp(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = TimestampArgs {};
+        let data = vector[184, 7, 119, 234];
 
-        let data = abi_encode_params(
-            vector[184, 7, 119, 234],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct VersionArgs {}
 
     public fun version(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = VersionArgs {};
+        let data = vector[84, 253, 77, 80];
 
-        let data = abi_encode_params(
-            vector[84, 253, 77, 80],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1Block, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);

--- a/genesis-builder/framework/l2/sources/L1BlockNumber.move
+++ b/genesis-builder/framework/l2/sources/L1BlockNumber.move
@@ -1,41 +1,31 @@
 module L1BlockNumber::l1_block_number {
     use aptos_framework::fungible_asset_u256::zero;
     use EthToken::eth_token::get_metadata;
-    use Evm::evm::{abi_encode_params, emit_evm_logs, evm_call, is_result_success, EvmResult};
+    use Evm::evm::{emit_evm_logs, evm_call, is_result_success, EvmResult};
     use std::error;
 
     const ENOT_SUCCESS: u64 = 1;
 
-    struct GetL1BlockNumberArgs {}
 
     public fun get_l1_block_number(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = GetL1BlockNumberArgs {};
+        let data = vector[185, 179, 239, 233];
 
-        let data = abi_encode_params(
-            vector[185, 179, 239, 233],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1BlockNumber, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct VersionArgs {}
 
     public fun version(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = VersionArgs {};
+        let data = vector[84, 253, 77, 80];
 
-        let data = abi_encode_params(
-            vector[84, 253, 77, 80],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1BlockNumber, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);

--- a/genesis-builder/framework/l2/sources/L1FeeVault.move
+++ b/genesis-builder/framework/l2/sources/L1FeeVault.move
@@ -1,113 +1,83 @@
 module L1FeeVault::l1_fee_vault {
     use aptos_framework::fungible_asset_u256::zero;
     use EthToken::eth_token::get_metadata;
-    use Evm::evm::{abi_encode_params, emit_evm_logs, evm_call, is_result_success, EvmResult};
+    use Evm::evm::{emit_evm_logs, evm_call, is_result_success, EvmResult};
     use std::error;
 
     const ENOT_SUCCESS: u64 = 1;
 
-    struct MinWithdrawalAmountArgs {}
 
     public fun min_withdrawal_amount(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = MinWithdrawalAmountArgs {};
+        let data = vector[211, 229, 121, 43];
 
-        let data = abi_encode_params(
-            vector[211, 229, 121, 43],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1FeeVault, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct RecipientArgs {}
 
     public fun recipient(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = RecipientArgs {};
+        let data = vector[13, 144, 25, 225];
 
-        let data = abi_encode_params(
-            vector[13, 144, 25, 225],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1FeeVault, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct WithdrawalNetworkArgs {}
 
     public fun withdrawal_network(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = WithdrawalNetworkArgs {};
+        let data = vector[208, 225, 47, 144];
 
-        let data = abi_encode_params(
-            vector[208, 225, 47, 144],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1FeeVault, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct TotalProcessedArgs {}
 
     public fun total_processed(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = TotalProcessedArgs {};
+        let data = vector[132, 65, 29, 101];
 
-        let data = abi_encode_params(
-            vector[132, 65, 29, 101],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1FeeVault, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct VersionArgs {}
 
     public fun version(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = VersionArgs {};
+        let data = vector[84, 253, 77, 80];
 
-        let data = abi_encode_params(
-            vector[84, 253, 77, 80],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1FeeVault, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct WithdrawArgs {}
 
     public fun withdraw(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = WithdrawArgs {};
+        let data = vector[60, 207, 214, 11];
 
-        let data = abi_encode_params(
-            vector[60, 207, 214, 11],
-            arg_struct,
-        );
         let result = evm_call(caller, @L1FeeVault, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);

--- a/genesis-builder/framework/l2/sources/L2CrossDomainMessenger.move
+++ b/genesis-builder/framework/l2/sources/L2CrossDomainMessenger.move
@@ -6,162 +6,117 @@ module L2CrossDomainMessenger::l2_cross_domain_messenger {
 
     const ENOT_SUCCESS: u64 = 1;
 
-    struct MessageVersionArgs {}
 
     public fun message_version(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = MessageVersionArgs {};
+        let data = vector[63, 130, 122, 90];
 
-        let data = abi_encode_params(
-            vector[63, 130, 122, 90],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct MinGasCalldataOverheadArgs {}
 
     public fun min_gas_calldata_overhead(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = MinGasCalldataOverheadArgs {};
+        let data = vector[2, 143, 133, 247];
 
-        let data = abi_encode_params(
-            vector[2, 143, 133, 247],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct MinGasDynamicOverheadDenominatorArgs {}
 
     public fun min_gas_dynamic_overhead_denominator(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = MinGasDynamicOverheadDenominatorArgs {};
+        let data = vector[12, 86, 132, 152];
 
-        let data = abi_encode_params(
-            vector[12, 86, 132, 152],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct MinGasDynamicOverheadNumeratorArgs {}
 
     public fun min_gas_dynamic_overhead_numerator(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = MinGasDynamicOverheadNumeratorArgs {};
+        let data = vector[40, 40, 215, 232];
 
-        let data = abi_encode_params(
-            vector[40, 40, 215, 232],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct OtherMessengerArgs {}
 
     public fun other_messenger(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = OtherMessengerArgs {};
+        let data = vector[159, 206, 129, 44];
 
-        let data = abi_encode_params(
-            vector[159, 206, 129, 44],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct RelayCallOverheadArgs {}
 
     public fun relay_call_overhead(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = RelayCallOverheadArgs {};
+        let data = vector[76, 29, 106, 105];
 
-        let data = abi_encode_params(
-            vector[76, 29, 106, 105],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct RelayConstantOverheadArgs {}
 
     public fun relay_constant_overhead(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = RelayConstantOverheadArgs {};
+        let data = vector[131, 167, 64, 116];
 
-        let data = abi_encode_params(
-            vector[131, 167, 64, 116],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct RelayGasCheckBufferArgs {}
 
     public fun relay_gas_check_buffer(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = RelayGasCheckBufferArgs {};
+        let data = vector[86, 68, 207, 223];
 
-        let data = abi_encode_params(
-            vector[86, 68, 207, 223],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct RelayReservedGasArgs {}
 
     public fun relay_reserved_gas(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = RelayReservedGasArgs {};
+        let data = vector[140, 190, 238, 242];
 
-        let data = abi_encode_params(
-            vector[140, 190, 238, 242],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -188,6 +143,7 @@ module L2CrossDomainMessenger::l2_cross_domain_messenger {
             vector[178, 138, 222, 37],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -211,6 +167,7 @@ module L2CrossDomainMessenger::l2_cross_domain_messenger {
             vector[164, 231, 248, 189],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -234,60 +191,46 @@ module L2CrossDomainMessenger::l2_cross_domain_messenger {
             vector[196, 214, 109, 232],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct L1CrossDomainMessengerArgs {}
 
     public fun l1_cross_domain_messenger(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = L1CrossDomainMessengerArgs {};
+        let data = vector[167, 17, 152, 105];
 
-        let data = abi_encode_params(
-            vector[167, 17, 152, 105],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct MessageNonceArgs {}
 
     public fun message_nonce(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = MessageNonceArgs {};
+        let data = vector[236, 199, 4, 40];
 
-        let data = abi_encode_params(
-            vector[236, 199, 4, 40],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct PausedArgs {}
 
     public fun paused(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = PausedArgs {};
+        let data = vector[92, 151, 90, 187];
 
-        let data = abi_encode_params(
-            vector[92, 151, 90, 187],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -326,6 +269,7 @@ module L2CrossDomainMessenger::l2_cross_domain_messenger {
             vector[215, 100, 173, 11],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -355,6 +299,7 @@ module L2CrossDomainMessenger::l2_cross_domain_messenger {
             vector[61, 187, 32, 43],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -378,42 +323,33 @@ module L2CrossDomainMessenger::l2_cross_domain_messenger {
             vector[177, 177, 178, 9],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct VersionArgs {}
 
     public fun version(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = VersionArgs {};
+        let data = vector[84, 253, 77, 80];
 
-        let data = abi_encode_params(
-            vector[84, 253, 77, 80],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct XDomainMessageSenderArgs {}
 
     public fun x_domain_message_sender(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = XDomainMessageSenderArgs {};
+        let data = vector[110, 41, 110, 69];
 
-        let data = abi_encode_params(
-            vector[110, 41, 110, 69],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);

--- a/genesis-builder/framework/l2/sources/L2ERC721Bridge.move
+++ b/genesis-builder/framework/l2/sources/L2ERC721Bridge.move
@@ -6,36 +6,26 @@ module L2ERC721Bridge::l2_erc721_bridge {
 
     const ENOT_SUCCESS: u64 = 1;
 
-    struct MessengerArgs {}
 
     public fun messenger(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = MessengerArgs {};
+        let data = vector[146, 126, 222, 45];
 
-        let data = abi_encode_params(
-            vector[146, 126, 222, 45],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2ERC721Bridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct OtherBridgeArgs {}
 
     public fun other_bridge(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = OtherBridgeArgs {};
+        let data = vector[127, 70, 221, 178];
 
-        let data = abi_encode_params(
-            vector[127, 70, 221, 178],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2ERC721Bridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -71,6 +61,7 @@ module L2ERC721Bridge::l2_erc721_bridge {
             vector[54, 135, 1, 26],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2ERC721Bridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -109,6 +100,7 @@ module L2ERC721Bridge::l2_erc721_bridge {
             vector[170, 85, 116, 82],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2ERC721Bridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -147,6 +139,7 @@ module L2ERC721Bridge::l2_erc721_bridge {
             vector[118, 31, 68, 147],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2ERC721Bridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -170,42 +163,33 @@ module L2ERC721Bridge::l2_erc721_bridge {
             vector[196, 214, 109, 232],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2ERC721Bridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct PausedArgs {}
 
     public fun paused(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = PausedArgs {};
+        let data = vector[92, 151, 90, 187];
 
-        let data = abi_encode_params(
-            vector[92, 151, 90, 187],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2ERC721Bridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct VersionArgs {}
 
     public fun version(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = VersionArgs {};
+        let data = vector[84, 253, 77, 80];
 
-        let data = abi_encode_params(
-            vector[84, 253, 77, 80],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2ERC721Bridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);

--- a/genesis-builder/framework/l2/sources/L2StandardBridge.move
+++ b/genesis-builder/framework/l2/sources/L2StandardBridge.move
@@ -6,36 +6,26 @@ module L2StandardBridge::l2_standard_bridge {
 
     const ENOT_SUCCESS: u64 = 1;
 
-    struct MessengerArgs {}
 
     public fun messenger(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = MessengerArgs {};
+        let data = vector[146, 126, 222, 45];
 
-        let data = abi_encode_params(
-            vector[146, 126, 222, 45],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2StandardBridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct OtherBridgeArgs {}
 
     public fun other_bridge(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = OtherBridgeArgs {};
+        let data = vector[127, 70, 221, 178];
 
-        let data = abi_encode_params(
-            vector[127, 70, 221, 178],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2StandardBridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -71,6 +61,7 @@ module L2StandardBridge::l2_standard_bridge {
             vector[135, 8, 118, 35],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2StandardBridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -109,6 +100,7 @@ module L2StandardBridge::l2_standard_bridge {
             vector[84, 10, 191, 115],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2StandardBridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -135,6 +127,7 @@ module L2StandardBridge::l2_standard_bridge {
             vector[9, 252, 136, 67],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2StandardBridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -164,6 +157,7 @@ module L2StandardBridge::l2_standard_bridge {
             vector[225, 16, 19, 221],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2StandardBridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -190,6 +184,7 @@ module L2StandardBridge::l2_standard_bridge {
             vector[143, 96, 31, 102],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2StandardBridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -228,6 +223,7 @@ module L2StandardBridge::l2_standard_bridge {
             vector[1, 102, 160, 122],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2StandardBridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -260,6 +256,7 @@ module L2StandardBridge::l2_standard_bridge {
             vector[22, 53, 245, 253],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2StandardBridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -283,60 +280,46 @@ module L2StandardBridge::l2_standard_bridge {
             vector[196, 214, 109, 232],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2StandardBridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct L1TokenBridgeArgs {}
 
     public fun l1_token_bridge(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = L1TokenBridgeArgs {};
+        let data = vector[54, 199, 23, 193];
 
-        let data = abi_encode_params(
-            vector[54, 199, 23, 193],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2StandardBridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct PausedArgs {}
 
     public fun paused(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = PausedArgs {};
+        let data = vector[92, 151, 90, 187];
 
-        let data = abi_encode_params(
-            vector[92, 151, 90, 187],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2StandardBridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct VersionArgs {}
 
     public fun version(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = VersionArgs {};
+        let data = vector[84, 253, 77, 80];
 
-        let data = abi_encode_params(
-            vector[84, 253, 77, 80],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2StandardBridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -369,6 +352,7 @@ module L2StandardBridge::l2_standard_bridge {
             vector[50, 183, 0, 109],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2StandardBridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -404,6 +388,7 @@ module L2StandardBridge::l2_standard_bridge {
             vector[163, 167, 149, 72],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2StandardBridge, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);

--- a/genesis-builder/framework/l2/sources/L2ToL1MessagePasser.move
+++ b/genesis-builder/framework/l2/sources/L2ToL1MessagePasser.move
@@ -6,36 +6,26 @@ module L2ToL1MessagePasser::l2_to_l1_message_passer {
 
     const ENOT_SUCCESS: u64 = 1;
 
-    struct MessageVersionArgs {}
 
     public fun message_version(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = MessageVersionArgs {};
+        let data = vector[63, 130, 122, 90];
 
-        let data = abi_encode_params(
-            vector[63, 130, 122, 90],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2ToL1MessagePasser, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct BurnArgs {}
 
     public fun burn(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = BurnArgs {};
+        let data = vector[68, 223, 142, 112];
 
-        let data = abi_encode_params(
-            vector[68, 223, 142, 112],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2ToL1MessagePasser, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -65,24 +55,20 @@ module L2ToL1MessagePasser::l2_to_l1_message_passer {
             vector[194, 179, 229, 172],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2ToL1MessagePasser, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct MessageNonceArgs {}
 
     public fun message_nonce(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = MessageNonceArgs {};
+        let data = vector[236, 199, 4, 40];
 
-        let data = abi_encode_params(
-            vector[236, 199, 4, 40],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2ToL1MessagePasser, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -106,24 +92,20 @@ module L2ToL1MessagePasser::l2_to_l1_message_passer {
             vector[130, 227, 112, 45],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2ToL1MessagePasser, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct VersionArgs {}
 
     public fun version(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = VersionArgs {};
+        let data = vector[84, 253, 77, 80];
 
-        let data = abi_encode_params(
-            vector[84, 253, 77, 80],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2ToL1MessagePasser, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);

--- a/genesis-builder/framework/l2/sources/L2ToL2CrossDomainMessenger.move
+++ b/genesis-builder/framework/l2/sources/L2ToL2CrossDomainMessenger.move
@@ -6,72 +6,52 @@ module L2ToL2CrossDomainMessenger::l2_to_l2_cross_domain_messenger {
 
     const ENOT_SUCCESS: u64 = 1;
 
-    struct CrossDomainMessageSenderArgs {}
 
     public fun cross_domain_message_sender(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = CrossDomainMessageSenderArgs {};
+        let data = vector[56, 255, 222, 24];
 
-        let data = abi_encode_params(
-            vector[56, 255, 222, 24],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2ToL2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct CrossDomainMessageSourceArgs {}
 
     public fun cross_domain_message_source(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = CrossDomainMessageSourceArgs {};
+        let data = vector[36, 121, 68, 98];
 
-        let data = abi_encode_params(
-            vector[36, 121, 68, 98],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2ToL2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct MessageNonceArgs {}
 
     public fun message_nonce(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = MessageNonceArgs {};
+        let data = vector[236, 199, 4, 40];
 
-        let data = abi_encode_params(
-            vector[236, 199, 4, 40],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2ToL2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct MessageVersionArgs {}
 
     public fun message_version(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = MessageVersionArgs {};
+        let data = vector[82, 97, 127, 60];
 
-        let data = abi_encode_params(
-            vector[82, 97, 127, 60],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2ToL2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -110,6 +90,7 @@ module L2ToL2CrossDomainMessenger::l2_to_l2_cross_domain_messenger {
             vector[30, 205, 38, 242],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2ToL2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -139,6 +120,7 @@ module L2ToL2CrossDomainMessenger::l2_to_l2_cross_domain_messenger {
             vector[112, 86, 244, 31],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2ToL2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -162,24 +144,20 @@ module L2ToL2CrossDomainMessenger::l2_to_l2_cross_domain_messenger {
             vector[177, 177, 178, 9],
             arg_struct,
         );
+
         let result = evm_call(caller, @L2ToL2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct VersionArgs {}
 
     public fun version(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = VersionArgs {};
+        let data = vector[84, 253, 77, 80];
 
-        let data = abi_encode_params(
-            vector[84, 253, 77, 80],
-            arg_struct,
-        );
         let result = evm_call(caller, @L2ToL2CrossDomainMessenger, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);

--- a/genesis-builder/framework/l2/sources/OptimismMintableERC20Factory.move
+++ b/genesis-builder/framework/l2/sources/OptimismMintableERC20Factory.move
@@ -6,18 +6,13 @@ module OptimismMintableERC20Factory::optimism_mintable_erc20_factory {
 
     const ENOT_SUCCESS: u64 = 1;
 
-    struct BridgeArgs {}
 
     public fun bridge(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = BridgeArgs {};
+        let data = vector[238, 154, 49, 162];
 
-        let data = abi_encode_params(
-            vector[238, 154, 49, 162],
-            arg_struct,
-        );
         let result = evm_call(caller, @OptimismMintableERC20Factory, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -47,6 +42,7 @@ module OptimismMintableERC20Factory::optimism_mintable_erc20_factory {
             vector[206, 90, 201, 15],
             arg_struct,
         );
+
         let result = evm_call(caller, @OptimismMintableERC20Factory, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -79,6 +75,7 @@ module OptimismMintableERC20Factory::optimism_mintable_erc20_factory {
             vector[140, 240, 98, 156],
             arg_struct,
         );
+
         let result = evm_call(caller, @OptimismMintableERC20Factory, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -108,6 +105,7 @@ module OptimismMintableERC20Factory::optimism_mintable_erc20_factory {
             vector[137, 111, 147, 209],
             arg_struct,
         );
+
         let result = evm_call(caller, @OptimismMintableERC20Factory, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -131,24 +129,20 @@ module OptimismMintableERC20Factory::optimism_mintable_erc20_factory {
             vector[196, 214, 109, 232],
             arg_struct,
         );
+
         let result = evm_call(caller, @OptimismMintableERC20Factory, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct VersionArgs {}
 
     public fun version(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = VersionArgs {};
+        let data = vector[84, 253, 77, 80];
 
-        let data = abi_encode_params(
-            vector[84, 253, 77, 80],
-            arg_struct,
-        );
         let result = evm_call(caller, @OptimismMintableERC20Factory, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);

--- a/genesis-builder/framework/l2/sources/OptimismMintableERC721Factory.move
+++ b/genesis-builder/framework/l2/sources/OptimismMintableERC721Factory.move
@@ -6,36 +6,26 @@ module OptimismMintableERC721Factory::optimism_mintable_erc721_factory {
 
     const ENOT_SUCCESS: u64 = 1;
 
-    struct BridgeArgs {}
 
     public fun bridge(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = BridgeArgs {};
+        let data = vector[238, 154, 49, 162];
 
-        let data = abi_encode_params(
-            vector[238, 154, 49, 162],
-            arg_struct,
-        );
         let result = evm_call(caller, @OptimismMintableERC721Factory, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct RemoteChainIdArgs {}
 
     public fun remote_chain_id(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = RemoteChainIdArgs {};
+        let data = vector[125, 29, 12, 91];
 
-        let data = abi_encode_params(
-            vector[125, 29, 12, 91],
-            arg_struct,
-        );
         let result = evm_call(caller, @OptimismMintableERC721Factory, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -65,6 +55,7 @@ module OptimismMintableERC721Factory::optimism_mintable_erc721_factory {
             vector[217, 125, 246, 82],
             arg_struct,
         );
+
         let result = evm_call(caller, @OptimismMintableERC721Factory, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -88,24 +79,20 @@ module OptimismMintableERC721Factory::optimism_mintable_erc721_factory {
             vector[85, 114, 172, 174],
             arg_struct,
         );
+
         let result = evm_call(caller, @OptimismMintableERC721Factory, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct VersionArgs {}
 
     public fun version(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = VersionArgs {};
+        let data = vector[84, 253, 77, 80];
 
-        let data = abi_encode_params(
-            vector[84, 253, 77, 80],
-            arg_struct,
-        );
         let result = evm_call(caller, @OptimismMintableERC721Factory, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);

--- a/genesis-builder/framework/l2/sources/ProxyAdmin.move
+++ b/genesis-builder/framework/l2/sources/ProxyAdmin.move
@@ -6,18 +6,13 @@ module ProxyAdmin::proxy_admin {
 
     const ENOT_SUCCESS: u64 = 1;
 
-    struct AddressManagerArgs {}
 
     public fun address_manager(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = AddressManagerArgs {};
+        let data = vector[58, 183, 110, 159];
 
-        let data = abi_encode_params(
-            vector[58, 183, 110, 159],
-            arg_struct,
-        );
         let result = evm_call(caller, @ProxyAdmin, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -44,6 +39,7 @@ module ProxyAdmin::proxy_admin {
             vector[126, 255, 39, 94],
             arg_struct,
         );
+
         let result = evm_call(caller, @ProxyAdmin, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -67,6 +63,7 @@ module ProxyAdmin::proxy_admin {
             vector[243, 183, 222, 173],
             arg_struct,
         );
+
         let result = evm_call(caller, @ProxyAdmin, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -90,6 +87,7 @@ module ProxyAdmin::proxy_admin {
             vector[32, 78, 28, 122],
             arg_struct,
         );
+
         let result = evm_call(caller, @ProxyAdmin, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -113,42 +111,33 @@ module ProxyAdmin::proxy_admin {
             vector[35, 129, 129, 174],
             arg_struct,
         );
+
         let result = evm_call(caller, @ProxyAdmin, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct IsUpgradingArgs {}
 
     public fun is_upgrading(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = IsUpgradingArgs {};
+        let data = vector[183, 148, 114, 98];
 
-        let data = abi_encode_params(
-            vector[183, 148, 114, 98],
-            arg_struct,
-        );
         let result = evm_call(caller, @ProxyAdmin, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct OwnerArgs {}
 
     public fun owner(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = OwnerArgs {};
+        let data = vector[141, 165, 203, 91];
 
-        let data = abi_encode_params(
-            vector[141, 165, 203, 91],
-            arg_struct,
-        );
         let result = evm_call(caller, @ProxyAdmin, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -172,24 +161,20 @@ module ProxyAdmin::proxy_admin {
             vector[107, 217, 245, 22],
             arg_struct,
         );
+
         let result = evm_call(caller, @ProxyAdmin, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct RenounceOwnershipArgs {}
 
     public fun renounce_ownership(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = RenounceOwnershipArgs {};
+        let data = vector[113, 80, 24, 166];
 
-        let data = abi_encode_params(
-            vector[113, 80, 24, 166],
-            arg_struct,
-        );
         let result = evm_call(caller, @ProxyAdmin, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -216,6 +201,7 @@ module ProxyAdmin::proxy_admin {
             vector[155, 46, 164, 189],
             arg_struct,
         );
+
         let result = evm_call(caller, @ProxyAdmin, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -239,6 +225,7 @@ module ProxyAdmin::proxy_admin {
             vector[6, 82, 181, 122],
             arg_struct,
         );
+
         let result = evm_call(caller, @ProxyAdmin, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -265,6 +252,7 @@ module ProxyAdmin::proxy_admin {
             vector[134, 15, 124, 218],
             arg_struct,
         );
+
         let result = evm_call(caller, @ProxyAdmin, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -291,6 +279,7 @@ module ProxyAdmin::proxy_admin {
             vector[141, 82, 212, 160],
             arg_struct,
         );
+
         let result = evm_call(caller, @ProxyAdmin, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -314,6 +303,7 @@ module ProxyAdmin::proxy_admin {
             vector[7, 200, 247, 176],
             arg_struct,
         );
+
         let result = evm_call(caller, @ProxyAdmin, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -337,6 +327,7 @@ module ProxyAdmin::proxy_admin {
             vector[242, 253, 227, 139],
             arg_struct,
         );
+
         let result = evm_call(caller, @ProxyAdmin, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -363,6 +354,7 @@ module ProxyAdmin::proxy_admin {
             vector[153, 168, 142, 196],
             arg_struct,
         );
+
         let result = evm_call(caller, @ProxyAdmin, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
@@ -392,6 +384,7 @@ module ProxyAdmin::proxy_admin {
             vector[150, 35, 96, 157],
             arg_struct,
         );
+
         let result = evm_call(caller, @ProxyAdmin, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);

--- a/genesis-builder/framework/l2/sources/SequencerFeeVault.move
+++ b/genesis-builder/framework/l2/sources/SequencerFeeVault.move
@@ -1,131 +1,96 @@
 module SequencerFeeVault::sequencer_fee_vault {
     use aptos_framework::fungible_asset_u256::zero;
     use EthToken::eth_token::get_metadata;
-    use Evm::evm::{abi_encode_params, emit_evm_logs, evm_call, is_result_success, EvmResult};
+    use Evm::evm::{emit_evm_logs, evm_call, is_result_success, EvmResult};
     use std::error;
 
     const ENOT_SUCCESS: u64 = 1;
 
-    struct MinWithdrawalAmountArgs {}
 
     public fun min_withdrawal_amount(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = MinWithdrawalAmountArgs {};
+        let data = vector[211, 229, 121, 43];
 
-        let data = abi_encode_params(
-            vector[211, 229, 121, 43],
-            arg_struct,
-        );
         let result = evm_call(caller, @SequencerFeeVault, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct RecipientArgs {}
 
     public fun recipient(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = RecipientArgs {};
+        let data = vector[13, 144, 25, 225];
 
-        let data = abi_encode_params(
-            vector[13, 144, 25, 225],
-            arg_struct,
-        );
         let result = evm_call(caller, @SequencerFeeVault, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct WithdrawalNetworkArgs {}
 
     public fun withdrawal_network(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = WithdrawalNetworkArgs {};
+        let data = vector[208, 225, 47, 144];
 
-        let data = abi_encode_params(
-            vector[208, 225, 47, 144],
-            arg_struct,
-        );
         let result = evm_call(caller, @SequencerFeeVault, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct L1FeeWalletArgs {}
 
     public fun l1_fee_wallet(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = L1FeeWalletArgs {};
+        let data = vector[212, 255, 146, 24];
 
-        let data = abi_encode_params(
-            vector[212, 255, 146, 24],
-            arg_struct,
-        );
         let result = evm_call(caller, @SequencerFeeVault, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct TotalProcessedArgs {}
 
     public fun total_processed(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = TotalProcessedArgs {};
+        let data = vector[132, 65, 29, 101];
 
-        let data = abi_encode_params(
-            vector[132, 65, 29, 101],
-            arg_struct,
-        );
         let result = evm_call(caller, @SequencerFeeVault, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct VersionArgs {}
 
     public fun version(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = VersionArgs {};
+        let data = vector[84, 253, 77, 80];
 
-        let data = abi_encode_params(
-            vector[84, 253, 77, 80],
-            arg_struct,
-        );
         let result = evm_call(caller, @SequencerFeeVault, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);
         result
     }
 
-    struct WithdrawArgs {}
 
     public fun withdraw(
         caller: &signer,
     ): EvmResult {
         let _value = zero(get_metadata());
-        let arg_struct = WithdrawArgs {};
+        let data = vector[60, 207, 214, 11];
 
-        let data = abi_encode_params(
-            vector[60, 207, 214, 11],
-            arg_struct,
-        );
         let result = evm_call(caller, @SequencerFeeVault, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);

--- a/genesis-builder/l2_move_template.hbs
+++ b/genesis-builder/l2_move_template.hbs
@@ -2,7 +2,8 @@ module {{name}}::{{snake name}} {
     use aptos_framework::fungible_asset_u256::
     {{~#if has_fungible_asset}}{FungibleAsset, zero}{{else}}zero{{/if}};
     use EthToken::eth_token::get_metadata;
-    use Evm::evm::{abi_encode_params, emit_evm_logs, evm_call, is_result_success, EvmResult};
+    use Evm::evm::{
+    {{~#if has_non_empty_args}}abi_encode_params, {{else}}{{/if}}emit_evm_logs, evm_call, is_result_success, EvmResult};
     use std::error;
 
     const ENOT_SUCCESS: u64 = 1;
@@ -22,8 +23,6 @@ module {{name}}::{{snake name}} {
         {{snake name}}: {{{ty}}},
         {{/each}}
     }
-    {{else}}
-    struct {{pascal name}}Args {}
     {{/if}}
 
     public fun {{snake name}}(
@@ -44,14 +43,15 @@ module {{name}}::{{snake name}} {
             {{snake name}},
             {{/each}}
         };
-        {{else}}
-        let arg_struct = {{pascal name}}Args {};
-        {{/if}}
 
         let data = abi_encode_params(
             vector{{selector}},
             arg_struct,
         );
+        {{else}}
+        let data = vector{{selector}};
+        {{/if}}
+
         let result = evm_call(caller, @{{../name}}, _value, data);
         assert!(is_result_success(&result), error::aborted(ENOT_SUCCESS));
         emit_evm_logs(&result);

--- a/genesis-builder/src/generate.rs
+++ b/genesis-builder/src/generate.rs
@@ -17,6 +17,7 @@ struct L2Module {
     functions: Vec<L2Function>,
     structs: BTreeMap<String, Vec<L2Input>>,
     has_fungible_asset: bool,
+    has_non_empty_args: bool,
 }
 
 #[derive(Default, Serialize)]
@@ -62,6 +63,9 @@ pub fn l2_abi_to_move() -> anyhow::Result<()> {
         let mut structs = BTreeMap::new();
         // If `FungibleAsset` should be imported in the Move file
         let mut has_fungible_asset = false;
+
+        // To determine if importing `abi_encode_params` is needed
+        let mut has_non_empty_args = false;
 
         let mut functions = Vec::new();
         let mut unique_function_names = Vec::new();
@@ -129,6 +133,10 @@ pub fn l2_abi_to_move() -> anyhow::Result<()> {
                     function.inputs.push(L2Input { name, ty });
                 });
 
+                if !has_non_empty_args && !function.inputs.is_empty() {
+                    has_non_empty_args = true;
+                }
+
                 functions.push(function);
             }
         }
@@ -143,6 +151,7 @@ pub fn l2_abi_to_move() -> anyhow::Result<()> {
             functions,
             structs,
             has_fungible_asset,
+            has_non_empty_args,
         };
         handlebars.render_to_write("move", &module, &mut output_file)?;
     }


### PR DESCRIPTION
### Description
<!-- What does this PR do? -->
Make parameter encoding step more efficient by skipping it for empty args in L2 contracts.
<!-- Fixes #123 -->
Fixes #316.

### Changes
<!-- Key changes -->
- Template file change
- New boolean flag in generation logic

### Testing
<!-- How was it tested? -->
Old tests pass as they should.