### PR TITLE
refactor: Reduce all application dependencies into one

### DIFF
--- a/api/src/methods/get_payload.rs
+++ b/api/src/methods/get_payload.rs
@@ -45,7 +45,7 @@ mod tests {
         super::*,
         crate::methods::forkchoice_updated,
         alloy::primitives::hex,
-        moved_app::Command,
+        moved_app::{Application, Command, StateActor, TestDependencies},
         moved_blockchain::{
             block::{
                 Block, BlockRepository, Eip1559GasFee, InMemoryBlockQueries,
@@ -114,31 +114,33 @@ mod tests {
         );
         let initial_state_root = genesis_config.initial_state_root;
 
-        let state = moved_app::StateActor::new(
+        let state: StateActor<TestDependencies<_, _, _, _>> = StateActor::new(
             rx,
-            state,
             head_hash,
             0,
             genesis_config,
-            head_hash,
-            repository,
-            Eip1559GasFee::default(),
-            U256::ZERO,
-            U256::ZERO,
-            (),
-            InMemoryBlockQueries,
-            memory,
-            InMemoryStateQueries::from_genesis(initial_state_root),
-            InMemoryTransactionRepository::new(),
-            InMemoryTransactionQueries::new(),
-            ReceiptMemory::new(),
-            InMemoryReceiptRepository::new(),
-            InMemoryReceiptQueries::new(),
-            InMemoryPayloadQueries::new(),
-            evm_storage,
-            moved_app::StateActor::on_tx_noop(),
-            moved_app::StateActor::on_tx_batch_noop(),
-            moved_app::StateActor::on_payload_in_memory(),
+            Application {
+                state,
+                block_hash: head_hash,
+                block_repository: repository,
+                gas_fee: Eip1559GasFee::default(),
+                base_token: (),
+                l1_fee: U256::ZERO,
+                l2_fee: U256::ZERO,
+                block_queries: InMemoryBlockQueries,
+                storage: memory,
+                state_queries: InMemoryStateQueries::from_genesis(initial_state_root),
+                transaction_repository: InMemoryTransactionRepository::new(),
+                transaction_queries: InMemoryTransactionQueries::new(),
+                receipt_memory: ReceiptMemory::new(),
+                receipt_repository: InMemoryReceiptRepository::new(),
+                receipt_queries: InMemoryReceiptQueries::new(),
+                payload_queries: InMemoryPayloadQueries::new(),
+                evm_storage,
+                on_tx: StateActor::on_tx_noop(),
+                on_tx_batch: StateActor::on_tx_batch_noop(),
+                on_payload: StateActor::on_payload_in_memory(),
+            },
         );
         let state_handle = state.spawn();
 

--- a/api/src/methods/new_payload.rs
+++ b/api/src/methods/new_payload.rs
@@ -163,6 +163,7 @@ mod tests {
         super::*,
         crate::methods::{forkchoice_updated, get_payload},
         alloy::primitives::hex,
+        moved_app::{Application, StateActor, TestDependencies},
         moved_blockchain::{
             block::{
                 Block, BlockRepository, Eip1559GasFee, InMemoryBlockQueries,
@@ -276,33 +277,35 @@ mod tests {
         );
         let initial_state_root = genesis_config.initial_state_root;
 
-        let state = moved_app::StateActor::new(
+        let state: StateActor<TestDependencies<_, _, _, _>> = StateActor::new(
             rx,
-            state,
             head_hash,
             0,
             genesis_config,
-            B256::from(hex!(
-                "c013e1ff1b8bca9f0d074618cc9e661983bc91d7677168b156765781aee775d3"
-            )),
-            repository,
-            Eip1559GasFee::default(),
-            U256::ZERO,
-            U256::ZERO,
-            (),
-            InMemoryBlockQueries,
-            memory,
-            InMemoryStateQueries::from_genesis(initial_state_root),
-            InMemoryTransactionRepository::new(),
-            InMemoryTransactionQueries::new(),
-            ReceiptMemory::new(),
-            InMemoryReceiptRepository::new(),
-            InMemoryReceiptQueries::new(),
-            InMemoryPayloadQueries::new(),
-            evm_storage,
-            moved_app::StateActor::on_tx_noop(),
-            moved_app::StateActor::on_tx_batch_noop(),
-            moved_app::StateActor::on_payload_in_memory(),
+            Application {
+                gas_fee: Eip1559GasFee::default(),
+                base_token: (),
+                l1_fee: U256::ZERO,
+                l2_fee: U256::ZERO,
+                block_hash: B256::from(hex!(
+                    "c013e1ff1b8bca9f0d074618cc9e661983bc91d7677168b156765781aee775d3"
+                )),
+                block_queries: InMemoryBlockQueries,
+                block_repository: repository,
+                on_payload: StateActor::on_payload_in_memory(),
+                on_tx: StateActor::on_tx_noop(),
+                on_tx_batch: StateActor::on_tx_batch_noop(),
+                payload_queries: InMemoryPayloadQueries::new(),
+                receipt_queries: InMemoryReceiptQueries::new(),
+                receipt_repository: InMemoryReceiptRepository::new(),
+                receipt_memory: ReceiptMemory::new(),
+                storage: memory,
+                state,
+                evm_storage,
+                transaction_queries: InMemoryTransactionQueries::new(),
+                state_queries: InMemoryStateQueries::from_genesis(initial_state_root),
+                transaction_repository: InMemoryTransactionRepository::new(),
+            },
         );
         let state_handle = state.spawn();
 

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 
 [features]
 default = []
-test-doubles = []
+test-doubles = [
+    "moved-blockchain/test-doubles",
+    "moved-execution/test-doubles",
+]
 
 [dependencies]
 alloy.workspace = true
@@ -24,8 +27,8 @@ op-alloy.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
-moved-execution.workspace = true
 moved-execution.features = ["test-doubles"]
+moved-execution.workspace = true
 moved-blockchain.features = ["test-doubles"]
 moved-blockchain.workspace = true
 moved-genesis-image.workspace = true

--- a/app/src/dependency.rs
+++ b/app/src/dependency.rs
@@ -1,0 +1,390 @@
+#[cfg(any(feature = "test-doubles", test))]
+pub use test_doubles::TestDependencies;
+
+use {
+    move_core_types::effects::ChangeSet, moved_blockchain::payload::PayloadId,
+    moved_genesis::config::GenesisConfig, moved_shared::primitives::B256,
+};
+
+pub struct Application<D: Dependencies> {
+    pub gas_fee: D::BaseGasFee,
+    pub base_token: D::BaseTokenAccounts,
+    pub l1_fee: D::CreateL1GasFee,
+    pub l2_fee: D::CreateL2GasFee,
+    pub block_hash: D::BlockHash,
+    pub block_queries: D::BlockQueries,
+    pub block_repository: D::BlockRepository,
+    pub on_payload: D::OnPayload,
+    pub on_tx: D::OnTx,
+    pub on_tx_batch: D::OnTxBatch,
+    pub payload_queries: D::PayloadQueries,
+    pub receipt_queries: D::ReceiptQueries,
+    pub receipt_repository: D::ReceiptRepository,
+    pub receipt_memory: D::ReceiptStorage,
+    pub storage: D::SharedStorage,
+    pub state: D::State,
+    pub state_queries: D::StateQueries,
+    pub evm_storage: D::StorageTrieRepository,
+    pub transaction_queries: D::TransactionQueries,
+    pub transaction_repository: D::TransactionRepository,
+}
+
+impl<D: Dependencies> Application<D> {
+    pub fn new(_: D, genesis_config: &GenesisConfig) -> Self {
+        Self {
+            gas_fee: D::base_gas_fee(),
+            base_token: D::base_token_accounts(genesis_config),
+            l1_fee: D::create_l1_gas_fee(),
+            l2_fee: D::create_l2_gas_fee(),
+            block_hash: D::block_hash(),
+            block_queries: D::block_queries(),
+            block_repository: D::block_repository(),
+            on_payload: D::on_payload(),
+            on_tx: D::on_tx(),
+            on_tx_batch: D::on_tx_batch(),
+            payload_queries: D::payload_queries(),
+            receipt_queries: D::receipt_queries(),
+            receipt_repository: D::receipt_repository(),
+            receipt_memory: D::receipt_memory(),
+            storage: D::shared_storage(),
+            state: D::state(),
+            state_queries: D::state_queries(genesis_config),
+            evm_storage: D::storage_trie_repository(),
+            transaction_queries: D::transaction_queries(),
+            transaction_repository: D::transaction_repository(),
+        }
+    }
+}
+
+pub trait DependenciesThreadSafe:
+    Dependencies<
+        BaseTokenAccounts: Send + Sync + 'static,
+        BlockHash: Send + Sync + 'static,
+        BlockQueries: Send + Sync + 'static,
+        BlockRepository: Send + Sync + 'static,
+        OnPayload: Send + Sync + 'static,
+        OnTx: Send + Sync + 'static,
+        OnTxBatch: Send + Sync + 'static,
+        PayloadQueries: Send + Sync + 'static,
+        ReceiptQueries: Send + Sync + 'static,
+        ReceiptRepository: Send + Sync + 'static,
+        ReceiptStorage: Send + Sync + 'static,
+        SharedStorage: Send + Sync + 'static,
+        State: Send + Sync + 'static,
+        StateQueries: Send + Sync + 'static,
+        StorageTrieRepository: Send + Sync + 'static,
+        TransactionQueries: Send + Sync + 'static,
+        TransactionRepository: Send + Sync + 'static,
+        BaseGasFee: Send + Sync + 'static,
+        CreateL1GasFee: Send + Sync + 'static,
+        CreateL2GasFee: Send + Sync + 'static,
+    > + Send
+    + Sync
+    + 'static
+{
+}
+
+impl<
+        T: Dependencies<
+                BaseTokenAccounts: Send + Sync + 'static,
+                BlockHash: Send + Sync + 'static,
+                BlockQueries: Send + Sync + 'static,
+                BlockRepository: Send + Sync + 'static,
+                OnPayload: Send + Sync + 'static,
+                OnTx: Send + Sync + 'static,
+                OnTxBatch: Send + Sync + 'static,
+                PayloadQueries: Send + Sync + 'static,
+                ReceiptQueries: Send + Sync + 'static,
+                ReceiptRepository: Send + Sync + 'static,
+                ReceiptStorage: Send + Sync + 'static,
+                SharedStorage: Send + Sync + 'static,
+                State: Send + Sync + 'static,
+                StateQueries: Send + Sync + 'static,
+                StorageTrieRepository: Send + Sync + 'static,
+                TransactionQueries: Send + Sync + 'static,
+                TransactionRepository: Send + Sync + 'static,
+                BaseGasFee: Send + Sync + 'static,
+                CreateL1GasFee: Send + Sync + 'static,
+                CreateL2GasFee: Send + Sync + 'static,
+            > + Send
+            + Sync
+            + 'static,
+    > DependenciesThreadSafe for T
+{
+}
+
+pub trait Dependencies: Sized {
+    type BaseTokenAccounts: moved_execution::BaseTokenAccounts;
+    type BlockHash: moved_blockchain::block::BlockHash;
+    type BlockQueries: moved_blockchain::block::BlockQueries<Storage = Self::SharedStorage>;
+    type BlockRepository: moved_blockchain::block::BlockRepository<Storage = Self::SharedStorage>;
+
+    /// A function invoked on an execution of a new payload.
+    type OnPayload: Fn() -> Box<dyn Fn(&mut Application<Self>, PayloadId, B256) + Send + Sync + 'static>
+        + Send
+        + Sync
+        + 'static;
+
+    /// A function invoked on an execution of a new transaction.
+    type OnTx: Fn() -> Box<dyn Fn(&mut Application<Self>, ChangeSet) + Send + Sync + 'static>
+        + Send
+        + Sync
+        + 'static;
+
+    /// A function invoked on a completion of new transaction execution batch.
+    type OnTxBatch: Fn() -> Box<dyn Fn(&mut Application<Self>) + Send + Sync + 'static>
+        + Send
+        + Sync
+        + 'static;
+
+    type PayloadQueries: moved_blockchain::payload::PayloadQueries<Storage = Self::SharedStorage>;
+    type ReceiptQueries: moved_blockchain::receipt::ReceiptQueries<Storage = Self::ReceiptStorage>;
+    type ReceiptRepository: moved_blockchain::receipt::ReceiptRepository<
+        Storage = Self::ReceiptStorage,
+    >;
+    type ReceiptStorage;
+    type SharedStorage;
+    type State: moved_state::State;
+    type StateQueries: moved_blockchain::state::StateQueries;
+    type StorageTrieRepository: moved_evm_ext::state::StorageTrieRepository;
+    type TransactionQueries: moved_blockchain::transaction::TransactionQueries<
+        Storage = Self::SharedStorage,
+    >;
+    type TransactionRepository: moved_blockchain::transaction::TransactionRepository<
+        Storage = Self::SharedStorage,
+    >;
+    type BaseGasFee: moved_blockchain::block::BaseGasFee;
+    type CreateL1GasFee: moved_execution::CreateL1GasFee;
+    type CreateL2GasFee: moved_execution::CreateL2GasFee;
+
+    fn base_token_accounts(genesis_config: &GenesisConfig) -> Self::BaseTokenAccounts;
+
+    fn block_hash() -> Self::BlockHash;
+
+    fn block_queries() -> Self::BlockQueries;
+
+    fn block_repository() -> Self::BlockRepository;
+
+    fn on_payload() -> Self::OnPayload;
+
+    fn on_tx() -> Self::OnTx;
+
+    fn on_tx_batch() -> Self::OnTxBatch;
+
+    fn payload_queries() -> Self::PayloadQueries;
+
+    fn receipt_queries() -> Self::ReceiptQueries;
+
+    fn receipt_repository() -> Self::ReceiptRepository;
+
+    fn receipt_memory() -> Self::ReceiptStorage;
+
+    fn shared_storage() -> Self::SharedStorage;
+
+    fn state() -> Self::State;
+
+    fn state_queries(genesis_config: &GenesisConfig) -> Self::StateQueries;
+
+    fn storage_trie_repository() -> Self::StorageTrieRepository;
+
+    fn transaction_queries() -> Self::TransactionQueries;
+
+    fn transaction_repository() -> Self::TransactionRepository;
+
+    fn base_gas_fee() -> Self::BaseGasFee;
+
+    fn create_l1_gas_fee() -> Self::CreateL1GasFee;
+
+    fn create_l2_gas_fee() -> Self::CreateL2GasFee;
+}
+
+#[cfg(any(feature = "test-doubles", test))]
+mod test_doubles {
+    use {
+        crate::{Application, Dependencies},
+        move_core_types::effects::ChangeSet,
+        moved_blockchain::{payload::PayloadId, state::StateQueries},
+        moved_genesis::config::GenesisConfig,
+        moved_shared::primitives::{B256, U256},
+        moved_state::State,
+    };
+
+    pub struct TestDependencies<
+        SQ = moved_blockchain::state::InMemoryStateQueries,
+        S = moved_state::InMemoryState,
+        BT = moved_execution::MovedBaseTokenAccounts,
+        BH = moved_blockchain::block::MovedBlockHash,
+        BQ = moved_blockchain::block::InMemoryBlockQueries,
+        BR = moved_blockchain::block::InMemoryBlockRepository,
+        PQ = moved_blockchain::payload::InMemoryPayloadQueries,
+        RQ = moved_blockchain::receipt::InMemoryReceiptQueries,
+        RR = moved_blockchain::receipt::InMemoryReceiptRepository,
+        R = moved_blockchain::receipt::ReceiptMemory,
+        B = moved_blockchain::in_memory::SharedMemory,
+        ST = moved_evm_ext::state::InMemoryStorageTrieRepository,
+        TQ = moved_blockchain::transaction::InMemoryTransactionQueries,
+        TR = moved_blockchain::transaction::InMemoryTransactionRepository,
+        BF = moved_blockchain::block::Eip1559GasFee,
+        F1 = U256,
+        F2 = U256,
+    >(
+        SQ,
+        S,
+        BT,
+        BH,
+        BQ,
+        BR,
+        PQ,
+        RQ,
+        RR,
+        R,
+        B,
+        ST,
+        TQ,
+        TR,
+        BF,
+        F1,
+        F2,
+    );
+
+    impl<
+            SQ: StateQueries + Send + Sync + 'static,
+            S: State + Send + Sync + 'static,
+            BT: moved_execution::BaseTokenAccounts + Send + Sync + 'static,
+            BH: moved_blockchain::block::BlockHash + Send + Sync + 'static,
+            BQ: moved_blockchain::block::BlockQueries<Storage = B> + Send + Sync + 'static,
+            BR: moved_blockchain::block::BlockRepository<Storage = B> + Send + Sync + 'static,
+            PQ: moved_blockchain::payload::PayloadQueries<Storage = B> + Send + Sync + 'static,
+            RQ: moved_blockchain::receipt::ReceiptQueries<Storage = R> + Send + Sync + 'static,
+            RR: moved_blockchain::receipt::ReceiptRepository<Storage = R> + Send + Sync + 'static,
+            R: Send + Sync + 'static,
+            B: Send + Sync + 'static,
+            ST: moved_evm_ext::state::StorageTrieRepository + Send + Sync + 'static,
+            TQ: moved_blockchain::transaction::TransactionQueries<Storage = B> + Send + Sync + 'static,
+            TR: moved_blockchain::transaction::TransactionRepository<Storage = B>
+                + Send
+                + Sync
+                + 'static,
+            BF: moved_blockchain::block::BaseGasFee + Send + Sync + 'static,
+            F1: moved_execution::CreateL1GasFee + Send + Sync + 'static,
+            F2: moved_execution::CreateL2GasFee + Send + Sync + 'static,
+        > Dependencies
+        for TestDependencies<SQ, S, BT, BH, BQ, BR, PQ, RQ, RR, R, B, ST, TQ, TR, BF, F1, F2>
+    {
+        type BaseTokenAccounts = BT;
+        type BlockHash = BH;
+        type BlockQueries = BQ;
+        type BlockRepository = BR;
+        type OnPayload = Box<
+            dyn Fn() -> Box<dyn Fn(&mut Application<Self>, PayloadId, B256) + Send + Sync + 'static>
+                + Send
+                + Sync
+                + 'static,
+        >;
+        type OnTx = Box<
+            dyn Fn() -> Box<dyn Fn(&mut Application<Self>, ChangeSet) + Send + Sync + 'static>
+                + Send
+                + Sync
+                + 'static,
+        >;
+        type OnTxBatch = Box<
+            dyn Fn() -> Box<dyn Fn(&mut Application<Self>) + Send + Sync + 'static>
+                + Send
+                + Sync
+                + 'static,
+        >;
+        type PayloadQueries = PQ;
+        type ReceiptQueries = RQ;
+        type ReceiptRepository = RR;
+        type ReceiptStorage = R;
+        type SharedStorage = B;
+        type State = S;
+        type StateQueries = SQ;
+        type StorageTrieRepository = ST;
+        type TransactionQueries = TQ;
+        type TransactionRepository = TR;
+        type BaseGasFee = BF;
+        type CreateL1GasFee = F1;
+        type CreateL2GasFee = F2;
+
+        fn base_token_accounts(_: &GenesisConfig) -> Self::BaseTokenAccounts {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn block_hash() -> Self::BlockHash {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn block_queries() -> Self::BlockQueries {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn block_repository() -> Self::BlockRepository {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn on_payload() -> Self::OnPayload {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn on_tx() -> Self::OnTx {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn on_tx_batch() -> Self::OnTxBatch {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn payload_queries() -> Self::PayloadQueries {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn receipt_queries() -> Self::ReceiptQueries {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn receipt_repository() -> Self::ReceiptRepository {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn receipt_memory() -> Self::ReceiptStorage {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn shared_storage() -> Self::SharedStorage {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn state() -> Self::State {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn state_queries(_: &GenesisConfig) -> Self::StateQueries {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn storage_trie_repository() -> Self::StorageTrieRepository {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn transaction_queries() -> Self::TransactionQueries {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn transaction_repository() -> Self::TransactionRepository {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn base_gas_fee() -> Self::BaseGasFee {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn create_l1_gas_fee() -> Self::CreateL1GasFee {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn create_l2_gas_fee() -> Self::CreateL2GasFee {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+    }
+}

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1,5 +1,6 @@
+pub use {actor::*, dependency::*, input::*};
+
 pub(crate) mod input;
 
 mod actor;
-
-pub use {actor::*, input::*};
+mod dependency;

--- a/server/src/dependency/in_memory.rs
+++ b/server/src/dependency/in_memory.rs
@@ -1,112 +1,95 @@
 use {
     crate::dependency::shared::*,
-    moved_blockchain::block::{BaseGasFee, BlockHash, BlockRepository, MovedBlockHash},
-    moved_execution::{BaseTokenAccounts, CreateL1GasFee, CreateL2GasFee, MovedBaseTokenAccounts},
+    moved_app::{Application, StateActor},
     moved_genesis::config::GenesisConfig,
-    moved_state::State,
 };
 
-pub type SharedStorage = moved_blockchain::in_memory::SharedMemory;
-pub type ReceiptStorage = moved_blockchain::receipt::ReceiptMemory;
-pub type StateQueries = moved_blockchain::state::InMemoryStateQueries;
-pub type ReceiptRepository = moved_blockchain::receipt::InMemoryReceiptRepository;
-pub type ReceiptQueries = moved_blockchain::receipt::InMemoryReceiptQueries;
-pub type PayloadQueries = moved_blockchain::payload::InMemoryPayloadQueries;
-pub type StorageTrieRepository = moved_evm_ext::state::InMemoryStorageTrieRepository;
-pub type TransactionRepository = moved_blockchain::transaction::InMemoryTransactionRepository;
-pub type TransactionQueries = moved_blockchain::transaction::InMemoryTransactionQueries;
-pub type BlockQueries = moved_blockchain::block::InMemoryBlockQueries;
+pub type Dependency = InMemoryDependencies;
 
-pub fn block_hash() -> impl BlockHash + Send + Sync + 'static {
-    MovedBlockHash
+pub fn create(genesis_config: &GenesisConfig) -> Application<InMemoryDependencies> {
+    Application::new(InMemoryDependencies, genesis_config)
 }
 
-pub fn base_token(
-    genesis_config: &GenesisConfig,
-) -> impl BaseTokenAccounts + Send + Sync + 'static {
-    MovedBaseTokenAccounts::new(genesis_config.treasury)
-}
+pub struct InMemoryDependencies;
 
-pub fn memory() -> SharedStorage {
-    moved_blockchain::in_memory::SharedMemory::new()
-}
+impl moved_app::Dependencies for InMemoryDependencies {
+    type SharedStorage = moved_blockchain::in_memory::SharedMemory;
+    type ReceiptStorage = moved_blockchain::receipt::ReceiptMemory;
+    type StateQueries = moved_blockchain::state::InMemoryStateQueries;
+    type ReceiptRepository = moved_blockchain::receipt::InMemoryReceiptRepository;
+    type OnPayload = moved_app::OnPayload<Application<Self>>;
+    type OnTx = moved_app::OnTx<Application<Self>>;
+    type OnTxBatch = moved_app::OnTxBatch<Application<Self>>;
+    type ReceiptQueries = moved_blockchain::receipt::InMemoryReceiptQueries;
+    type PayloadQueries = moved_blockchain::payload::InMemoryPayloadQueries;
+    type StorageTrieRepository = moved_evm_ext::state::InMemoryStorageTrieRepository;
+    type TransactionRepository = moved_blockchain::transaction::InMemoryTransactionRepository;
+    type TransactionQueries = moved_blockchain::transaction::InMemoryTransactionQueries;
+    type BlockQueries = moved_blockchain::block::InMemoryBlockQueries;
+    type BlockRepository = moved_blockchain::block::InMemoryBlockRepository;
+    type State = moved_state::InMemoryState;
 
-pub fn block_repository() -> impl BlockRepository<Storage = SharedStorage> + Send + Sync + 'static {
-    moved_blockchain::block::InMemoryBlockRepository::new()
-}
+    fn block_repository() -> Self::BlockRepository {
+        moved_blockchain::block::InMemoryBlockRepository::new()
+    }
 
-pub fn state() -> impl State + Send + Sync + 'static {
-    moved_state::InMemoryState::new()
-}
+    fn state() -> Self::State {
+        moved_state::InMemoryState::new()
+    }
 
-pub fn state_query(genesis_config: &GenesisConfig) -> StateQueries {
-    moved_blockchain::state::InMemoryStateQueries::from_genesis(genesis_config.initial_state_root)
-}
+    fn on_tx_batch() -> Self::OnTxBatch {
+        StateActor::on_tx_batch_in_memory()
+    }
 
-pub fn on_tx_batch<
-    S: State,
-    BH: BlockHash,
-    BR: BlockRepository<Storage = SharedStorage>,
-    Fee: BaseGasFee,
-    L1F: CreateL1GasFee,
-    L2F: CreateL2GasFee,
-    Token: BaseTokenAccounts,
->() -> OnTxBatch<S, BH, BR, Fee, L1F, L2F, Token> {
-    moved_app::StateActor::on_tx_batch_in_memory()
-}
+    fn on_tx() -> Self::OnTx {
+        StateActor::on_tx_in_memory()
+    }
 
-pub fn on_tx<
-    S: State,
-    BH: BlockHash,
-    BR: BlockRepository<Storage = SharedStorage>,
-    Fee: BaseGasFee,
-    L1F: CreateL1GasFee,
-    L2F: CreateL2GasFee,
-    Token: BaseTokenAccounts,
->() -> OnTx<S, BH, BR, Fee, L1F, L2F, Token> {
-    moved_app::StateActor::on_tx_in_memory()
-}
+    fn on_payload() -> Self::OnPayload {
+        StateActor::on_payload_in_memory()
+    }
 
-pub fn on_payload<
-    S: State,
-    BH: BlockHash,
-    BR: BlockRepository<Storage = SharedStorage>,
-    Fee: BaseGasFee,
-    L1F: CreateL1GasFee,
-    L2F: CreateL2GasFee,
-    Token: BaseTokenAccounts,
->() -> OnPayload<S, BH, BR, Fee, L1F, L2F, Token> {
-    moved_app::StateActor::on_payload_in_memory()
-}
+    fn transaction_repository() -> Self::TransactionRepository {
+        moved_blockchain::transaction::InMemoryTransactionRepository::new()
+    }
 
-pub fn transaction_repository() -> TransactionRepository {
-    moved_blockchain::transaction::InMemoryTransactionRepository::new()
-}
+    fn transaction_queries() -> Self::TransactionQueries {
+        moved_blockchain::transaction::InMemoryTransactionQueries::new()
+    }
 
-pub fn transaction_queries() -> TransactionQueries {
-    moved_blockchain::transaction::InMemoryTransactionQueries::new()
-}
+    fn receipt_repository() -> Self::ReceiptRepository {
+        moved_blockchain::receipt::InMemoryReceiptRepository::new()
+    }
 
-pub fn receipt_repository() -> ReceiptRepository {
-    moved_blockchain::receipt::InMemoryReceiptRepository::new()
-}
+    fn receipt_queries() -> Self::ReceiptQueries {
+        moved_blockchain::receipt::InMemoryReceiptQueries::new()
+    }
 
-pub fn receipt_queries() -> ReceiptQueries {
-    moved_blockchain::receipt::InMemoryReceiptQueries::new()
-}
+    fn receipt_memory() -> Self::ReceiptStorage {
+        moved_blockchain::receipt::ReceiptMemory::new()
+    }
 
-pub fn receipt_memory() -> ReceiptStorage {
-    moved_blockchain::receipt::ReceiptMemory::new()
-}
+    fn block_queries() -> Self::BlockQueries {
+        moved_blockchain::block::InMemoryBlockQueries
+    }
 
-pub fn block_queries() -> BlockQueries {
-    moved_blockchain::block::InMemoryBlockQueries
-}
+    fn payload_queries() -> Self::PayloadQueries {
+        moved_blockchain::payload::InMemoryPayloadQueries::new()
+    }
 
-pub fn payload_queries() -> PayloadQueries {
-    moved_blockchain::payload::InMemoryPayloadQueries::new()
-}
+    fn storage_trie_repository() -> Self::StorageTrieRepository {
+        moved_evm_ext::state::InMemoryStorageTrieRepository::new()
+    }
 
-pub fn storage_trie_repository() -> StorageTrieRepository {
-    moved_evm_ext::state::InMemoryStorageTrieRepository::new()
+    fn shared_storage() -> Self::SharedStorage {
+        moved_blockchain::in_memory::SharedMemory::new()
+    }
+
+    fn state_queries(genesis_config: &GenesisConfig) -> Self::StateQueries {
+        moved_blockchain::state::InMemoryStateQueries::from_genesis(
+            genesis_config.initial_state_root,
+        )
+    }
+
+    impl_shared!();
 }

--- a/server/src/dependency/shared.rs
+++ b/server/src/dependency/shared.rs
@@ -1,26 +1,34 @@
-use super::*;
+macro_rules! impl_shared {
+    () => {
+        type BlockHash = moved_blockchain::block::MovedBlockHash;
+        type BaseTokenAccounts = moved_execution::MovedBaseTokenAccounts;
+        type BaseGasFee = moved_blockchain::block::Eip1559GasFee;
+        type CreateL1GasFee = moved_execution::CreateEcotoneL1GasFee;
+        type CreateL2GasFee = moved_execution::CreateMovedL2GasFee;
 
-pub(super) type StateActor<A, B, C, D, E, F, G> = moved_app::StateActor<
-    A,
-    B,
-    C,
-    D,
-    E,
-    F,
-    G,
-    BlockQueries,
-    SharedStorage,
-    StateQueries,
-    TransactionRepository,
-    TransactionQueries,
-    ReceiptStorage,
-    ReceiptRepository,
-    ReceiptQueries,
-    PayloadQueries,
-    StorageTrieRepository,
->;
-pub(super) type OnTxBatch<A, B, C, D, E, F, G> =
-    moved_app::OnTxBatch<StateActor<A, B, C, D, E, F, G>>;
-pub(super) type OnTx<A, B, C, D, E, F, G> = moved_app::OnTx<StateActor<A, B, C, D, E, F, G>>;
-pub(super) type OnPayload<A, B, C, D, E, F, G> =
-    moved_app::OnPayload<StateActor<A, B, C, D, E, F, G>>;
+        fn block_hash() -> Self::BlockHash {
+            moved_blockchain::block::MovedBlockHash
+        }
+
+        fn base_gas_fee() -> Self::BaseGasFee {
+            moved_blockchain::block::Eip1559GasFee::new(
+                crate::EIP1559_ELASTICITY_MULTIPLIER,
+                crate::EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR,
+            )
+        }
+
+        fn create_l1_gas_fee() -> Self::CreateL1GasFee {
+            moved_execution::CreateEcotoneL1GasFee
+        }
+
+        fn create_l2_gas_fee() -> Self::CreateL2GasFee {
+            moved_execution::CreateMovedL2GasFee
+        }
+
+        fn base_token_accounts(genesis_config: &GenesisConfig) -> Self::BaseTokenAccounts {
+            moved_execution::MovedBaseTokenAccounts::new(genesis_config.treasury)
+        }
+    };
+}
+
+pub(crate) use impl_shared;


### PR DESCRIPTION
Closes #174 

# About
Groups all application dependencies into one object.

# Motivation
* The `StateActor::new` has a lot of parameters. There is a parameter per dependency. Since state actor orchestrates all queries and commands, it is dependent on everything.
* The creation of these dependencies has several variants for different kinds picked by feature flags. It is not standardized by any language tool, but it implicitly relies on the assumption that functions for creating these dependencies are named the same in every variant.

# Problem
* The `StateActor::new` triggers a warning from `clippy` that is supressed.
* `StateActor` is an exclusive owner of all these dependencies. Delegating the responsibility of specifying and holding all application dependencies and making them shareable is a prerequisite for parallel read queries.
* The creation of dependencies relies on an implicit assumption on how the `dependency` modules are structured and how the functions are named.

# Solution
* Create a new object `Application` that holds all application dependencies.
* Define a trait `Dependencies` for creating each of these dependencies.
* Make `StateActor` dependent on `Application`.
* Implement `Dependencies` separately for `InMemory`, `Heed` and `RocksDb` versions.