### PR TITLE
perf: Remove indirection and heap allocation from callbacks

### DIFF
--- a/server/src/dependency/heed.rs
+++ b/server/src/dependency/heed.rs
@@ -42,25 +42,21 @@ impl moved_app::Dependencies for HeedDependencies {
         block::HeedBlockRepository
     }
 
-    fn on_payload() -> Self::OnPayload {
-        Box::new(|| {
-            Box::new(|state, id, hash| state.payload_queries.add_block_hash(id, hash).unwrap())
-        })
+    fn on_payload() -> &'static Self::OnPayload {
+        &|state, id, hash| state.payload_queries.add_block_hash(id, hash).unwrap()
     }
 
-    fn on_tx() -> Self::OnTx {
+    fn on_tx() -> &'static Self::OnTx {
         StateActor::on_tx_noop()
     }
 
-    fn on_tx_batch() -> Self::OnTxBatch {
-        Box::new(|| {
-            Box::new(|state| {
-                state
-                    .state_queries
-                    .push_state_root(state.state.state_root())
-                    .unwrap()
-            })
-        })
+    fn on_tx_batch() -> &'static Self::OnTxBatch {
+        &|state| {
+            state
+                .state_queries
+                .push_state_root(state.state.state_root())
+                .unwrap()
+        }
     }
 
     fn payload_queries() -> Self::PayloadQueries {

--- a/server/src/dependency/in_memory.rs
+++ b/server/src/dependency/in_memory.rs
@@ -1,5 +1,6 @@
 use {
     crate::dependency::shared::*,
+    move_core_types::effects::ChangeSet,
     moved_app::{Application, StateActor},
     moved_genesis::config::GenesisConfig,
 };
@@ -37,15 +38,15 @@ impl moved_app::Dependencies for InMemoryDependencies {
         moved_state::InMemoryState::new()
     }
 
-    fn on_tx_batch() -> Self::OnTxBatch {
+    fn on_tx_batch() -> &'static Self::OnTxBatch {
         StateActor::on_tx_batch_in_memory()
     }
 
-    fn on_tx() -> Self::OnTx {
+    fn on_tx() -> &'static Self::OnTx {
         StateActor::on_tx_in_memory()
     }
 
-    fn on_payload() -> Self::OnPayload {
+    fn on_payload() -> &'static Self::OnPayload {
         StateActor::on_payload_in_memory()
     }
 

--- a/server/src/dependency/rocksdb.rs
+++ b/server/src/dependency/rocksdb.rs
@@ -1,5 +1,6 @@
 use {
     crate::dependency::shared::*,
+    move_core_types::effects::ChangeSet,
     moved_app::{Application, StateActor},
     moved_genesis::config::GenesisConfig,
     moved_state::State,
@@ -38,25 +39,21 @@ impl moved_app::Dependencies for RocksDbDependencies {
         moved_storage_rocksdb::block::RocksDbBlockRepository
     }
 
-    fn on_payload() -> Self::OnPayload {
-        Box::new(|| {
-            Box::new(|state, id, hash| state.payload_queries.add_block_hash(id, hash).unwrap())
-        })
+    fn on_payload() -> &'static Self::OnPayload {
+        &|state, id, hash| state.payload_queries.add_block_hash(id, hash).unwrap()
     }
 
-    fn on_tx() -> Self::OnTx {
+    fn on_tx() -> &'static Self::OnTx {
         StateActor::on_tx_noop()
     }
 
-    fn on_tx_batch() -> Self::OnTxBatch {
-        Box::new(|| {
-            Box::new(|state| {
-                state
-                    .state_queries
-                    .push_state_root(state.state.state_root())
-                    .unwrap()
-            })
-        })
+    fn on_tx_batch() -> &'static Self::OnTxBatch {
+        &|state| {
+            state
+                .state_queries
+                .push_state_root(state.state.state_root())
+                .unwrap()
+        }
     }
 
     fn payload_queries() -> Self::PayloadQueries {


### PR DESCRIPTION
# About

Reduces overhead for creating callback functions.

# Motivation

The type for creating callbacks is pretty complex and requires heap allocation for static values.

# Problem

The callback functions, when used as `Box<dyn Fn(&mut self, ...)>` require mutable borrowing of `self`. But calling the function also requires `self` to be borrowed. Therefore, calling it and passing `self` or a field on `self` as argument, means that `self` is borrowed twice, triggering a compile error.

To circumvent this, an indirection is introduced `Box<dyn Fn(...) -> Box<dyn Fn(&mut self)>>` which is a function that creates a function. In this way, the created function is a new value that is not owned by `self` and therefore can accept `self` or fields on `self` as arguments.

# Solution

The callback is reduced to a static reference. In this way, it does not force borrowing of `self`. Without borrowing of `self`, there is no need to have the indirection of creating callback function as its own independently owned object.
