### PR TITLE
feat: trigger image rebuild on genesis change

### DIFF
--- a/genesis-image/build.rs
+++ b/genesis-image/build.rs
@@ -11,6 +11,9 @@ use {
 };
 
 fn main() {
+    // We're particularly interested in Aptos / Sui bundle changes, but wouldn't
+    // hurt to rerun whenever anything in genesis changes as it's a separate package
+    println!("cargo::rerun-if-changed=../genesis/");
     let state = InMemoryState::default();
     let storage_trie = InMemoryStorageTrieRepository::new();
     let genesis_config = GenesisConfig::default();


### PR DESCRIPTION
### Description
<!-- What does this PR do? -->
I've noticed that if I was fiddling with the the Aptos bundle by rerunning the genesis builder and swapping the .mrb file, the tests would keep failing even when they shouldn't unless I change something else in the code. This was due to the image in the out dir not being updated on changes. This can be solved by a little tweak. 
<!-- Fixes #123 -->

### Changes
<!-- Key changes -->
- Just a single build directive for the build script

### Testing
<!-- How was it tested? -->
No new tests, but should be in accordance with the [spec](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed).
