### PR TITLE
feat: Shut the server down if command queue panics

### DIFF
--- a/api/src/json_utils.rs
+++ b/api/src/json_utils.rs
@@ -27,10 +27,6 @@ pub fn deserialize<T: DeserializeOwned>(x: &serde_json::Value) -> Result<T, Json
     })
 }
 
-pub fn access_state_error<E: fmt::Debug>(e: E) -> JsonRpcError {
-    JsonRpcError::access_state_error(e)
-}
-
 pub fn transaction_error<E: fmt::Debug>(e: E) -> JsonRpcError {
     JsonRpcError::without_data(3, format!("Execution reverted: {e:?}"))
 }

--- a/api/src/jsonrpc.rs
+++ b/api/src/jsonrpc.rs
@@ -1,7 +1,4 @@
-use {
-    std::fmt,
-    tokio::sync::{mpsc::error::SendError, oneshot::error::RecvError},
-};
+use std::fmt;
 
 #[derive(Debug, serde::Serialize)]
 pub struct JsonRpcError {
@@ -27,12 +24,8 @@ impl JsonRpcError {
         }
     }
 
-    pub fn access_state_error<E: fmt::Debug>(e: E) -> JsonRpcError {
-        Self::without_data(-1, format!("Failed to access state: {e:?}"))
-    }
-
     pub fn block_not_found<T: fmt::Display>(block_number: T) -> Self {
-        JsonRpcError::without_data(-32001, format!("Block not found: {block_number}"))
+        Self::without_data(-32001, format!("Block not found: {block_number}"))
     }
 }
 
@@ -44,16 +37,4 @@ pub struct JsonRpcResponse {
     pub result: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<JsonRpcError>,
-}
-
-impl<T> From<SendError<T>> for JsonRpcError {
-    fn from(value: SendError<T>) -> Self {
-        Self::access_state_error(value)
-    }
-}
-
-impl From<RecvError> for JsonRpcError {
-    fn from(value: RecvError) -> Self {
-        Self::access_state_error(value)
-    }
 }

--- a/api/src/methods/get_transaction_receipt.rs
+++ b/api/src/methods/get_transaction_receipt.rs
@@ -24,23 +24,20 @@ mod tests {
             methods::{forkchoice_updated, get_payload, send_raw_transaction, tests::create_app},
             schema::{ForkchoiceUpdatedResponseV1, GetPayloadResponseV3},
         },
-        moved_app::CommandActor,
         moved_blockchain::receipt::TransactionReceipt,
         std::iter,
-        tokio::sync::mpsc,
     };
 
     #[tokio::test]
     async fn test_execute() {
-        let (state_channel, rx) = mpsc::channel(10);
         let app = create_app();
-        let state_actor = CommandActor::new(rx, app.clone());
-        let state_handle = state_actor.spawn();
+        let (queue, state) = moved_app::create(app.clone(), 10);
+        let state_handle = state.spawn();
 
         // 1. Send transaction
         let tx_hash = send_raw_transaction::execute(
             send_raw_transaction::tests::example_request(),
-            state_channel.clone(),
+            queue.clone(),
         )
         .await
         .unwrap();
@@ -49,7 +46,7 @@ mod tests {
         let forkchoice_response: ForkchoiceUpdatedResponseV1 = serde_json::from_value(
             forkchoice_updated::execute_v3(
                 forkchoice_updated::tests::example_request(),
-                state_channel.clone(),
+                queue.clone(),
                 &0x03421ee50df45cacu64,
             )
             .await
@@ -57,7 +54,7 @@ mod tests {
         )
         .unwrap();
 
-        drop(state_channel);
+        drop(queue);
         state_handle.await.unwrap();
 
         let request = serde_json::Value::Object(

--- a/api/src/methods/mod.rs
+++ b/api/src/methods/mod.rs
@@ -19,7 +19,6 @@ pub mod send_raw_transaction;
 #[cfg(test)]
 pub mod tests {
     use {
-        crate::json_utils::access_state_error,
         alloy::{
             consensus::{SignableTransaction, TxEip1559, TxEnvelope},
             hex::FromHex,
@@ -52,22 +51,11 @@ pub mod tests {
         moved_shared::primitives::{Address, B256, U64, U256},
         moved_state::InMemoryState,
         std::sync::Arc,
-        tokio::sync::{
-            RwLock,
-            mpsc::{self, Sender},
-        },
+        tokio::sync::{RwLock, mpsc::Sender},
     };
 
     /// The address corresponding to this private key is 0x8fd379246834eac74B8419FfdA202CF8051F7A03
     pub const PRIVATE_KEY: [u8; 32] = [0xaa; 32];
-
-    pub fn create_state_actor() -> (CommandActor<impl DependenciesThreadSafe>, Sender<Command>) {
-        let (state_channel, rx) = mpsc::channel(10);
-        let app = create_app();
-
-        let state: CommandActor<TestDependencies> = CommandActor::new(rx, app);
-        (state, state_channel)
-    }
 
     pub fn create_app() -> Arc<RwLock<Application<TestDependencies>>> {
         let genesis_config = GenesisConfig::default();
@@ -145,7 +133,7 @@ pub mod tests {
             payload_attributes,
             payload_id: U64::from(0x03421ee50df45cacu64),
         };
-        channel.send(msg).await.map_err(access_state_error).unwrap();
+        channel.send(msg).await.unwrap();
     }
 
     pub async fn deploy_contract(contract_bytes: Bytes, channel: &Sender<Command>) {
@@ -175,7 +163,7 @@ pub mod tests {
             payload_attributes,
             payload_id: U64::from(0x03421ee50df45cacu64),
         };
-        channel.send(msg).await.map_err(access_state_error).unwrap();
+        channel.send(msg).await.unwrap();
     }
 
     #[allow(clippy::type_complexity)]

--- a/app/src/factory.rs
+++ b/app/src/factory.rs
@@ -1,0 +1,15 @@
+use {
+    crate::{Application, CommandActor, DependenciesThreadSafe, queue::CommandQueue},
+    std::sync::Arc,
+    tokio::sync::{RwLock, broadcast, mpsc},
+};
+
+pub fn create<T: DependenciesThreadSafe>(
+    app: Arc<RwLock<Application<T>>>,
+    buffer: u32,
+) -> (CommandQueue, CommandActor<T>) {
+    let (ktx, _) = broadcast::channel(1);
+    let (tx, rx) = mpsc::channel(buffer as usize);
+
+    (CommandQueue::new(tx, ktx), CommandActor::new(rx, app))
+}

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1,4 +1,4 @@
-pub use {actor::*, dependency::*, input::*};
+pub mod factory;
 
 pub(crate) mod input;
 
@@ -6,6 +6,9 @@ mod actor;
 mod command;
 mod dependency;
 mod query;
+mod queue;
 
 #[cfg(test)]
 mod tests;
+
+pub use {actor::*, dependency::*, factory::create, input::*, queue::CommandQueue};

--- a/app/src/queue.rs
+++ b/app/src/queue.rs
@@ -1,0 +1,54 @@
+use {
+    crate::Command,
+    std::pin::Pin,
+    tokio::sync::{broadcast, mpsc},
+};
+
+#[derive(Debug, Clone)]
+pub struct CommandQueue {
+    sender: mpsc::Sender<Command>,
+    killshot: broadcast::Sender<()>,
+}
+
+impl CommandQueue {
+    /// Constructs new [`CommandQueue`] that sends [`Command`]s via `sender`.
+    ///
+    /// In case of a panic of the `sender` channel, a shutdown signal is sent through the
+    /// `killshot`.
+    pub fn new(sender: mpsc::Sender<Command>, killshot: broadcast::Sender<()>) -> Self {
+        Self { sender, killshot }
+    }
+
+    /// Sends a [`Command`] to the background queue for asynchronous processing.
+    pub async fn send(&self, msg: Command) {
+        if self.sender.send(msg).await.is_err() {
+            self.shutdown();
+        }
+    }
+
+    /// Waits for all the commands in the queue to be processed.
+    pub async fn wait_for_pending_commands(&self) {
+        if self
+            .sender
+            .reserve_many(self.sender.max_capacity())
+            .await
+            .is_err()
+        {
+            self.shutdown();
+        }
+    }
+
+    /// Signals the shutdown.
+    pub fn shutdown(&self) {
+        self.killshot.send(()).ok();
+    }
+
+    /// Subscribes to the shutdown signal receiver.
+    pub fn shutdown_listener(&self) -> Pin<Box<dyn Future<Output = ()> + Send + Sync>> {
+        let mut rx = self.killshot.subscribe();
+
+        Box::pin(async move {
+            rx.recv().await.ok();
+        })
+    }
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,4 +1,8 @@
 #[tokio::main]
 async fn main() {
-    moved_server::run().await;
+    // TODO: think about channel size bound
+    let max_buffered_commands = 1_000;
+    let max_concurrent_queries = 4;
+
+    moved_server::run(max_buffered_commands, max_concurrent_queries).await;
 }

--- a/server/src/tests/get_proof.rs
+++ b/server/src/tests/get_proof.rs
@@ -5,24 +5,23 @@ use {
         ForkchoiceUpdatedResponseV1, GetBlockResponse, GetPayloadResponseV3, PayloadStatusV1,
         Status,
     },
-    moved_app::{Application, Command, CommandActor, Dependencies},
+    moved_app::{Application, CommandQueue, Dependencies},
     moved_blockchain::{payload::StatePayloadId, state::ProofResponse},
     moved_evm_ext::state,
     moved_genesis::config::GenesisConfig,
     serde::de::DeserializeOwned,
     std::sync::Arc,
-    tokio::sync::{mpsc, RwLock},
+    tokio::sync::RwLock,
 };
 
 #[tokio::test]
 async fn test_get_proof() -> anyhow::Result<()> {
-    let (state_channel, rx) = mpsc::channel(10);
     let genesis_config = GenesisConfig::default();
     let app = initialize_app(genesis_config);
     let app = Arc::new(RwLock::new(app));
-    let state_actor = CommandActor::new(rx, app.clone());
+    let (queue, state) = moved_app::create(app.clone(), 10);
 
-    let state_task = state_actor.spawn();
+    let state_task = state.spawn();
 
     let request = serde_json::json!({
         "jsonrpc": "2.0",
@@ -33,7 +32,7 @@ async fn test_get_proof() -> anyhow::Result<()> {
             true
         ]
     });
-    let genesis_block: GetBlockResponse = handle_request(request, &state_channel, &app).await?;
+    let genesis_block: GetBlockResponse = handle_request(request, &queue, &app).await?;
     let genesis_hash = genesis_block.0.header.hash;
 
     let request = serde_json::json!({
@@ -49,8 +48,7 @@ async fn test_get_proof() -> anyhow::Result<()> {
             null
         ]
     });
-    let response: ForkchoiceUpdatedResponseV1 =
-        handle_request(request, &state_channel, &app).await?;
+    let response: ForkchoiceUpdatedResponseV1 = handle_request(request, &queue, &app).await?;
     assert_eq!(response.payload_status.status, Status::Valid);
 
     let request = serde_json::json!({
@@ -76,13 +74,10 @@ async fn test_get_proof() -> anyhow::Result<()> {
             }
         ]
     });
-    let response: ForkchoiceUpdatedResponseV1 =
-        handle_request(request, &state_channel, &app).await?;
+    let response: ForkchoiceUpdatedResponseV1 = handle_request(request, &queue, &app).await?;
     let payload_id = response.payload_id.unwrap();
 
-    state_channel
-        .reserve_many(state_channel.max_capacity())
-        .await?;
+    queue.wait_for_pending_commands().await;
 
     let request = serde_json::json!({
         "jsonrpc": "2.0",
@@ -92,7 +87,7 @@ async fn test_get_proof() -> anyhow::Result<()> {
            String::from(payload_id),
         ]
     });
-    let response: GetPayloadResponseV3 = handle_request(request, &state_channel, &app).await?;
+    let response: GetPayloadResponseV3 = handle_request(request, &queue, &app).await?;
 
     let request = serde_json::json!({
         "jsonrpc": "2.0",
@@ -104,7 +99,7 @@ async fn test_get_proof() -> anyhow::Result<()> {
            "0x0000000000000000000000000000000000000000000000000000000000000000"
         ]
     });
-    let response: PayloadStatusV1 = handle_request(request, &state_channel, &app).await?;
+    let response: PayloadStatusV1 = handle_request(request, &queue, &app).await?;
     assert_eq!(response.status, Status::Valid);
 
     let request = serde_json::json!({
@@ -116,7 +111,7 @@ async fn test_get_proof() -> anyhow::Result<()> {
             true
         ]
     });
-    let block: GetBlockResponse = handle_request(request, &state_channel, &app).await?;
+    let block: GetBlockResponse = handle_request(request, &queue, &app).await?;
     let state_root = block.0.header.state_root;
 
     let request = serde_json::json!({
@@ -129,7 +124,7 @@ async fn test_get_proof() -> anyhow::Result<()> {
            format!("{}", response.latest_valid_hash.unwrap())
         ]
     });
-    let response: ProofResponse = handle_request(request, &state_channel, &app).await?;
+    let response: ProofResponse = handle_request(request, &queue, &app).await?;
 
     // Proof is verified successfully
     let trie = EthTrie::new(Arc::new(MemoryDB::new(false)));
@@ -155,19 +150,19 @@ async fn test_get_proof() -> anyhow::Result<()> {
         "Proof leaf contains account data"
     );
 
-    drop(state_channel);
+    drop(queue);
     state_task.await.unwrap();
     Ok(())
 }
 
 async fn handle_request<T: DeserializeOwned>(
     request: serde_json::Value,
-    state_channel: &mpsc::Sender<Command>,
+    queue: &CommandQueue,
     app: &Arc<RwLock<Application<impl Dependencies>>>,
 ) -> anyhow::Result<T> {
     let response = moved_api::request::handle(
         request.clone(),
-        state_channel.clone(),
+        queue.clone(),
         |_| true,
         &StatePayloadId,
         app,

--- a/server/src/tests/integration.rs
+++ b/server/src/tests/integration.rs
@@ -78,7 +78,7 @@ async fn test_on_ethereum() -> Result<()> {
 
     // 8. Start op-move to accept requests from the sequencer
     let op_move_runtime = Runtime::new()?;
-    op_move_runtime.spawn(crate::run());
+    op_move_runtime.spawn(crate::run(1_000, 4));
 
     // 9. In separate threads run op-node, op-batcher, op-proposer
     let (op_node, op_batcher, op_proposer) = run_op()?;


### PR DESCRIPTION
# About
Maintains the consistency of the server application state.

# Motivation
If the application is running we want some guarantee that it is in a consistent state that is ready to be used.

# Problem
When a panic happens during the processing of a command, it closes the command channel.

However, the server remains running and still accepts requests to RPC endpoints.

In this application state, if a command is sent to the queue, it fails and returns an RPC error. Such case would be valid if that would be a user error. A command should never panic based on a user input, therefore this does not classify as a user error and should not result in a RPC error response.

# Solution
A server is launched while listening to a graceful shutdown listener. That listener listens to a signal that is turned on when the background thread processing the commands exits.