### PR TITLE
Fix(tx): Return only values from call without layout

### DIFF
--- a/api/src/methods/call.rs
+++ b/api/src/methods/call.rs
@@ -107,7 +107,7 @@ mod tests {
         drop(state_channel);
         state_handle.await.unwrap();
 
-        let expected_response = serde_json::json!([1, 1, 0, 0]);
+        let expected_response = serde_json::json!([1, 1, 0]);
         let actual_response = execute(request, &app).await.unwrap();
 
         assert_eq!(actual_response, expected_response);

--- a/evm-ext/src/events.rs
+++ b/evm-ext/src/events.rs
@@ -78,13 +78,17 @@ pub static EVM_LOGS_EVENT_TAG: LazyLock<StructTag> = LazyLock::new(|| StructTag 
     type_args: Vec::new(),
 });
 
+pub static EVM_LOG_LAYOUT: LazyLock<MoveTypeLayout> = LazyLock::new(|| {
+    MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![
+        MoveTypeLayout::Address,                                // address
+        MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U256)), // topics
+        MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),   // data
+    ]))
+});
+
 pub static EVM_LOGS_EVENT_LAYOUT: LazyLock<MoveTypeLayout> = LazyLock::new(|| {
     MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![MoveTypeLayout::Vector(
-        Box::new(MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![
-            MoveTypeLayout::Address,                                // address
-            MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U256)), // topics
-            MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),   // data
-        ]))),
+        Box::new(EVM_LOG_LAYOUT.clone()),
     )]))
 });
 

--- a/evm-ext/src/lib.rs
+++ b/evm-ext/src/lib.rs
@@ -10,11 +10,15 @@ pub use self::{
 };
 
 use {
+    crate::events::EVM_LOG_LAYOUT,
     move_core_types::{
-        account_address::AccountAddress, ident_str, identifier::IdentStr, value::MoveTypeLayout,
+        account_address::AccountAddress,
+        ident_str,
+        identifier::IdentStr,
+        value::{MoveStructLayout, MoveTypeLayout},
     },
     revm::primitives::Log,
-    std::sync::LazyLock,
+    std::{clone::Clone, sync::LazyLock},
 };
 
 pub mod events;
@@ -34,6 +38,14 @@ pub const EVM_NATIVE_MODULE: &IdentStr = ident_str!("evm");
 /// Layout for EVM byte code. It is simply a byte vector because we store the raw bytes directly.
 pub static CODE_LAYOUT: LazyLock<MoveTypeLayout> =
     LazyLock::new(|| MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)));
+
+pub static EVM_NATIVE_OUTCOME_LAYOUT: LazyLock<MoveTypeLayout> = LazyLock::new(|| {
+    MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![
+        MoveTypeLayout::Bool,
+        CODE_LAYOUT.clone(),
+        MoveTypeLayout::Vector(Box::new(EVM_LOG_LAYOUT.clone())),
+    ]))
+});
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EvmNativeOutcome {

--- a/evm-ext/src/lib.rs
+++ b/evm-ext/src/lib.rs
@@ -18,7 +18,7 @@ use {
         value::{MoveStructLayout, MoveTypeLayout},
     },
     revm::primitives::Log,
-    std::{clone::Clone, sync::LazyLock},
+    std::sync::LazyLock,
 };
 
 pub mod events;

--- a/execution/src/simulate.rs
+++ b/execution/src/simulate.rs
@@ -115,6 +115,8 @@ pub fn call_transaction(
                 verify_input.traversal_context,
                 &code_storage,
             )?;
+            // Only return the results of the transaction in bytes without the Move value layout.
+            // Sending just the bytes works better when it comes to parsing on the client side.
             Ok(bcs::to_bytes(
                 &outcome
                     .return_values

--- a/execution/src/simulate.rs
+++ b/execution/src/simulate.rs
@@ -115,7 +115,13 @@ pub fn call_transaction(
                 verify_input.traversal_context,
                 &code_storage,
             )?;
-            Ok(bcs::to_bytes(&outcome.return_values)?)
+            Ok(bcs::to_bytes(
+                &outcome
+                    .return_values
+                    .into_iter()
+                    .map(|(bytes, _ty)| bytes)
+                    .collect::<Vec<_>>(),
+            )?)
         }
         TransactionData::ScriptOrModule(ScriptOrModule::Script(script)) => {
             crate::execute::execute_script(

--- a/server/src/tests/integration/erc20.rs
+++ b/server/src/tests/integration/erc20.rs
@@ -3,7 +3,7 @@ use {
     super::*,
     alloy::sol_types::SolEvent,
     move_vm_runtime::session::SerializedReturnValues,
-    moved_evm_ext::{extract_evm_result, EVM_NATIVE_ADDRESS},
+    moved_evm_ext::{extract_evm_result, EVM_NATIVE_ADDRESS, EVM_NATIVE_OUTCOME_LAYOUT},
     moved_shared::primitives::{ToEthAddress, ToMoveU256},
 };
 
@@ -239,9 +239,14 @@ pub async fn l2_erc20_balance_of(token: Address, account: Address, rpc_url: &str
         .call()
         .await?;
 
+    // Extract the first result and combine with EVM result layout for deserialization
+    let output: Vec<Vec<u8>> = bcs::from_bytes(&eth_call_result)?;
     let return_values = SerializedReturnValues {
         mutable_reference_outputs: Vec::new(),
-        return_values: bcs::from_bytes(&eth_call_result)?,
+        return_values: Vec::from([(
+            output.first().unwrap().to_owned(),
+            EVM_NATIVE_OUTCOME_LAYOUT.clone(),
+        )]),
     };
     let evm_result = extract_evm_result(return_values);
 
@@ -284,9 +289,13 @@ pub async fn l2_erc20_allowance(
         .call()
         .await?;
 
+    let output: Vec<Vec<u8>> = bcs::from_bytes(&eth_call_result)?;
     let return_values = SerializedReturnValues {
         mutable_reference_outputs: Vec::new(),
-        return_values: bcs::from_bytes(&eth_call_result)?,
+        return_values: Vec::from([(
+            output.first().unwrap().to_owned(),
+            EVM_NATIVE_OUTCOME_LAYOUT.clone(),
+        )]),
     };
     let evm_result = extract_evm_result(return_values);
 


### PR DESCRIPTION
### Description
Only return the results of the transaction in bytes without Move value layout. This is the standard way the results are returned even though `session` execution also returns the layout. This response works better when it comes to parsing on the client side. Closes #322 

### Changes
- Return `call_transaction` response bytes.
- Create EVM native outcome layout to be used in integration test.
- Fix integration test to parse the balance and allowance values from the returned bytes.

### Testing
✓ Integration test passes.