### PR TITLE
Fix(docker): Copy bridged token file

### DIFF
--- a/docker/Dockerfile.op-move
+++ b/docker/Dockerfile.op-move
@@ -53,6 +53,7 @@ COPY genesis/sui.mrb genesis/sui.mrb
 
 # Copy L2 genesis config into expected path
 COPY execution/src/tests/res/l2_genesis_tests.json src/tests/optimism/packages/contracts-bedrock/deployments/genesis.json
+COPY execution/src/tests/res/bridged_tokens_test.json execution/src/tests/res/bridged_tokens_test.json
 
 # Copy built binary
 COPY --from=build /volume/op-move /volume/op-move


### PR DESCRIPTION
### Description
`op-move` fails to run with `docker compose` and the error message is:

```
Tokens list should parse: Path: "/volume/execution/src/tests/res/bridged_tokens_test.json"
No such file or directory (os error 2)
```

### Changes
- Copy the bridged token JSON file that's used in genesis config

### Testing
✓ Docker compose runs successfully on the cloud