### PR TITLE
perf(app): Remove `UpdateHead` command

### DIFF
--- a/api/src/methods/forkchoice_updated.rs
+++ b/api/src/methods/forkchoice_updated.rs
@@ -59,12 +59,6 @@ async fn inner_execute_v3(
 
     // TODO: implement proper validation of Forkchoice state
 
-    // Update the state with the new head
-    let msg = Command::UpdateHead {
-        block_hash: forkchoice_state.head_block_hash,
-    };
-    queue.send(msg).await;
-
     let payload_status = PayloadStatusV1 {
         status: Status::Valid,
         latest_valid_hash: Some(forkchoice_state.head_block_hash),

--- a/api/src/methods/get_payload.rs
+++ b/api/src/methods/get_payload.rs
@@ -36,7 +36,7 @@ mod tests {
         super::*,
         crate::methods::forkchoice_updated,
         alloy::primitives::hex,
-        moved_app::{Application, Command, CommandActor, TestDependencies},
+        moved_app::{Application, CommandActor, TestDependencies},
         moved_blockchain::{
             block::{
                 Block, BlockRepository, Eip1559GasFee, InMemoryBlockQueries,
@@ -132,12 +132,6 @@ mod tests {
         }));
         let (queue, state) = moved_app::create(app.clone(), 10);
         let state_handle = state.spawn();
-
-        // Set head block hash
-        let msg = Command::UpdateHead {
-            block_hash: head_hash,
-        };
-        queue.send(msg).await;
 
         // Update the state with an execution payload
         forkchoice_updated::execute_v3(

--- a/api/src/methods/mod.rs
+++ b/api/src/methods/mod.rs
@@ -126,8 +126,11 @@ pub mod tests {
 
         let mut encoded = Vec::new();
         tx.encode(&mut encoded);
-        let mut payload_attributes = Payload::default();
-        payload_attributes.transactions.push(encoded.into());
+        let payload_attributes = Payload {
+            gas_limit: U64::MAX,
+            transactions: vec![encoded.into()],
+            ..Default::default()
+        };
 
         let msg = Command::StartBlockBuild {
             payload_attributes,
@@ -156,8 +159,11 @@ pub mod tests {
 
         let mut encoded = Vec::new();
         tx.encode(&mut encoded);
-        let mut payload_attributes = Payload::default();
-        payload_attributes.transactions.push(encoded.into());
+        let payload_attributes = Payload {
+            gas_limit: U64::MAX,
+            transactions: vec![encoded.into()],
+            ..Default::default()
+        };
 
         let msg = Command::StartBlockBuild {
             payload_attributes,

--- a/app/src/actor.rs
+++ b/app/src/actor.rs
@@ -45,7 +45,6 @@ impl<D: Dependencies> CommandActor<D> {
 
     pub fn handle_command(mut app: impl DerefMut<Target = Application<D>>, msg: Command) {
         match msg {
-            Command::UpdateHead { block_hash } => app.update_head(block_hash),
             Command::StartBlockBuild {
                 payload_attributes,
                 payload_id,

--- a/app/src/command.rs
+++ b/app/src/command.rs
@@ -30,10 +30,6 @@ use {
 };
 
 impl<D: Dependencies> Application<D> {
-    pub fn update_head(&mut self, block_hash: B256) {
-        self.head = block_hash;
-    }
-
     pub fn start_block_build(&mut self, attributes: Payload, id: PayloadId) {
         // Include transactions from both `payload_attributes` and internal mem-pool
         let transactions = attributes
@@ -146,6 +142,8 @@ impl<D: Dependencies> Application<D> {
         self.block_repository.add(&mut self.storage, block).unwrap();
 
         self.height = self.height.max(block_number);
+        self.head = block_hash;
+
         (self.on_payload)(self, id, block_hash);
     }
 

--- a/app/src/input.rs
+++ b/app/src/input.rs
@@ -22,9 +22,6 @@ pub type Withdrawal = alloy::rpc::types::Withdrawal;
 
 #[derive(Debug)]
 pub enum Command {
-    UpdateHead {
-        block_hash: B256,
-    },
     StartBlockBuild {
         payload_attributes: Payload,
         payload_id: PayloadId,

--- a/app/src/tests.rs
+++ b/app/src/tests.rs
@@ -399,7 +399,13 @@ fn test_older_payload_can_be_fetched_again_successfully() {
 
     let payload_id = U64::from(0x03421ee50df45cacu64);
 
-    app.start_block_build(Default::default(), payload_id);
+    app.start_block_build(
+        Payload {
+            gas_limit: U64::MAX,
+            ..Default::default()
+        },
+        payload_id,
+    );
 
     let expected_payload = app.payload(payload_id);
 
@@ -412,6 +418,7 @@ fn test_older_payload_can_be_fetched_again_successfully() {
     app.start_block_build(
         Payload {
             timestamp: U64::from(1u64),
+            gas_limit: U64::MAX,
             ..Default::default()
         },
         payload_2_id,

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -6,7 +6,7 @@ use {
     moved_api::method_name::MethodName,
     moved_app::{Application, Command, CommandQueue, Dependencies},
     moved_blockchain::{
-        block::{Block, BlockHash, BlockRepository, ExtendedBlock, Header},
+        block::{Block, BlockHash, ExtendedBlock, Header},
         payload::{NewPayloadId, StatePayloadId},
     },
     moved_genesis::config::GenesisConfig,
@@ -163,11 +163,8 @@ pub fn initialize_app(genesis_config: GenesisConfig) -> Application<dependency::
     );
 
     let genesis_block = create_genesis_block(&app.block_hash, &genesis_config);
-    let head = genesis_block.hash;
-    app.block_repository
-        .add(&mut app.storage, genesis_block)
-        .expect("Database should be ready");
-    app.update_head(head);
+
+    app.genesis_update(genesis_block);
 
     app
 }


### PR DESCRIPTION
### Description

While observing the commands received in the app as part of making benchmarks I noticed that the `UpdateHead` command is called repeatedly in unbroken sequences with the same hash.

The command is invoked when calling `engine_forkchoiceUpdated` by `op-node`. This endpoint is called repeatedly without payload as a part of canonical chain validation process. Every time this endpoint is invoked it produces `UpdateHead` command.

This behavior is incorrect, but that is expected and recorded in the issue #63. Perhaps this way was to instead of validation assume that the op-node state is valid and make sure op-move is at the same state.

Effectively this only does one thing which is sets the head hash to the last block. It is critical that this happens. If the head pointer is not correctly updated, building block panics.

Building the block should update the head and validating forkchoice state should not update the state, hence this change. This gives us the following results:

* Reduces the amount of commands received by ~75%
* Reveals bugs in tests where the head is not updated and multiple blocks are built with genesis as parent
* Reveals another bug that causes division by zero when payload received had `gas_limit` set to zero

### Changes
- Update the head block hash pointer only when building new block
- Fix error where having `gas_limit` causes division by zero

### Testing
```
cargo test
```