### PR TITLE
feat: Compute `head` and `height` pointers from persisted data

### DIFF
--- a/api/src/methods/get_payload.rs
+++ b/api/src/methods/get_payload.rs
@@ -107,8 +107,6 @@ mod tests {
         let app = Arc::new(RwLock::new(Application::<TestDependencies<_, _, _, _>> {
             mem_pool: Default::default(),
             genesis_config,
-            head: head_hash,
-            height: 0,
             state,
             block_hash: head_hash,
             block_repository: repository,

--- a/api/src/methods/new_payload.rs
+++ b/api/src/methods/new_payload.rs
@@ -287,8 +287,6 @@ mod tests {
 
         let app = Arc::new(RwLock::new(Application::<TestDependencies<_, _, _, _>> {
             mem_pool: Default::default(),
-            head: head_hash,
-            height: 0,
             genesis_config,
             gas_fee: Eip1559GasFee::default(),
             base_token: (),

--- a/app/src/dependency.rs
+++ b/app/src/dependency.rs
@@ -12,8 +12,6 @@ use {
 
 pub struct Application<D: Dependencies> {
     pub genesis_config: GenesisConfig,
-    pub head: B256,
-    pub height: u64,
     pub mem_pool: HashMap<B256, (ExtendedTxEnvelope, L1GasFeeInput)>,
     pub gas_fee: D::BaseGasFee,
     pub base_token: D::BaseTokenAccounts,
@@ -41,8 +39,6 @@ impl<D: Dependencies> Application<D> {
     pub fn new(_: D, genesis_config: &GenesisConfig) -> Self {
         Self {
             genesis_config: genesis_config.clone(),
-            head: Default::default(),
-            height: 0,
             mem_pool: Default::default(),
             gas_fee: D::base_gas_fee(),
             base_token: D::base_token_accounts(genesis_config),

--- a/app/src/tests.rs
+++ b/app/src/tests.rs
@@ -70,7 +70,12 @@ fn create_app_with_given_queries<SQ: StateQueries + Send + Sync + 'static>(
 
     let mut memory = SharedMemory::new();
     let mut repository = InMemoryBlockRepository::new();
-    repository.add(&mut memory, genesis_block).unwrap();
+
+    for i in 0..=height {
+        let mut block = genesis_block.clone();
+        block.block.header.number = i;
+        repository.add(&mut memory, block).unwrap();
+    }
 
     let mut state = InMemoryState::new();
     let mut evm_storage = InMemoryStorageTrieRepository::new();
@@ -86,8 +91,6 @@ fn create_app_with_given_queries<SQ: StateQueries + Send + Sync + 'static>(
 
     Application {
         mem_pool: Default::default(),
-        head: head_hash,
-        height,
         genesis_config,
         base_token: MovedBaseTokenAccounts::new(AccountAddress::ONE),
         block_hash: MovedBlockHash,
@@ -156,7 +159,6 @@ fn create_app_with_fake_queries(
     let head_hash = B256::new(hex!(
         "e56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d"
     ));
-    let height = 0;
     let genesis_block = Block::default().with_hash(head_hash).with_value(U256::ZERO);
 
     let mut memory = SharedMemory::new();
@@ -177,8 +179,6 @@ fn create_app_with_fake_queries(
 
     Application::<TestDependencies> {
         mem_pool: Default::default(),
-        head: head_hash,
-        height,
         genesis_config,
         base_token: MovedBaseTokenAccounts::new(AccountAddress::ONE),
         block_hash: MovedBlockHash,

--- a/blockchain/src/block/in_memory.rs
+++ b/blockchain/src/block/in_memory.rs
@@ -57,6 +57,10 @@ impl BlockMemory {
         let index = *self.heights.get(&height)?;
         self.blocks.get(index).cloned()
     }
+
+    pub fn last(&self) -> Option<&ExtendedBlock> {
+        self.blocks.last()
+    }
 }
 
 /// Block repository that works with in memory backing store [`BlockMemory`].
@@ -86,6 +90,10 @@ impl BlockRepository for InMemoryBlockRepository {
 
     fn by_hash(&self, mem: &Self::Storage, hash: B256) -> Result<Option<ExtendedBlock>, Self::Err> {
         Ok(mem.block_memory.by_hash(hash))
+    }
+
+    fn latest(&self, mem: &Self::Storage) -> Result<Option<ExtendedBlock>, Self::Err> {
+        Ok(mem.block_memory.last().cloned())
     }
 }
 
@@ -134,6 +142,10 @@ impl BlockQueries for InMemoryBlockQueries {
                 .map(BlockResponse::from_block_with_transaction_hashes)
         })
     }
+
+    fn latest(&self, mem: &Self::Storage) -> Result<Option<u64>, Self::Err> {
+        Ok(mem.block_memory.last().map(|v| v.block.header.number))
+    }
 }
 
 #[cfg(any(feature = "test-doubles", test))]
@@ -161,6 +173,10 @@ mod test_doubles {
         ) -> Result<Option<BlockResponse>, Self::Err> {
             Ok(None)
         }
+
+        fn latest(&self, _: &Self::Storage) -> Result<Option<u64>, Self::Err> {
+            Ok(None)
+        }
     }
 
     impl BlockRepository for () {
@@ -172,6 +188,10 @@ mod test_doubles {
         }
 
         fn by_hash(&self, _: &Self::Storage, _: B256) -> Result<Option<ExtendedBlock>, Self::Err> {
+            Ok(None)
+        }
+
+        fn latest(&self, _: &Self::Storage) -> Result<Option<ExtendedBlock>, Self::Err> {
             Ok(None)
         }
     }

--- a/blockchain/src/block/root.rs
+++ b/blockchain/src/block/root.rs
@@ -23,6 +23,8 @@ pub trait BlockQueries: Debug {
         height: u64,
         include_transactions: bool,
     ) -> Result<Option<BlockResponse>, Self::Err>;
+
+    fn latest(&self, storage: &Self::Storage) -> Result<Option<u64>, Self::Err>;
 }
 
 pub trait BlockRepository: Debug {
@@ -38,6 +40,8 @@ pub trait BlockRepository: Debug {
         storage: &Self::Storage,
         hash: B256,
     ) -> Result<Option<ExtendedBlock>, Self::Err>;
+
+    fn latest(&self, storage: &Self::Storage) -> Result<Option<ExtendedBlock>, Self::Err>;
 }
 
 pub type Header = alloy::consensus::Header;

--- a/server/src/dependency/rocksdb.rs
+++ b/server/src/dependency/rocksdb.rs
@@ -1,6 +1,5 @@
 use {
     crate::dependency::shared::*,
-    move_core_types::effects::ChangeSet,
     moved_app::{Application, CommandActor},
     moved_genesis::config::GenesisConfig,
     moved_state::State,

--- a/storage/heed/src/all.rs
+++ b/storage/heed/src/all.rs
@@ -46,6 +46,14 @@ impl<Key, Value> HeedDb<Key, Value> {
         self.0.get(txn, key)
     }
 
+    pub fn last<'txn>(&self, txn: &'txn RoTxn) -> heed::Result<Option<(Key::DItem, Value::DItem)>>
+    where
+        Key: BytesDecode<'txn>,
+        Value: BytesDecode<'txn>,
+    {
+        self.0.last(txn)
+    }
+
     pub fn lazily_decode_data(&self) -> HeedDb<Key, LazyDecode<Value>> {
         HeedDb(self.0.lazily_decode_data())
     }

--- a/storage/heed/src/generic.rs
+++ b/storage/heed/src/generic.rs
@@ -1,7 +1,7 @@
 use {
     heed::{
         BoxedError, BytesDecode, BytesEncode,
-        byteorder::LittleEndian,
+        byteorder::BigEndian,
         types::{Bytes, U64},
     },
     moved_shared::primitives::{Address, B256},
@@ -47,7 +47,7 @@ impl<'item> BytesDecode<'item> for EncodableAddress {
     }
 }
 
-pub type EncodableU64 = U64<LittleEndian>;
+pub type EncodableU64 = U64<BigEndian>;
 pub type EncodableBytes = Bytes;
 
 /// Describes a type that is [`Serialize`]/[`Deserialize`] and uses `serde_json` to do so.


### PR DESCRIPTION
### Description
An on-ramp to #268 is to remove `head` and `height` pointers. The reason is that these pointers are lost when the node shuts down. To resolve this, these need to be computed from persisted data instead.

### Changes
- Remove `Application::height`
- Remove `Application::head`
- Add `BlockRepository::latest`
- Add `BlockQuery::latest`

### Testing
```
cargo test
```
```
docker compose down && docker compose build && docker compose up -d && docker compose logs -f
```

### Notes
* Endianness of `HeightKey` in `storage_heed` was switched to big endian, because otherwise the `last` iterator caps out at 256 / 0xff.