### PR TITLE
fix(genesis): Do not apply `ChangeSet` to `State` on build

### DIFF
--- a/genesis-image/build.rs
+++ b/genesis-image/build.rs
@@ -5,7 +5,6 @@ use {
     moved_genesis::{
         MovedVm, SerdeAllChanges, SerdeChanges, SerdeTableChangeSet, build, config::GenesisConfig,
     },
-    moved_state::{InMemoryState, State},
     std::io::Write,
 };
 
@@ -13,22 +12,20 @@ fn main() {
     // We're particularly interested in Aptos / Sui bundle changes, but wouldn't
     // hurt to rerun whenever anything in genesis changes as it's a separate package
     println!("cargo::rerun-if-changed=../genesis/");
-    let mut state = InMemoryState::default();
     let storage_trie = InMemoryStorageTrieRepository::new();
     let genesis_config = GenesisConfig::default();
     let vm = MovedVm::new(&genesis_config);
 
-    save(&vm, &genesis_config, &mut state, &storage_trie);
+    save(&vm, &genesis_config, &storage_trie);
 }
 
 pub fn save(
     vm: &MovedVm,
     config: &GenesisConfig,
-    state: &mut impl State,
     storage_trie: &impl StorageTrieRepository,
 ) -> (ChangeSet, TableChangeSet) {
     let path = std::env::var("OUT_DIR").unwrap() + "/genesis.bin";
-    let (changes, table_changes, evm_storage) = build(vm, config, state, storage_trie);
+    let (changes, table_changes, evm_storage) = build(vm, config, storage_trie);
     let changes = SerdeChanges::from(changes);
     let tables = SerdeTableChangeSet::from(table_changes);
     let all_changes = SerdeAllChanges::new(changes, tables, evm_storage.into());

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -148,7 +148,6 @@ pub fn initialize_app(genesis_config: GenesisConfig) -> Application<dependency::
             moved_genesis::build(
                 &moved_genesis::MovedVm::new(&genesis_config),
                 &genesis_config,
-                &mut app.state,
                 &app.evm_storage,
             )
         }


### PR DESCRIPTION
### Description
Genesis state build should produce changes without applying them in a side-effect free manner.

The node crashes on startup when using in-memory storage backend as a consequence of applying some parts of the `ChangeSet` twice.

### Changes
- Remove `&mut State` parameter from `moved_genesis::build`
- Use temporary `InMemoryState` inside `moved_genesis::build`

### Testing
```
docker compose build && docker compose up -d
```
With `--feature storage` removed from `docker/Dockerfile.op-move`
