### PR TITLE
feat(server): Recover from persisted state

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,7 @@ services:
       - localnet
     volumes:
       - ./docker/volumes/shared:/volume/shared
+      - ./docker/volumes/db:/volume/db
     ports:
       - "8545:8545"
 

--- a/server/src/dependency/heed.rs
+++ b/server/src/dependency/heed.rs
@@ -117,11 +117,7 @@ fn create_db() -> moved_storage_heed::Env {
 
     let path = "db";
 
-    if std::fs::exists(path).unwrap() {
-        std::fs::remove_dir_all(path)
-            .expect("Removing non-empty database directory should succeed");
-    }
-    std::fs::create_dir(path).unwrap();
+    let _ = std::fs::create_dir(path);
 
     let env = unsafe {
         EnvOpenOptions::new()


### PR DESCRIPTION
Following-up on #350 the node can simply start-up and recover from persisted state exactly where it stopped. Strictly speaking, the only thing that can be lost is the transactions mem-pool if it's not empty.

However, this still does not grant reliable re-deployment of upgraded versions of the op-move container. The reason is that the op stack may not fully recover past the brief unavailability of the execution client.

The next step is to investigate ways to grant that the op stack survives op-move restart.
1. Maybe there are ways to improve graceful shutdown?
2. Implement zero-downtime deployment configuration

Specifically the option 2 should be the best because if the node restores from persisted state and there is no unavailability, then it's the same as if the node is running continuously. This also improves the UX as the RPC does not experience any downtime.