### PR TITLE
chore(gas): reword operator fee todo for clarity

### DIFF
--- a/execution/src/gas.rs
+++ b/execution/src/gas.rs
@@ -164,7 +164,9 @@ impl L1GasFee for EcotoneGasFee {
             l1_base_fee_scalar: Some(self.base_fee_scalar.saturating_to()),
             l1_blob_base_fee: Some(self.blob_base_fee.saturating_to()),
             l1_blob_base_fee_scalar: Some(self.blob_base_fee_scalar.saturating_to()),
-            // TODO(#327): What are these?
+            // TODO: These fields are at operator discretion and were introduced with
+            // Isthmus hard fork (<https://gov.optimism.io/t/upgrade-proposal-15-isthmus-hard-fork/9804>).
+            // They are not set by default yet, but might be in the future, so we track it in a separate issue. (#327)
             operator_fee_scalar: None,
             operator_fee_constant: None,
         })


### PR DESCRIPTION
### Description
<!-- What does this PR do? -->
After research into the OP governance docs regarding operator fees, I found out that these fields are indeed set at L1 level in the SystemConfig contract, but their storage slots and values are still 0, though it might change if some consensus baseline for them is agreed upon in the future. So #327 still needs to stay open, but I demoted it to P2 as we're not doing anything wrong yet.
<!-- Fixes #123 -->

### Changes
<!-- Key changes -->
- Clearer wording for the TODO
