### PR TITLE
refactor(state): Remove `db` from `State` trait

### DIFF
--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -25,7 +25,7 @@ use {
     move_table_extension::TableResolver,
     move_vm_types::{code::ModuleBytesStorage, resolver::MoveResolver},
     nodes::{TreeKey, TreeValue},
-    std::{collections::HashMap, fmt::Debug, sync::Arc},
+    std::{collections::HashMap, fmt::Debug},
     umi_evm_ext::{EVM_NATIVE_ADDRESS, EVM_NATIVE_MODULE, type_utils::ACCOUNT_INFO_PREFIX},
     umi_shared::primitives::{Address, B256, KeyHashable},
 };
@@ -46,10 +46,6 @@ pub trait State {
 
     /// Applies the `changes` to the blockchain state.
     fn apply(&mut self, changes: Changes) -> Result<(), Self::Err>;
-
-    /// Returns a reference to a [`DB`] that can access the merkle trie holding the current
-    /// blockchain state.
-    fn db(&self) -> Arc<impl DB>;
 
     /// Returns a reference to a [`MoveResolver`] that can resolve both resources and modules on
     /// the current blockchain state.

--- a/state/src/state.rs
+++ b/state/src/state.rs
@@ -56,10 +56,6 @@ impl<D: DbWithRoot> State for EthTrieState<D> {
             .map_err(|e| TrieError::DB(e.to_string()))
     }
 
-    fn db(&self) -> Arc<impl DB> {
-        self.db().clone()
-    }
-
     fn resolver(&self) -> &(impl MoveResolver + TableResolver) {
         &self.resolver
     }


### PR DESCRIPTION
### Description
`State` is not responsible for creating its own `eth_trie::DB` since 0130abb3

It also binds `eth_trie` implementation with the trait. The interface should not assume it's implementation.

### Changes
- Remove `State::db`

### Testing
:green_circle: fmt
:green_circle: clippy
:green_circle: test