### PR TITLE
fix(api): add missing resolver cache to a custom create app method

### DIFF
--- a/api/src/methods/block_number.rs
+++ b/api/src/methods/block_number.rs
@@ -76,6 +76,7 @@ mod tests {
             },
             Application {
                 mem_pool: Default::default(),
+                resolver_cache: Default::default(),
                 genesis_config,
                 gas_fee: Eip1559GasFee::default(),
                 base_token: UmiBaseTokenAccounts::new(AccountAddress::ONE),


### PR DESCRIPTION
### Description
<!-- What does this PR do? -->
I broke the CI by not altering one of the new tests after rebase, so this is a one-line fix. 
<!-- Fixes #123 -->

### Changes
<!-- Key changes -->
- Fixed method in `api/methods/block_number`


### Testing
<!-- How was it tested? -->

### Notes
<!-- Additional info -->