### PR TITLE
feat(server-args): Implement `Layer` that parses CLI arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12494,6 +12494,7 @@ dependencies = [
 name = "umi-server-args"
 version = "0.1.0"
 dependencies = [
+ "clap 4.5.39",
  "serde",
  "thiserror 1.0.69",
  "toml 0.8.23",

--- a/server/args/Cargo.toml
+++ b/server/args/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+clap.workspace = true
 toml.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/server/args/src/declaration.rs
+++ b/server/args/src/declaration.rs
@@ -1,4 +1,9 @@
-use {serde::Deserialize, std::net::SocketAddr, thiserror::Error};
+use {
+    clap::{Args, Parser},
+    serde::Deserialize,
+    std::net::SocketAddr,
+    thiserror::Error,
+};
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Config {
@@ -17,20 +22,25 @@ pub struct HttpSocket {
     pub addr: SocketAddr,
 }
 
-#[derive(Deserialize, PartialEq, Debug, Clone, Default)]
+#[derive(Deserialize, Parser, PartialEq, Debug, Clone, Default)]
 pub struct OptionalConfig {
+    #[command(flatten)]
     pub auth: Option<OptionalAuthSocket>,
+    #[command(flatten)]
     pub http: Option<OptionalHttpSocket>,
 }
 
-#[derive(Deserialize, PartialEq, Debug, Clone, Default)]
+#[derive(Deserialize, Args, PartialEq, Debug, Clone, Default)]
 pub struct OptionalAuthSocket {
+    #[arg(long = "auth.addr", id = "auth.addr")]
     pub addr: Option<SocketAddr>,
+    #[arg(long = "auth.jwt-secret", id = "auth.jwt-secret")]
     pub jwt_secret: Option<String>,
 }
 
-#[derive(Deserialize, PartialEq, Debug, Clone, Default)]
+#[derive(Deserialize, Args, PartialEq, Debug, Clone, Default)]
 pub struct OptionalHttpSocket {
+    #[arg(long = "http.addr", id = "http.addr")]
     pub addr: Option<SocketAddr>,
 }
 

--- a/server/args/src/layers/cli.rs
+++ b/server/args/src/layers/cli.rs
@@ -1,0 +1,58 @@
+use {
+    crate::{declaration::OptionalConfig, stack::Layer},
+    clap::Parser,
+    std::{
+        env::{self, ArgsOs},
+        ffi::OsString,
+    },
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct CliLayer<Args>(Args);
+
+impl CliLayer<ArgsOs> {
+    pub fn new() -> Self {
+        Self(env::args_os())
+    }
+}
+
+impl<Args: IntoIterator<Item: Into<OsString> + Clone>> Layer for CliLayer<Args> {
+    type Err = clap::Error;
+
+    fn try_load(self) -> Result<OptionalConfig, Self::Err> {
+        OptionalConfig::try_parse_from(self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::declaration::{OptionalAuthSocket, OptionalHttpSocket},
+    };
+
+    #[test]
+    fn test_cli_layer_parses_arguments_successfully() {
+        let layer = CliLayer(vec![
+            "",
+            "--http.addr",
+            "0.0.0.0:1",
+            "--auth.addr",
+            "0.0.0.0:2",
+            "--auth.jwt-secret",
+            "test",
+        ]);
+        let actual_config = layer.try_load().unwrap();
+        let expected_config = OptionalConfig {
+            auth: Some(OptionalAuthSocket {
+                addr: "0.0.0.0:2".parse().ok(),
+                jwt_secret: Some("test".to_owned()),
+            }),
+            http: Some(OptionalHttpSocket {
+                addr: "0.0.0.0:1".parse().ok(),
+            }),
+        };
+
+        assert_eq!(actual_config, expected_config);
+    }
+}

--- a/server/args/src/layers/mod.rs
+++ b/server/args/src/layers/mod.rs
@@ -1,3 +1,4 @@
-pub use file::FileLayer;
+pub use {cli::CliLayer, file::FileLayer};
 
+mod cli;
 mod file;

--- a/server/args/src/lib.rs
+++ b/server/args/src/lib.rs
@@ -1,5 +1,5 @@
 pub use {
-    layers::FileLayer,
+    layers::{CliLayer, FileLayer},
     stack::{ConfigBuilder, Layer},
 };
 


### PR DESCRIPTION
### Description
Adds a `Layer` that loads config from command-line arguments.

### Changes
- Add `CliLayer`

### Testing
:green_circle: CI

### Notes
#45 