### PR TITLE
feat(server-args): Add genesis configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12511,6 +12511,7 @@ dependencies = [
  "serde-env",
  "thiserror 1.0.69",
  "toml 0.8.23",
+ "umi-shared",
 ]
 
 [[package]]

--- a/genesis/src/config.rs
+++ b/genesis/src/config.rs
@@ -4,7 +4,7 @@ use {
     aptos_gas_schedule::{InitialGasSchedule, NativeGasParameters, VMGasParameters},
     aptos_vm_types::storage::StorageGasParameters,
     move_core_types::{account_address::AccountAddress, gas_algebra::GasQuantity},
-    std::path::Path,
+    std::{fs::File, path::Path},
     umi_shared::primitives::B256,
 };
 
@@ -64,6 +64,25 @@ impl Default for GasCosts {
         result.vm.txn.max_execution_gas = GasQuantity::new(INTERNAL_EXECUTION_LIMIT);
         result.vm.txn.min_transaction_gas_units = GasQuantity::new(TRANSACTION_BASE_COST);
         result
+    }
+}
+
+impl GenesisConfig {
+    pub fn try_new(
+        chain_id: u64,
+        initial_state_root: B256,
+        treasury: AccountAddress,
+        l2_contract_genesis: &Path,
+        token_list: &Path,
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
+            chain_id,
+            initial_state_root,
+            gas_costs: Default::default(),
+            treasury,
+            l2_contract_genesis: serde_json::from_reader(File::open(l2_contract_genesis)?)?,
+            token_list: bridged_tokens::parse_token_list(token_list)?,
+        })
     }
 }
 

--- a/server/args/Cargo.toml
+++ b/server/args/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+umi-shared.workspace = true
 clap.workspace = true
 toml.workspace = true
 serde.workspace = true

--- a/server/args/src/stack.rs
+++ b/server/args/src/stack.rs
@@ -76,9 +76,10 @@ mod tests {
         super::*,
         crate::{
             declaration::{AuthSocket, HttpSocket, OptionalAuthSocket, OptionalHttpSocket},
-            Database, DatabaseBackend, OptionalDatabase,
+            Database, DatabaseBackend, Genesis, OptionalDatabase, OptionalGenesis,
         },
         std::path::Path,
+        umi_shared::primitives::{MoveAddress, B256},
     };
 
     pub struct StubLayer(OptionalConfig);
@@ -111,6 +112,13 @@ mod tests {
                     dir: Some(Path::new("db").into()),
                     purge: Some(false),
                 }),
+                genesis: Some(OptionalGenesis {
+                    chain_id: Some(1),
+                    initial_state_root: Some(B256::ZERO),
+                    treasury: Some(MoveAddress::ZERO),
+                    l2_contract_genesis: Some(Path::new("l2").into()),
+                    token_list: Some(Path::new("tokens").into()),
+                }),
             }))
             .layer(StubLayer(OptionalConfig {
                 auth: None,
@@ -133,6 +141,13 @@ mod tests {
                 backend: DatabaseBackend::InMemory,
                 dir: Path::new("db").into(),
                 purge: false,
+            },
+            genesis: Genesis {
+                chain_id: 1,
+                initial_state_root: B256::ZERO,
+                treasury: MoveAddress::ZERO,
+                l2_contract_genesis: Path::new("l2").into(),
+                token_list: Path::new("tokens").into(),
             },
         };
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,3 +1,5 @@
+pub use alloy::hex;
+
 pub mod error;
 pub mod iter;
 pub mod primitives;

--- a/shared/src/primitives.rs
+++ b/shared/src/primitives.rs
@@ -1,4 +1,7 @@
-pub use alloy::primitives::{Address, B64, B256, Bytes, U64, U256, aliases::B2048};
+pub use {
+    alloy::primitives::{Address, B64, B256, Bytes, U64, U256, aliases::B2048},
+    move_core_types::account_address::AccountAddress as MoveAddress,
+};
 
 use {
     alloy::consensus::{Receipt, ReceiptWithBloom},


### PR DESCRIPTION
### Description
Adds genesis parameters into the main `Config`.

### Changes
- Add `Genesis` into `Config`
- Use the `Genesis` parameters in the server `run` function

### Testing
:green_circle: Fmt
:green_circle: Clippy
:green_circle: Test

### Notes
#45 