### PR TITLE
build(docker): Squash all `RUN` stages and remove all useless files in the `foundry` image

### DIFF
--- a/docker/Dockerfile.foundry
+++ b/docker/Dockerfile.foundry
@@ -1,29 +1,35 @@
 FROM alpine:3.20
-
 ARG TARGETARCH
 WORKDIR /opt
 
-RUN apk add clang lld curl build-base linux-headers git \
+RUN --mount=type=cache,target=/root/.cargo/registry --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/opt/foundry/target \
+    [[ "$TARGETARCH" = "arm64" ]] && echo "export CFLAGS=-mno-outline-atomics" >> $HOME/.profile || true \
+    # Install dependencies
+    && apk add clang lld curl build-base linux-headers git \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh \
     && chmod +x ./rustup.sh \
-    && ./rustup.sh -y
-
-RUN [[ "$TARGETARCH" = "arm64" ]] && echo "export CFLAGS=-mno-outline-atomics" >> $HOME/.profile || true
-
-WORKDIR /opt/foundry
-RUN git clone https://github.com/foundry-rs/foundry.git . && git checkout 1bcd17c
-
-# see <https://github.com/foundry-rs/foundry/issues/7925>
-RUN git update-index --force-write-index
-
-RUN --mount=type=cache,target=/root/.cargo/registry --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/opt/foundry/target \
-    source $HOME/.profile && cargo build --release --features cast/aws-kms,forge/aws-kms \
+    && ./rustup.sh -y \
+    # Add sources \
+    && git clone https://github.com/foundry-rs/foundry.git foundry2 \
+    && mv foundry2/.* foundry2/* foundry/ || true \
+    && rm -rf foundry2 \
+    && git -C foundry checkout 1bcd17c \
+    # See <https://github.com/foundry-rs/foundry/issues/7925>
+    && git -C foundry update-index --force-write-index \
+    # Build
+    && source $HOME/.profile \
+    && cargo build --release --features cast/aws-kms,forge/aws-kms --manifest-path foundry/Cargo.toml \
     && mkdir out \
-    && mv target/release/forge out/forge \
-    && mv target/release/cast out/cast \
-    && mv target/release/anvil out/anvil \
-    && mv target/release/chisel out/chisel \
+    && mv foundry/target/release/forge out/forge \
+    && mv foundry/target/release/cast out/cast \
+    && mv foundry/target/release/anvil out/anvil \
+    && mv foundry/target/release/chisel out/chisel \
     && strip out/forge \
     && strip out/cast \
     && strip out/chisel \
-    && strip out/anvil;
+    && strip out/anvil \
+    # Cleanup
+    && apk del clang lld curl build-base linux-headers git \
+    && find foundry -maxdepth 1 -mindepth 1 ! -name target -exec rm -rf {} \; \
+    && find ~/.cargo -maxdepth 1 -mindepth 1 ! -name git ! -name registry -exec rm -rf {} \; \
+    && rm -rf rustup.sh /tmp/* ~/.rustup ;


### PR DESCRIPTION
### Description
To speed up build times and minimize space requirements we need to minimize:
* Cache size
* Image size

Or in other words:
* Number of layers
* Size of layers

This change squashes all `RUN` stages and removes all files after usage.

Decreases the image size from over **2 gigabytes** to under **200 megabytes**.

### Changes
- Squash all RUN stages in `foundry` image
- Cleanup all build files and tools in `foundry` image

### Testing
By calling `docker compose build foundry`
