### PR TITLE
build(docker): Declare image dependencies using `additional_context`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     build:
       context: ./
       dockerfile: ./docker/Dockerfile.optimism
+      additional_contexts:
+        ghcr.io/uminetwork/foundry: "service:foundry"
     depends_on:
       - foundry
     deploy:
@@ -24,6 +26,9 @@ services:
     build:
       context: ./
       dockerfile: ./docker/Dockerfile.op-node
+      additional_contexts:
+        ghcr.io/uminetwork/optimism: "service:optimism"
+        ghcr.io/uminetwork/foundry: "service:foundry"
     environment:
       JWT_SECRET: "f3099a1d969c4f5aba1a94434c368a84f8d950121feb4a398a67f78453853d1d"
     networks:
@@ -39,6 +44,9 @@ services:
     build:
       context: ./
       dockerfile: ./docker/Dockerfile.op-batcher
+      additional_contexts:
+        ghcr.io/uminetwork/optimism: "service:optimism"
+        ghcr.io/uminetwork/foundry: "service:foundry"
     networks:
       - localnet
     depends_on:
@@ -52,6 +60,9 @@ services:
     build:
       context: ./
       dockerfile: ./docker/Dockerfile.op-proposer
+      additional_contexts:
+        ghcr.io/uminetwork/optimism: "service:optimism"
+        ghcr.io/uminetwork/foundry: "service:foundry"
     networks:
       - localnet
     depends_on:
@@ -65,6 +76,9 @@ services:
     build:
       context: ./
       dockerfile: ./docker/Dockerfile.op-geth
+      additional_contexts:
+        ghcr.io/uminetwork/optimism: "service:optimism"
+        ghcr.io/uminetwork/foundry: "service:foundry"
     environment:
       JWT_SECRET: "f3099a1d969c4f5aba1a94434c368a84f8d950121feb4a398a67f78453853d1d"
     networks:
@@ -119,6 +133,8 @@ services:
     build:
       context: ./
       dockerfile: ./docker/Dockerfile.geth
+      additional_contexts:
+        ghcr.io/uminetwork/foundry: "service:foundry"
     networks:
       - localnet
     depends_on:


### PR DESCRIPTION
### Description
While there is already `depends_on` in the config, that one only works with containers. It works on images too as a side-effect, but only on the first build. Using additional context is one of the suggested approaches by [docker manual](https://docs.docker.com/compose/how-tos/dependent-images/#use-another-services-image-as-the-base-image).

### Changes
- Declare image dependencies using `additional_context`

### Testing
Using docker compose build
