### PR TITLE
refactor(app): treat block body withdrawals according to spec

### DIFF
--- a/blockchain/src/block/write.rs
+++ b/blockchain/src/block/write.rs
@@ -1,5 +1,8 @@
 use {
-    crate::{payload::PayloadId, transaction::ExtendedTransaction},
+    crate::{
+        payload::{PayloadId, Withdrawal},
+        transaction::ExtendedTransaction,
+    },
     alloy::{
         rlp::Encodable,
         rpc::types::{BlockTransactions, Withdrawals},
@@ -81,11 +84,13 @@ impl ExtendedBlock {
     }
 }
 
-/// TODO: Add withdrawals
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct Block {
     pub header: Header,
     pub transactions: Vec<B256>,
+    /// Always expected to be empty, so technically a constant:
+    /// <https://specs.optimism.io/protocol/isthmus/exec-engine.html?highlight=withdrawals#block-body-withdrawals-list>
+    pub withdrawals: Vec<Withdrawal>,
 }
 
 impl Block {
@@ -93,6 +98,7 @@ impl Block {
         Self {
             header,
             transactions,
+            withdrawals: Vec::new(),
         }
     }
 

--- a/blockchain/src/payload/read.rs
+++ b/blockchain/src/payload/read.rs
@@ -91,7 +91,8 @@ impl ExecutionPayload {
             extra_data: block.block.header.extra_data,
             base_fee_per_gas: U256::from(block.block.header.base_fee_per_gas.unwrap_or_default()),
             transactions,
-            withdrawals: Vec::new(), // TODO: withdrawals
+            // L1 withdrawals are set to be empty at block construction time
+            withdrawals: block.block.withdrawals,
             blob_gas_used: U64::from(block.block.header.blob_gas_used.unwrap_or_default()),
             excess_blob_gas: U64::from(block.block.header.excess_blob_gas.unwrap_or_default()),
         }

--- a/server/benches/perf/queue/input.rs
+++ b/server/benches/perf/queue/input.rs
@@ -59,6 +59,7 @@ pub const GENESIS: ExtendedBlock = {
                 requests_hash: None,
             },
             transactions: Vec::new(),
+            withdrawals: Vec::new(),
         },
     }
 };

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -23,7 +23,9 @@ use {
     },
     umi_shared::{
         hex,
-        primitives::{ToSaturatedU64, B2048, B256, B64, U256},
+        primitives::{
+            ToSaturatedU64, B2048, B256, B64, EMPTY_LIST_ROOT, EMPTY_OMMERS_ROOT_HASH, U256,
+        },
     },
     warp::{
         http::{header::CONTENT_TYPE, HeaderMap, HeaderValue, StatusCode},
@@ -272,13 +274,6 @@ fn create_genesis_block(
     block_hash: &impl BlockHash,
     genesis_config: &GenesisConfig,
 ) -> ExtendedBlock {
-    const EMPTY_ROOT: B256 = B256::new(hex!(
-        "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
-    ));
-    const EMPTY_OMMERS_ROOT_HASH: B256 = B256::new(hex!(
-        "1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
-    ));
-
     let genesis_header = Header {
         base_fee_per_gas: genesis_config
             .l2_contract_genesis
@@ -296,13 +291,13 @@ fn create_genesis_block(
         number: genesis_config.l2_contract_genesis.number.unwrap_or(0),
         parent_beacon_block_root: Some(B256::ZERO),
         parent_hash: B256::ZERO,
-        receipts_root: EMPTY_ROOT,
+        receipts_root: EMPTY_LIST_ROOT,
         state_root: B256::new(hex!(
             "30b67e4b5ef34eacb9e083c07fd5578982c2cb4e0ee1dc0a14d72b99a28ed80e"
         )),
         timestamp: genesis_config.l2_contract_genesis.timestamp,
-        transactions_root: EMPTY_ROOT,
-        withdrawals_root: Some(EMPTY_ROOT),
+        transactions_root: EMPTY_LIST_ROOT,
+        withdrawals_root: Some(EMPTY_LIST_ROOT),
         beneficiary: genesis_config.l2_contract_genesis.coinbase,
         ommers_hash: EMPTY_OMMERS_ROOT_HASH,
         requests_hash: None,

--- a/shared/src/primitives.rs
+++ b/shared/src/primitives.rs
@@ -4,10 +4,21 @@ pub use {
 };
 
 use {
-    alloy::consensus::{Receipt, ReceiptWithBloom},
+    alloy::{
+        consensus::{Receipt, ReceiptWithBloom},
+        hex,
+    },
     move_core_types::{account_address::AccountAddress, u256::U256 as MoveU256},
     op_alloy::consensus::{OpDepositReceipt, OpDepositReceiptWithBloom, OpReceiptEnvelope},
 };
+
+pub const EMPTY_LIST_ROOT: B256 = B256::new(hex!(
+    "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+));
+
+pub const EMPTY_OMMERS_ROOT_HASH: B256 = B256::new(hex!(
+    "1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+));
 
 pub trait ToEthAddress {
     fn to_eth_address(&self) -> Address;


### PR DESCRIPTION
### Description
<!-- What does this PR do? -->
Insert description here
<!-- Fixes #123 -->
Fixes #256.

### Changes
<!-- Key changes -->
- Removed all the withdrawal related todos, added some wordy comments
- Propagate empty withdrawals in block data
- Log non-empty withdrawals
- Use a preset empty list hash value for the withdrawals root instead of recomputing it every time

### Testing
<!-- How was it tested? -->
All previous tests pass