### PR TITLE
Chore(readme): Optimism repo inside op-move, remove op-geth

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Move VM execution layer for OP Stack.
 
 Make sure you have `go` installed on your system. Due to the pinned versions being based around August 2024, a version not older than 1.22 is required. Other dependencies include [foundry](http://getfoundry.sh/) for smart contract interaction and [jq](https://jqlang.github.io/jq/) being called indirectly by Optimism itself.
 
-First, clone the Optimism monorepo. The repo is used to compile and deploy Optimism contracts.
+While inside the `op-move` folder, clone the Optimism monorepo. The repo is used to compile and deploy Optimism contracts.
 
 ```bash
 git clone https://github.com/ethereum-optimism/optimism server/src/tests/optimism
@@ -30,16 +30,6 @@ mv op-batcher/bin/op-batcher ~/go/bin/
 mv op-proposer/bin/op-proposer ~/go/bin/
 ```
 
-Similarly, clone the [`op-geth` project](https://github.com/ethereum-optimism/op-geth) and install the `geth` binary, but save it as `op-geth`.
-
-```bash
-git clone https://github.com/ethereum-optimism/op-geth.git
-cd op-geth
-git checkout f2e69450
-make geth
-mv build/bin/geth ~/go/bin/op-geth # make sure it's saved as op-geth instead of geth
-```
-
 Build and install the Ethereum L1 runner from the [`geth` project](https://github.com/ethereum/go-ethereum).
 
 ```bash
@@ -54,7 +44,7 @@ mv build/bin/geth ~/go/bin/geth
 
 ### Go-Ethereum version
 
-Make sure the `geth` and `op-geth` versions are compatible. Otherwise, the API communication could fail. The best way to match the versions is to check out a `go-ethereum` `tag` around the day of the `optimism` commit in submodule.
+Make sure the `geth` version is compatible. Otherwise, the API communication could fail. The best way to match the versions is to check out a `go-ethereum` `tag` around the day of the `optimism` commit in submodule.
 For instance, a compatible `geth` tag is `tags/v1.14.5` for the current `optimism` version.
 To check which commit we use for Optimism:
 
@@ -77,3 +67,7 @@ make cannon-prestate
 
 When you see a message with the address already being used, it means `geth` isn't shutdown correctly from a previous test run and most likely `geth` is still running in the background.
 The integration test cannot shut this down automatically when it starts, so open up Activity Monitor or Task Manager to force any process with names `geth` or `op-*` to shut down.
+
+### Optimism repo location
+
+Make sure the `optimism` folder is inside the `op-move` project, at `op-move/server/src/tests/optimism`.


### PR DESCRIPTION
### Description
It's not clear that `optimism` repo is cloned into the `op-move` folder, so explained that.
Removed the `op-geth` step.