### PR TITLE
build(docker): Remove local directory cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,6 @@ server/*.log
 # Docker mounted volumes
 docker/volumes
 
-# Docker buildx cache directory
-.buildx-cache
-
 # Optimism cloned repository
 server/src/tests/optimism
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,6 @@ services:
       context: ./
       dockerfile: ./docker/Dockerfile.optimism
       target: op-node
-      cache_from:
-        - type=local,src=.buildx-cache/op-node
-      cache_to:
-        - type=local,dest=.buildx-cache/op-node,mode=max
     environment:
       JWT_SECRET: "f3099a1d969c4f5aba1a94434c368a84f8d950121feb4a398a67f78453853d1d"
     networks:
@@ -22,10 +18,6 @@ services:
       context: ./
       dockerfile: ./docker/Dockerfile.optimism
       target: op-batcher
-      cache_from:
-        - type=local,src=.buildx-cache/op-batcher
-      cache_to:
-        - type=local,dest=.buildx-cache/op-batcher,mode=max
     networks:
       - localnet
     volumes:
@@ -37,10 +29,6 @@ services:
       context: ./
       dockerfile: ./docker/Dockerfile.optimism
       target: op-proposer
-      cache_from:
-        - type=local,src=.buildx-cache/op-proposer
-      cache_to:
-        - type=local,dest=.buildx-cache/op-proposer,mode=max
     networks:
       - localnet
     volumes:
@@ -51,10 +39,6 @@ services:
     build:
       context: ./
       dockerfile: ./docker/Dockerfile.op-move
-      cache_from:
-        - type=local,src=.buildx-cache/op-move
-      cache_to:
-        - type=local,dest=.buildx-cache/op-move,mode=max
     environment:
       OP_MOVE_AUTH_JWT_SECRET: "f3099a1d969c4f5aba1a94434c368a84f8d950121feb4a398a67f78453853d1d"
       OP_MOVE_DB_PURGE: ${OP_MOVE_DB_PURGE:-false}
@@ -95,10 +79,6 @@ services:
     build:
       context: ./
       dockerfile: ./docker/Dockerfile.geth
-      cache_from:
-        - type=local,src=.buildx-cache/geth
-      cache_to:
-        - type=local,dest=.buildx-cache/geth,mode=max
     networks:
       - localnet
     ports:


### PR DESCRIPTION
### Description

The `docker-compose.yml` has a `local` cache. This is a cache that uses a local directory.

This causes that the cache gets exported. Since it is local only, the export and import is not needed, and takes time to generate and over 10 gigabytes of storage to keep.

### Changes
- Remove local directory cache from `docker-compose.yml`

### Testing
```
docker compose build
```