### PR TITLE
ci: Cache Rust build artifacts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,12 +19,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install mold to speed up ELF linking and decrease memory usage
+        uses: rui314/setup-mold@v1
       - name: Free up disk space
         run: rm -rf /opt/hostedtoolcache
       - run: echo "TOOLCHAIN=$(cat rust-toolchain)" >> $GITHUB_ENV
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.TOOLCHAIN }}
+      - name: Restore cached build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - name: Test
         run: cargo test -- --skip integration
       - name: Run flaky tests
@@ -46,6 +52,10 @@ jobs:
         with:
           toolchain: ${{ env.TOOLCHAIN }}
           components: clippy
+      - name: Restore cached build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - uses: auguwu/clippy-action@1.4.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -47,6 +47,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.TOOLCHAIN }}
+      - name: Restore cached build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - name: Run integration test
         run: cargo test --release test_on_ethereum
       - name: Capture logs


### PR DESCRIPTION
### Description
Adds [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) action to cache cargo and target using [Github cache API](https://cli.github.com/manual/gh_cache).

### Changes
- Add cache step before all steps that produce Rust build artifacts

### Testing
Using Github actions

### Notes
The action was sometimes failing with `exit code 143`. Upon some research, it was discovered that this code is when a process receives SIGTERM, which, in the context of Github actions, probably means that it was interrupted due to exhaustion of resources, likely memory.

I added a different ELF linker `mold`, which seems to mitigate this issue while providing a significant compilation speed boost (about 2-3 minutes).