### PR TITLE
Feat(metrics): Add metric for number of blocks produced

### DIFF
--- a/app/src/command.rs
+++ b/app/src/command.rs
@@ -283,6 +283,7 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
         in_progress_payloads.finish_id(block, executed_transactions.into_iter().map(Into::into));
 
         histogram!("block_build_duration_seconds").record(t0.elapsed().as_secs_f64());
+        metrics::counter!("blocks_produced_count").increment(1);
 
         Ok(())
     }


### PR DESCRIPTION
### Description
This should be good for alerting if the chain stalls.

### Changes
- New counter-type metric which increments by 1 whenever a block is produced.

### Testing
- Observed metric in load test
