### PR TITLE
fix(docker): Unignore `load-testing` directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,3 +26,4 @@ server/*.log
 !Cargo.toml
 !rust-toolchain
 !trie
+!load-testing


### PR DESCRIPTION
### Description
Fixes current [build issues](https://github.com/UmiNetwork/op-move/actions/runs/18381500681/job/52368847908) with `op-move` docker image build.

### Changes
- Unignore `load-testing` directory

### Testing
```
docker compose build
```
