### PR TITLE
build(docker): Import ghcr.io cache in local builds

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -1,35 +1,25 @@
 services:
   op-node:
     build:
-      cache_from:
-        - type=registry,ref=ghcr.io/uminetwork/op-node:latest-cache
       cache_to:
         - type=registry,ref=ghcr.io/uminetwork/op-node:latest-cache,mode=max
 
   op-batcher:
     build:
-      cache_from:
-        - type=registry,ref=ghcr.io/uminetwork/op-batcher:latest-cache
       cache_to:
         - type=registry,ref=ghcr.io/uminetwork/op-batcher:latest-cache,mode=max
 
   op-proposer:
     build:
-      cache_from:
-        - type=registry,ref=ghcr.io/uminetwork/op-proposer:latest-cache
       cache_to:
         - type=registry,ref=ghcr.io/uminetwork/op-proposer:latest-cache,mode=max
 
   op-move:
     build:
-      cache_from:
-        - type=registry,ref=ghcr.io/uminetwork/op-move:latest-cache
       cache_to:
         - type=registry,ref=ghcr.io/uminetwork/op-move:latest-cache,mode=max
 
   geth:
     build:
-      cache_from:
-        - type=registry,ref=ghcr.io/uminetwork/geth:latest-cache
       cache_to:
         - type=registry,ref=ghcr.io/uminetwork/geth:latest-cache,mode=max

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   op-node:
     image: ghcr.io/uminetwork/op-node:${UMI_TAG:-latest}
     build:
+      cache_from:
+        - type=registry,ref=ghcr.io/uminetwork/op-node:latest-cache
       dockerfile: docker/shared/Dockerfile
       target: op-node
     environment:
@@ -14,6 +16,8 @@ services:
   op-batcher:
     image: ghcr.io/uminetwork/op-batcher:${UMI_TAG:-latest}
     build:
+      cache_from:
+        - type=registry,ref=ghcr.io/uminetwork/op-batcher:latest-cache
       dockerfile: docker/shared/Dockerfile
       target: op-batcher
     networks:
@@ -24,6 +28,8 @@ services:
   op-proposer:
     image: ghcr.io/uminetwork/op-proposer:${UMI_TAG:-latest}
     build:
+      cache_from:
+        - type=registry,ref=ghcr.io/uminetwork/op-proposer:latest-cache
       dockerfile: docker/shared/Dockerfile
       target: op-proposer
     networks:
@@ -34,6 +40,8 @@ services:
   op-move:
     image: ghcr.io/uminetwork/op-move:${UMI_TAG:-latest}
     build:
+      cache_from:
+        - type=registry,ref=ghcr.io/uminetwork/op-move:latest-cache
       dockerfile: docker/op-move/Dockerfile
       args:
         - RUST_TOOLCHAIN
@@ -76,6 +84,8 @@ services:
   geth:
     image: ghcr.io/uminetwork/geth:${UMI_TAG:-latest}
     build:
+      cache_from:
+        - type=registry,ref=ghcr.io/uminetwork/geth:latest-cache
       dockerfile: docker/shared/Dockerfile
       target: geth
     networks:


### PR DESCRIPTION
### Description
The cache on the github registry can be still beneficial to reduce the build time on local. It's only the exports that are unwanted on local.

### Changes
- Add `cache_from` statements to `docker-compose.yml`

### Testing
Using docker