### PR TITLE
fix(nginx): Parse the `$msec` decimal dot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,8 @@ node_modules
 server/*.log
 
 # Docker mounted volumes
-docker/*/volume
+docker/op-move/volume
+docker/shared/volume
 
 # Optimism cloned repository
 server/src/tests/optimism

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13317,6 +13317,7 @@ dependencies = [
  "openssl",
  "serde",
  "serde_json",
+ "test-case",
  "tokio",
  "tokio-metrics",
  "tracing",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,12 +99,14 @@ services:
 
   proxy:
     image: nginx:1.29.1-alpine
-    ports:
-      - "8545:8545"
-    volumes:
-      - ./nginx:/etc/nginx/conf.d:ro
+    networks:
+      - localnet
     depends_on:
       - op-move
+    volumes:
+      - ./docker/proxy/volume:/etc/nginx/conf.d:ro
+    ports:
+      - "8545:8545"
 
 networks:
   localnet:

--- a/docker/proxy/volume/rpc.conf
+++ b/docker/proxy/volume/rpc.conf
@@ -7,14 +7,11 @@ server {
   location / {
     set $req_start_ms $msec;
     proxy_set_header X-Req-Start-Ms $req_start_ms;
-
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
     proxy_http_version 1.1;
     proxy_set_header Connection "";
 
-    # set dynamically to avoid it failing at startup
-    set $upstream_host op-move;
-    proxy_pass http://$upstream_host:8545;
+    proxy_pass http://op-move:8545;
   }
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -64,6 +64,7 @@ move-vm-runtime.workspace = true
 umi-evm-ext.workspace = true
 umi-genesis-image.workspace = true
 openssl.workspace = true
+test-case.workspace = true
 
 [[bin]]
 name = "op-move"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -7,6 +7,7 @@ use {
         net::{Ipv4Addr, SocketAddr, SocketAddrV4},
         num::NonZeroUsize,
         path::Path,
+        str::FromStr,
         time::SystemTime,
     },
     tracing::level_filters::LevelFilter,
@@ -219,7 +220,7 @@ pub fn server_filter(
 
     get_method_auto_response
         .or(serialization_kind
-            .and(warp::header::optional::<u128>("X-Req-Start-Ms"))
+            .and(warp::header::optional::<Msec>("X-Req-Start-Ms"))
             .and(app_state)
             .and(jwt_validation)
             .and(request_body)
@@ -238,6 +239,23 @@ pub fn server_filter(
             ))
         .with(warp::reply::with::headers(content_type))
         .with(warp::cors().allow_any_origin())
+}
+
+#[derive(Debug)]
+struct Msec(u128);
+
+impl FromStr for Msec {
+    type Err = <f64 as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self((s.parse::<f64>()? * 1000.0) as u128))
+    }
+}
+
+impl From<Msec> for u128 {
+    fn from(value: Msec) -> Self {
+        value.0
+    }
 }
 
 fn serve(
@@ -435,13 +453,18 @@ pub fn validate_jwt(
 async fn handle_request<'reader>(
     queue: CommandQueue,
     serialization_tag: SerializationKind,
-    request_start: Option<u128>,
+    request_start: Option<Msec>,
     request: serde_json::Value,
     is_allowed: &impl Fn(&MethodName) -> bool,
     payload_id: &impl NewPayloadId,
     app: ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> Result<warp::reply::Response, Rejection> {
-    let modifiers = RequestModifiers::new(is_allowed, payload_id, serialization_tag, request_start);
+    let modifiers = RequestModifiers::new(
+        is_allowed,
+        payload_id,
+        serialization_tag,
+        request_start.map(Msec::into),
+    );
     let op_move_response =
         umi_api::request::handle(request.clone(), queue.clone(), modifiers, app).await;
     let log = ServerLog {

--- a/server/src/tests/mod.rs
+++ b/server/src/tests/mod.rs
@@ -4,6 +4,7 @@ mod integration;
 mod invalid_tx;
 mod legacy_tx;
 mod listing_apis;
+mod msec;
 mod payload;
 mod table_api;
 mod test_context;

--- a/server/src/tests/msec.rs
+++ b/server/src/tests/msec.rs
@@ -1,0 +1,20 @@
+use {crate::Msec, std::str::FromStr, test_case::test_case};
+
+#[test_case("125.5", 125500)]
+#[test_case("125", 125000)]
+#[test_case("125.55554", 125555)]
+fn test_msec_parses_with_three_decimal_places_and_converts_to_uint(
+    msec: &str,
+    expected_value: u128,
+) {
+    let actual_value = u128::from(Msec::from_str(msec).unwrap());
+
+    assert_eq!(actual_value, expected_value);
+}
+
+#[test]
+fn test_msec_fails_to_parse_from_non_decimal_numeric_strings() {
+    let actual_error = Msec::from_str("fds45sd").unwrap_err().to_string();
+
+    assert_eq!(actual_error, "invalid float literal");
+}


### PR DESCRIPTION
### Description
The format that nginx uses for the timestamp is milliseconds in seconds, i.e. with a decimal dot. This cannot be parsed directly into `u128` and causes no request to come through due to the invalid request header.

### Changes
- Add `Msec` type that can parse nginx timestamp and convert into `u128`

### Testing
Using docker