### PR TITLE
ci(integration): Restore cache mounts artifacts

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -27,8 +27,18 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Restore Docker cache mounts
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          builder: ${{ steps.setup-buildx.outputs.name }}
+          cache-dir: cache-mount
+          dockerfile: docker/op-move/Dockerfile
+          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
+
       - name: Run container images
         run: |
           docker network create localnet


### PR DESCRIPTION
### Description
The cache mounts are added do the integration workflow. These are not useful unless run from outside the main branch.

### Changes
- Restore cache mounts artifacts 

### Testing
Using Github Actions