### PR TITLE
fix(docker): Initialize `geth` during container setup

### DIFF
--- a/docker/geth/deploy-optimism.sh
+++ b/docker/geth/deploy-optimism.sh
@@ -18,8 +18,23 @@ SHARED="/volume/shared"
 # Remove existing output files in the shared volume
 rm -f "${SHARED}/umi.json" "${SHARED}/1337-deploy.json" "${SHARED}/state-dump-42069.json" "${SHARED}/genesis.json" "${SHARED}/rollup.json"
 
+# Create datadir for geth
+mkdir -p "${L1_DATADIR}"
+
+# Initialize keystore in the datadir
+./keystore.sh
+
 # Wait for the RPC node to become available
 wait-for-it "${L1_RPC_ADDR}:${L1_RPC_PORT}"
+
+# Prefund Optimism service accounts
+./prefund.sh
+
+# Deploy Optimism factory deployer contract
+cast publish --rpc-url "${L1_RPC_URL}" "${SIGNED_L1_CONTRACT_TX}"
+
+# Wait for a finalized block with a positive timestamp
+while [ "$(cast block finalized --rpc-url "${L1_RPC_URL}" | awk '/^timestamp/ { print $2 }')" -le 0 ]; do sleep 3; done
 
 # Generate L2 genesis deploy config file
 DEPLOY_CONFIG_PATH="${DEPLOY_CONFIG}" \

--- a/docker/geth/init.sh
+++ b/docker/geth/init.sh
@@ -11,12 +11,3 @@ L1_RPC_URL="http://0.0.0.0:${L1_RPC_PORT}"
 
 # Wait for the RPC node to become available
 wait-for-it "${L1_RPC_ADDR}:${L1_RPC_PORT}"
-
-# Prefund Optimism service accounts
-./prefund.sh
-
-# Deploy Optimism factory deployer contract
-cast publish --rpc-url "${L1_RPC_URL}" "${SIGNED_L1_CONTRACT_TX}"
-
-# Wait for a finalized block with a positive timestamp
-while [ "$(cast block finalized --rpc-url "${L1_RPC_URL}" | awk '/^timestamp/ { print $2 }')" -le 0 ]; do sleep 3; done

--- a/docker/shared/Dockerfile
+++ b/docker/shared/Dockerfile
@@ -151,31 +151,6 @@ COPY --chmod=0777 docker/geth/*.sh server/src/tests/config.sh ./
 # Copy environment variables
 COPY .env ./
 
-RUN \
-  # Create datadir for geth
-  mkdir -p ./l1_datadir \
-  # Initialize keystore in the datadir
-  && ./keystore.sh \
-  # Launch geth node to receive transactions
-  && geth \
-  --dev \
-  --datadir "${L1_DATADIR}" \
-  --rpc.allow-unprotected-txs \
-  --http \
-  --http.addr 0.0.0.0 \
-  --http.port 58138 \
-  --http.corsdomain '*' \
-  --http.api 'web3,debug,eth,txpool,net,engine' \
-  --http.vhosts '*' \
-  # Store geth process ID
-  & GETH_PID=$! \
-  # Send transactions that prefund accounts and deploy Optimism factory deployer
-  && ./init.sh \
-  # Send interrupt signal to geth to shut it down gracefully preventing datadir corruption
-  && kill -SIGINT "${GETH_PID}" \
-  # Wait for geth to exit
-  && wait "${GETH_PID}"
-
 # Set entrypoint to a script that launches geth
 ENTRYPOINT [ "/volume/entrypoint.sh" ]
 


### PR DESCRIPTION
### Description
Removes all `geth` startup and initialization from the image stage.

The motivation is that the op-node is trying to catchup with the build timestamp in this setup. That takes time and makes no sense to do.

### Changes
- Remove `geth` initialization from the image stage
- Initialize `geth` during container startup

### Testing
Using docker