### PR TITLE
fix(server): Remove database files on purge flag while keeping the directory itself

### DIFF
--- a/server/src/dependency/heed.rs
+++ b/server/src/dependency/heed.rs
@@ -138,7 +138,7 @@ impl<'db> umi_app::Dependencies<'db> for HeedDependencies {
     }
 
     fn state(&self) -> Self::State {
-        fallible::retry(|| {
+        storage::retry(|| {
             EthTrieState::try_new(Arc::new(trie::HeedEthTrieDb::new(self.db.clone())))
         })
     }
@@ -257,7 +257,7 @@ impl<'db> umi_app::Dependencies<'db> for HeedReaderDependencies {
     }
 
     fn state(&self) -> Self::State {
-        fallible::retry(|| {
+        storage::retry(|| {
             EthTrieState::try_new(Arc::new(trie::HeedEthTrieDb::new(self.db.clone())))
         })
     }
@@ -289,7 +289,7 @@ fn create_db(args: umi_server_args::Database) -> umi_storage_heed::Env {
     assert_eq!(umi_storage_heed::DATABASES.len(), 11);
 
     if args.purge {
-        let _ = std::fs::remove_dir_all(&args.dir);
+        storage::remove_files_in_dir(&args.dir).expect("Removing database files should succeed")
     }
     let _ = std::fs::create_dir(&args.dir);
 

--- a/server/src/dependency/rocksdb.rs
+++ b/server/src/dependency/rocksdb.rs
@@ -142,7 +142,7 @@ impl<'db> umi_app::Dependencies<'db> for RocksDbDependencies {
     }
 
     fn state(&self) -> Self::State {
-        fallible::retry(|| EthTrieState::try_new(Arc::new(RocksEthTrieDb::new(self.db.clone()))))
+        storage::retry(|| EthTrieState::try_new(Arc::new(RocksEthTrieDb::new(self.db.clone()))))
     }
 
     fn state_queries(&self, genesis_config: &GenesisConfig) -> Self::StateQueries {
@@ -264,7 +264,7 @@ impl<'db> umi_app::Dependencies<'db> for RocksDbReaderDependencies {
     }
 
     fn state(&self) -> Self::State {
-        fallible::retry(|| EthTrieState::try_new(Arc::new(RocksEthTrieDb::new(self.db.clone()))))
+        storage::retry(|| EthTrieState::try_new(Arc::new(RocksEthTrieDb::new(self.db.clone()))))
     }
 
     fn state_queries(&self, genesis_config: &GenesisConfig) -> Self::StateQueries {
@@ -292,7 +292,7 @@ impl<'db> umi_app::Dependencies<'db> for RocksDbReaderDependencies {
 
 fn create_db(args: umi_server_args::Database) -> umi_storage_rocksdb::RocksDb {
     if args.purge {
-        let _ = std::fs::remove_dir_all(&args.dir);
+        storage::remove_files_in_dir(&args.dir).expect("Removing database files should succeed")
     }
 
     let mut options = umi_storage_rocksdb::rocksdb::Options::default();

--- a/server/src/dependency/shared.rs
+++ b/server/src/dependency/shared.rs
@@ -57,9 +57,10 @@ macro_rules! impl_shared {
 pub(crate) use impl_shared;
 
 #[cfg(any(feature = "storage-lmdb", feature = "storage-rocksdb"))]
-pub(super) mod fallible {
+pub(super) mod storage {
     use std::{
         fmt::{Debug, Display},
+        fs,
         time::Duration,
     };
 
@@ -77,5 +78,13 @@ pub(super) mod fallible {
                 }
             }
         }
+    }
+
+    pub(crate) fn remove_files_in_dir(path: impl AsRef<std::path::Path>) -> std::io::Result<()> {
+        for i in fs::read_dir(path)? {
+            fs::remove_file(i?.path())?;
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
### Description
For both database backends, RocksDB and LMDB, it is true that their directories contain only files and no subdirectories.

This change makes it so that the `purge` flag only removes these files, but not the directory itself.

Removing the directory is not needed and can trigger unnecessary permission errors. Specifically in docker it fails to remove this directory, because it is also mounted as a volume.

### Changes
- Add function `remove_files_in_dir`
- Use function `remove_files_in_dir` instead of `remove_dir_all` when `purge` flag is on.

### Testing
Using the docker stack with `export OP_MOVE_DB_PURGE=true`
