### PR TITLE
build(docker): Perform local build after pulling in the deploy script

### DIFF
--- a/docker/host/deploy.sh
+++ b/docker/host/deploy.sh
@@ -11,8 +11,8 @@ mkdir -p docker/op-move/volume docker/shared/volume
 # Create shared network for services deployed to the swarm
 docker network inspect localnet -f "Network exists" || docker network create localnet --scope swarm --driver overlay
 
-# Pull all images
-docker compose pull
+# Pull and build images
+docker compose build --pull
 
 # Deploy the stack
 docker stack deploy --resolve-image never -c docker-compose.yml -d umi


### PR DESCRIPTION
### Description
This change makes the deploy script support deployment when local source files are changed.

This is useful for local testing or when using modified source code on a node.

### Changes
- Perform `build` after `pull` in `docker/host/deploy.sh`

### Testing
Using docker
