### PR TITLE
build(docker): Apply `.env` from compose instead of build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,7 +10,6 @@ server/src/tests/optimism
 server/db
 server/*.log
 
-!.env
 !api
 !app
 !blockchain

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,13 @@ services:
         - type=registry,ref=ghcr.io/uminetwork/op-node:latest-cache
       dockerfile: docker/shared/Dockerfile
       target: op-node
+    env_file:
+      - .env
     environment:
       JWT_SECRET: "f3099a1d969c4f5aba1a94434c368a84f8d950121feb4a398a67f78453853d1d"
+      L1_RPC_URL: "http://geth:58138"
+      L2_RPC_HTTP_URL: "http://op-move:8545"
+      L2_RPC_AUTH_URL: "http://op-move:8551"
     networks:
       - localnet
     volumes:
@@ -20,6 +25,12 @@ services:
         - type=registry,ref=ghcr.io/uminetwork/op-batcher:latest-cache
       dockerfile: docker/shared/Dockerfile
       target: op-batcher
+    env_file:
+      - .env
+    environment:
+      L1_RPC_URL: "http://geth:58138"
+      L2_RPC_URL: "http://op-move:8545"
+      ROLLUP_RPC_URL: "http://op-node:8547"
     networks:
       - localnet
     volumes:
@@ -32,6 +43,11 @@ services:
         - type=registry,ref=ghcr.io/uminetwork/op-proposer:latest-cache
       dockerfile: docker/shared/Dockerfile
       target: op-proposer
+    env_file:
+      - .env
+    environment:
+      L1_RPC_URL: "http://geth:58138"
+      ROLLUP_RPC_URL: "http://op-node:8547"
     networks:
       - localnet
     volumes:

--- a/docker/geth/deploy-optimism.sh
+++ b/docker/geth/deploy-optimism.sh
@@ -6,7 +6,6 @@
 # -x Print out command arguments during execution
 # -a Export all variables
 set -euxa
-. /volume/.env
 WORKDIR="/volume/packages/contracts-bedrock"
 DEPLOY_CONFIG="${WORKDIR}/deploy-config/umi.json"
 L1_DEPLOYMENT="${WORKDIR}/deployments/1337-deploy.json"

--- a/docker/geth/init-op.sh
+++ b/docker/geth/init-op.sh
@@ -6,7 +6,6 @@
 # -x Print out command arguments during execution
 # -a Export all variables
 set -euxa
-. /volume/.env
 
 # Ephemeral proof-of-authority network with a pre-funded developer account,
 # with automatic mining when there are pending transactions.

--- a/docker/geth/prefund.sh
+++ b/docker/geth/prefund.sh
@@ -2,8 +2,6 @@
 # Entrypoint of the op-batcher docker container
 
 set -eu
-. /volume/.env
-L1_RPC_URL="http://127.0.0.1:58138"
 FROM_WALLET=$(ls l1_datadir/keystore | grep -o '.\{40\}$')
 FACTORY_DEPLOYER_ADDRESS="0x3fAB184622Dc19b6109349B94811493BF2a45362"
 NONCE=0

--- a/docker/op-batcher/entrypoint.sh
+++ b/docker/op-batcher/entrypoint.sh
@@ -2,15 +2,11 @@
 # Entrypoint of the op-batcher docker container
 
 set -eux
-. /volume/.env
-L1_RPC_URL="http://geth:58138"
-L2_RPC_URL="http://op-move:8545"
-ROLLUP_RPC_URL="http://op-node:8547"
 TIMEOUT_SECS=1500
 
-wait-for-it -t "${TIMEOUT_SECS}" "$(echo ${L1_RPC_URL} | cut -c 8-)"
-wait-for-it -t "${TIMEOUT_SECS}" "$(echo ${L2_RPC_URL} | cut -c 8-)"
-wait-for-it -t "${TIMEOUT_SECS}" "$(echo ${ROLLUP_RPC_URL} | cut -c 8-)"
+wait-for-it -t "${TIMEOUT_SECS}" "$(echo "${L1_RPC_URL}" | cut -c 8-)"
+wait-for-it -t "${TIMEOUT_SECS}" "$(echo "${L2_RPC_URL}" | cut -c 8-)"
+wait-for-it -t "${TIMEOUT_SECS}" "$(echo "${ROLLUP_RPC_URL}" | cut -c 8-)"
 
 op-batcher \
     --l2-eth-rpc "${L2_RPC_URL}" \

--- a/docker/op-node/entrypoint.sh
+++ b/docker/op-node/entrypoint.sh
@@ -2,18 +2,13 @@
 # Entrypoint of the op-node docker container
 
 set -eux
-. /volume/.env
 WORKDIR="/volume"
-SHARED="/volume/shared"
+SHARED="${WORKDIR}/shared"
 ROLLUP_FILE="${SHARED}/rollup.json"
 JWT_FILE="${WORKDIR}/jwt.txt"
-L1_RPC_URL="http://geth:58138"
-OP_MOVE_ADDR="op-move"
-OP_MOVE_PORT="8545"
-L2_RPC_URL="http://${OP_MOVE_ADDR}:8551"
 
 # Wait for op-move to serve the genesis block
-while [ "$(cast block 0 --rpc-url http://${OP_MOVE_ADDR}:${OP_MOVE_PORT} >/dev/null 2>&1 ; echo $?)" -ne 0 ]; do sleep 1; done
+while [ "$(cast block 0 --rpc-url "${L2_RPC_HTTP_URL}" >/dev/null 2>&1 ; echo $?)" -ne 0 ]; do sleep 1; done
 
 # Wait for geth to deploy Optimism
 while [ ! -f "${ROLLUP_FILE}" ]; do sleep 1; done
@@ -22,7 +17,7 @@ echo "${JWT_SECRET}" > "${JWT_FILE}"
 
 op-node \
   --l1.beacon.ignore \
-  --l2 "${L2_RPC_URL}" \
+  --l2 "${L2_RPC_AUTH_URL}" \
   --l2.jwt-secret "${JWT_FILE}" \
   --sequencer.enabled \
   --sequencer.l1-confs 5 \
@@ -33,5 +28,5 @@ op-node \
   --p2p.disable \
   --rpc.enable-admin \
   --p2p.sequencer.key "${SEQUENCER_PRIVATE_KEY}" \
-  --l1 ${L1_RPC_URL} \
+  --l1 "${L1_RPC_URL}" \
   --l1.rpckind basic

--- a/docker/op-proposer/entrypoint.sh
+++ b/docker/op-proposer/entrypoint.sh
@@ -2,10 +2,7 @@
 # Entrypoint of the op-proposer docker container
 
 set -eux
-. /volume/.env
 SHARED="/volume/shared"
-L1_RPC_URL="http://geth:58138"
-ROLLUP_RPC_URL="http://op-node:8547"
 L1_DEPLOYMENT="${SHARED}/1337-deploy.json"
 TIMEOUT_SECS=1500
 

--- a/docker/shared/Dockerfile
+++ b/docker/shared/Dockerfile
@@ -70,7 +70,6 @@ COPY --from=optimism /op-proposer /usr/local/bin/
 
 # Copy entrypoint with run privileges
 COPY --chmod=0777 docker/op-proposer/entrypoint.sh ./
-COPY .env ./
 COPY --chmod=0777 docker/shared/wait-for-it.sh /usr/local/bin/wait-for-it
 
 ENTRYPOINT [ "/volume/entrypoint.sh" ]
@@ -90,7 +89,6 @@ COPY --from=optimism /op-batcher /usr/local/bin/
 
 # Copy entrypoint with run privileges
 COPY --chmod=0777 docker/op-batcher/entrypoint.sh ./
-COPY .env ./
 COPY --chmod=0777 docker/shared/wait-for-it.sh /usr/local/bin/wait-for-it
 
 ENTRYPOINT [ "/volume/entrypoint.sh" ]
@@ -148,9 +146,6 @@ COPY --from=go-ethereum /geth /usr/local/bin/
 COPY --chmod=0777 docker/shared/wait-for-it.sh /usr/local/bin/wait-for-it
 COPY --chmod=0777 docker/geth/*.sh server/src/tests/config.sh ./
 
-# Copy environment variables
-COPY .env ./
-
 # Set entrypoint to a script that launches geth
 ENTRYPOINT [ "/volume/entrypoint.sh" ]
 
@@ -169,8 +164,5 @@ COPY --from=optimism /op-node /usr/local/bin/
 
 # Copy entrypoint with run privileges
 COPY --chmod=0777 docker/op-node/entrypoint.sh ./
-
-# Copy ENV file that include Optimism wallet addresses
-COPY .env ./
 
 ENTRYPOINT [ "/volume/entrypoint.sh" ]


### PR DESCRIPTION
### Description
Extracts relevant ENV vars from entrypoints and docker build and instead propagates them from docker-compose.

### Changes
<!-- Key changes -->
- Remove `COPY .env` statements from Dockerfiles
- Add `env_file:` to `docker-compose.yml`

### Testing
Using docker