### PR TITLE
build(docker): Wait for L1 to become online in op-move

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,10 +64,9 @@ services:
     environment:
       OP_MOVE_AUTH_JWT_SECRET: "f3099a1d969c4f5aba1a94434c368a84f8d950121feb4a398a67f78453853d1d"
       OP_MOVE_DB_PURGE: ${OP_MOVE_DB_PURGE:-false}
+      L1_RPC_URL: "http://geth:58138"
     networks:
       - localnet
-    depends_on:
-      - op-node
     volumes:
       - ./docker/shared/volume:/volume/shared
       - ./docker/op-move/volume:/volume/db

--- a/docker/geth/init-op.sh
+++ b/docker/geth/init-op.sh
@@ -14,7 +14,7 @@ geth \
   --datadir "${L1_DATADIR}" \
   --rpc.allow-unprotected-txs \
   --http \
-  --http.addr 0.0.0.0 \
+  --http.addr 127.0.0.1 \
   --http.port 58138 \
   --http.corsdomain '*' \
   --http.api 'web3,debug,eth,txpool,net,engine' \

--- a/docker/op-move/Dockerfile
+++ b/docker/op-move/Dockerfile
@@ -35,24 +35,24 @@ WORKDIR /volume
 
 RUN \
   # Install run dependencies
-  apk add --no-cache clang lld curl build-base linux-headers git openssl-dev \
+  apk add --no-cache bash clang lld curl build-base linux-headers git openssl-dev \
   # Clean up
-  && rm -rf /tmp/* /var/cache/apk/* \
-  # Create directory that is used in relative paths to Move framework snapshot files
-  && mkdir genesis
+  && rm -rf /tmp/* /var/cache/apk/*
 
 # Copy Move framework snapshot files into expected paths
-COPY genesis/aptos.mrb genesis/aptos.mrb
-COPY genesis/sui.mrb genesis/sui.mrb
+COPY genesis/aptos.mrb genesis/sui.mrb genesis/
 
 # Copy L2 genesis config into expected path
 COPY execution/src/tests/res/l2_genesis_tests.json server/src/tests/optimism/packages/contracts-bedrock/deployments/genesis.json
 COPY execution/src/tests/res/bridged_tokens_test.json execution/src/tests/res/bridged_tokens_test.json
 
-# Copy built binary
-COPY --from=build /volume/op-move ./
+# Copy script that waits for other services availability
+COPY --chmod=0777 docker/shared/wait-for-it.sh /usr/local/bin/wait-for-it
 
 # Copy entrypoint with run privileges
 COPY --chmod=0777 docker/op-move/entrypoint.sh ./
+
+# Copy built binary
+COPY --from=build /volume/op-move ./
 
 ENTRYPOINT [ "/volume/entrypoint.sh" ]

--- a/docker/op-move/entrypoint.sh
+++ b/docker/op-move/entrypoint.sh
@@ -6,12 +6,7 @@ SHARED="/volume/shared"
 GENESIS_FILE="${SHARED}/genesis.json"
 TIMEOUT_SECS=1500
 
-# Wait for op-node to generate this file
-for _ in $(seq "${TIMEOUT_SECS}"); do
-    if [ -f "${GENESIS_FILE}" ]; then
-        break
-    fi
-    sleep 1
-done
+wait-for-it -t "${TIMEOUT_SECS}" "$(echo "${L1_RPC_URL}" | cut -c 8-)"
+while [ ! -f "${GENESIS_FILE}" ]; do sleep 1; done
 
 /volume/op-move --genesis.l2-contract-genesis "${GENESIS_FILE}"


### PR DESCRIPTION
### Description
The entrypoint of `op-move` container waits for the `genesis.json` file to be generated. This file is generated by the `geth` container entrypoint. The problem is that `op-move` might become active with files produced by an older run of `geth`. This change makes it so that `op-move` waits for `geth` to become online, giving it the space it needs to regenerate op stack files like `genesis.json`.

### Changes
- Bind `geth` to `127.0.0.1` in the initialization phase so that it's not accessible from other containers during that
- Remove useless `depends_on` from `op-move`

### Testing
Using docker