### PR TITLE
fix(server): treat requests hash properly under OP upgrade

### DIFF
--- a/api/src/methods/new_payload.rs
+++ b/api/src/methods/new_payload.rs
@@ -174,7 +174,10 @@ fn validate_payload_block_hash(
         blob_gas_used: Some(execution_payload.blob_gas_used.saturating_to()),
         excess_blob_gas: Some(execution_payload.excess_blob_gas.saturating_to()),
         parent_beacon_block_root: Some(parent_beacon_block_root),
+        #[cfg(not(feature = "op-upgrade"))]
         requests_hash: None,
+        #[cfg(feature = "op-upgrade")]
+        requests_hash: Some(umi_app::EMPTY_REQUESTS_HASH),
     };
     let computed_hash = alloy::primitives::keccak256(alloy::rlp::encode(&payload_header));
 

--- a/app/src/command.rs
+++ b/app/src/command.rs
@@ -181,6 +181,8 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
             excess_blob_gas: Some(0),
             #[cfg(feature = "op-upgrade")]
             extra_data: self.gas_fee.encode_parameters_for_header(),
+            #[cfg(feature = "op-upgrade")]
+            requests_hash: Some(crate::EMPTY_REQUESTS_HASH),
             ..Default::default()
         }
         .with_payload_attributes(attributes)

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -28,3 +28,7 @@ mod uninit;
 #[cfg(feature = "op-upgrade")]
 pub const L2_TO_L1_MESSAGE_PASSER_ADDRESS: alloy::primitives::Address =
     alloy::primitives::address!("0x4200000000000000000000000000000000000016");
+
+#[cfg(feature = "op-upgrade")]
+pub const EMPTY_REQUESTS_HASH: alloy::primitives::B256 =
+    alloy::primitives::b256!("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -371,9 +371,7 @@ fn create_genesis_block(
     // As defined in <https://specs.optimism.io/protocol/isthmus/exec-engine.html#header-validity-rules>,
     // i.e. a hash of an empty string
     #[cfg(feature = "op-upgrade")]
-    let requests_hash = Some(B256::from(hex!(
-        "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-    )));
+    let requests_hash = Some(umi_app::EMPTY_REQUESTS_HASH);
     #[cfg(not(feature = "op-upgrade"))]
     let requests_hash = None;
     let genesis_header = Header {


### PR DESCRIPTION
### Description
<!-- What does this PR do? -->
The requests hash should be absent in the header pre-Isthmus and be a SHA-256 hash of the empty string after that. Previously it wasn't propagated in block build under the feature flag, so this PR fixes that.
<!-- Fixes #123 -->

### Changes
<!-- Key changes -->
- A constant for the hash
- Proper setting in block build

### Testing
<!-- How was it tested? -->
Old tests pass